### PR TITLE
fix(webui): filter findings by scan_id query parameter

### DIFF
--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/surfbot-io/surfbot-agent/internal/detection"
 	"github.com/surfbot-io/surfbot-agent/internal/model"
 	"github.com/surfbot-io/surfbot-agent/internal/pipeline"
@@ -286,6 +288,13 @@ func (h *handler) handleFindings(w http.ResponseWriter, r *http.Request) {
 	}
 	if targetID := r.URL.Query().Get("target_id"); targetID != "" {
 		opts.TargetID = targetID
+	}
+	if scanID := r.URL.Query().Get("scan_id"); scanID != "" {
+		if _, err := uuid.Parse(scanID); err != nil {
+			writeError(w, http.StatusBadRequest, "scan_id must be a valid UUID")
+			return
+		}
+		opts.ScanID = scanID
 	}
 
 	findings, err := h.store.ListFindings(r.Context(), opts)

--- a/internal/webui/handlers_test.go
+++ b/internal/webui/handlers_test.go
@@ -169,6 +169,83 @@ func TestHandleFindingsSeverityFilter(t *testing.T) {
 	assert.Equal(t, model.SeverityCritical, resp.Findings[0].Severity)
 }
 
+func TestHandleFindingsScanIDFilter(t *testing.T) {
+	h, s := newTestHandler(t)
+	seedTestData(t, s)
+
+	// Seed a second scan with its own finding so we can prove the
+	// filter scopes results to the requested scan_id only.
+	ctx := context.Background()
+	target, err := s.GetTargetByValue(ctx, "example.com")
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	started := now.Add(-2 * time.Minute)
+	scan2 := &model.Scan{
+		TargetID:   target.ID,
+		Type:       model.ScanTypeQuick,
+		Status:     model.ScanStatusCompleted,
+		Phase:      "completed",
+		Progress:   100,
+		StartedAt:  &started,
+		FinishedAt: &now,
+	}
+	require.NoError(t, s.CreateScan(ctx, scan2))
+
+	assets, err := s.ListAssets(ctx, storage.AssetListOptions{TargetID: target.ID, Limit: 1})
+	require.NoError(t, err)
+	require.NotEmpty(t, assets)
+
+	scan2Finding := &model.Finding{
+		AssetID:      assets[0].ID,
+		ScanID:       scan2.ID,
+		TemplateID:   "exposed-env-file",
+		TemplateName: "Exposed .env",
+		Severity:     model.SeverityHigh,
+		Title:        "Exposed environment file",
+		Description:  "found .env at web root",
+		Status:       model.FindingStatusOpen,
+		SourceTool:   "nuclei",
+		Confidence:   90,
+	}
+	require.NoError(t, s.UpsertFinding(ctx, scan2Finding))
+
+	// Sanity: without scan_id we see all 3 findings.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/findings", nil)
+	w := httptest.NewRecorder()
+	h.handleFindings(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var all findingsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &all))
+	assert.Equal(t, 3, all.Total)
+
+	// Filter by scan2.ID — must return only the single finding tied to it.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/findings?scan_id="+scan2.ID, nil)
+	w2 := httptest.NewRecorder()
+	h.handleFindings(w2, req2)
+	assert.Equal(t, http.StatusOK, w2.Code)
+	var filtered findingsResponse
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &filtered))
+	assert.Equal(t, 1, filtered.Total)
+	require.Len(t, filtered.Findings, 1)
+	assert.Equal(t, scan2.ID, filtered.Findings[0].ScanID)
+	assert.Equal(t, "exposed-env-file", filtered.Findings[0].TemplateID)
+}
+
+func TestHandleFindingsScanIDInvalid(t *testing.T) {
+	h, s := newTestHandler(t)
+	seedTestData(t, s)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/findings?scan_id=not-a-uuid", nil)
+	w := httptest.NewRecorder()
+	h.handleFindings(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Contains(t, body["error"], "scan_id")
+}
+
 func TestHandleFindingsPagination(t *testing.T) {
 	h, s := newTestHandler(t)
 	seedTestData(t, s)


### PR DESCRIPTION
## Summary
`/api/v1/findings` accepted `scan_id` in spirit but never parsed it, so the dashboard's scan detail page rendered findings from every scan in the DB instead of only the ones tied to the requested scan. Storage (`FindingListOptions.ScanID`) already supported the filter — only the HTTP handler was failing to wire it through.

- Parse `scan_id` from the query string in `handleFindings`.
- Validate as a UUID; reject with 400 on bad input.
- Pass through to `ListFindings` / `CountFindingsFiltered` (no storage changes).

## Repro that goes from broken to fixed
\`\`\`
curl 'http://127.0.0.1:8470/api/v1/findings?scan_id=<uuid>' \\
  | jq '.findings | group_by(.scan_id) | length'
\`\`\`
Was returning >1 (findings from multiple scans). Now returns 1.

## Tests
- `TestHandleFindingsScanIDFilter` — seeds two scans with distinct findings, verifies that without the filter all are returned and with `?scan_id=<a>` only A's findings come back.
- `TestHandleFindingsScanIDInvalid` — `?scan_id=not-a-uuid` → 400.
- Existing `TestHandleFindings` and pagination tests still pass (regression coverage for the no-filter path).

## Test plan
- [x] go build ./...
- [x] go test ./...
- [x] gofmt clean on touched files
- [ ] CI green