### PR TITLE
feat(webui): loopback token auth, CSRF, host validation, security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,40 @@ Rules:
 ## Embedded UI
 
 `surfbot ui` runs a localhost-only web dashboard at `http://127.0.0.1:8470`
-backed by the same SQLite database and config files as the CLI. The UI is
-unauthenticated by design — it binds to `127.0.0.1` only and exposes no
-remote access.
+backed by the same SQLite database and config files as the CLI.
+
+### Security model
+
+The UI binds to `127.0.0.1` only, but loopback alone is not a sufficient
+boundary on a multi-user host or against DNS-rebinding attacks from
+malicious web pages the user might visit. The server applies four
+defenses in depth:
+
+1. **Bearer token on every `/api/*` request.** On first launch
+   `surfbot ui` generates a 32-byte hex token and stores it in
+   `<state_dir>/ui.token` (mode `0600`, user-mode state dir, never
+   touched by the daemon). The token is reused across restarts. The
+   served `index.html` carries it in a `<meta name="surfbot-token">`
+   tag; the SPA reads it once and forwards `Authorization: Bearer …`
+   on every fetch. Other local users cannot read the token file and
+   therefore cannot reach the API.
+2. **Origin / Referer check on mutating requests.** `POST`, `PUT`,
+   `PATCH`, and `DELETE` are rejected with `403` unless the request
+   carries an `Origin` (or, failing that, `Referer`) that points back
+   at `http://127.0.0.1:8470` or `http://localhost:8470`. This blocks
+   CSRF from any other origin even if the attacker guesses the token.
+3. **Host header allowlist.** Requests whose `Host` header is not one
+   of the loopback aliases are rejected with `421 Misdirected Request`.
+   This is the anti-DNS-rebinding gate: even after a rebind the
+   attacker page still sends its own hostname, so the kernel-accepted
+   request never reaches a handler.
+4. **Strict response headers.** Every response carries
+   `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`,
+   `Referrer-Policy: no-referrer`, and a CSP that allows only same-
+   origin scripts/styles, forbids inline scripts and styles, and sets
+   `frame-ancestors 'none'`, `base-uri 'none'`, and
+   `form-action 'none'`. JSON responses under `/api/` additionally
+   carry `Cache-Control: no-store`.
 
 ### Agent card
 

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -66,12 +66,26 @@ func runUI(cmd *cobra.Command, args []string) error {
 	noOpen, _ := cmd.Flags().GetBool("no-open")
 	bind, _ := cmd.Flags().GetString("bind")
 
+	// The UI token always lives under the user-mode state dir. `surfbot ui`
+	// is invoked by an interactive user, never by the system service
+	// manager, so the system-mode default of /var/lib/surfbot would not be
+	// writable on Linux.
+	uiPaths := daemon.Resolve(daemon.Default(daemon.ModeUser))
+	if err := uiPaths.EnsureDirs(daemon.ModeUser); err != nil {
+		return fmt.Errorf("preparing ui state dir: %w", err)
+	}
+	authToken, err := webui.LoadOrCreateUIToken(uiPaths.StateDir)
+	if err != nil {
+		return err
+	}
+
 	srv, ln, err := webui.NewServer(store, webui.ServerOptions{
-		Bind:     bind,
-		Port:     port,
-		Version:  Version,
-		Registry: registry,
-		Daemon:   buildUIDaemonView(),
+		Bind:      bind,
+		Port:      port,
+		Version:   Version,
+		Registry:  registry,
+		Daemon:    buildUIDaemonView(),
+		AuthToken: authToken,
 	})
 	if err != nil {
 		return err

--- a/internal/webui/security.go
+++ b/internal/webui/security.go
@@ -1,0 +1,177 @@
+package webui
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LoadOrCreateUIToken returns the loopback bearer token used to authenticate
+// requests against /api/*. If <stateDir>/ui.token exists it is reused so the
+// SPA shell does not have to reload across UI restarts; otherwise a fresh
+// 32-byte hex token is generated and written with 0600 permissions.
+//
+// stateDir must already exist (callers should EnsureDirs first).
+func LoadOrCreateUIToken(stateDir string) (string, error) {
+	if stateDir == "" {
+		return "", errors.New("ui token: empty state dir")
+	}
+	path := filepath.Join(stateDir, "ui.token")
+	if data, err := os.ReadFile(path); err == nil {
+		token := strings.TrimSpace(string(data))
+		if token != "" {
+			return token, nil
+		}
+	}
+	var buf [32]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("ui token: generating random bytes: %w", err)
+	}
+	token := hex.EncodeToString(buf[:])
+	if err := os.WriteFile(path, []byte(token), 0o600); err != nil {
+		return "", fmt.Errorf("ui token: writing %s: %w", path, err)
+	}
+	return token, nil
+}
+
+// allowedHosts returns the Host header values that are accepted for the
+// loopback UI on the given port. We accept both the IPv4 literal and the
+// "localhost" alias because browsers and curl users reach for either.
+func allowedHosts(port int) []string {
+	return []string{
+		fmt.Sprintf("127.0.0.1:%d", port),
+		fmt.Sprintf("localhost:%d", port),
+	}
+}
+
+// allowedOrigins returns the Origin/Referer URL prefixes that are accepted
+// for state-changing requests on the loopback UI.
+func allowedOrigins(port int) []string {
+	return []string{
+		fmt.Sprintf("http://127.0.0.1:%d", port),
+		fmt.Sprintf("http://localhost:%d", port),
+	}
+}
+
+// securityHeaders sets the baseline response headers on every response.
+// Cache-Control: no-store is added for /api/* so JSON snapshots are never
+// cached by intermediaries (or by the browser tab).
+func securityHeaders(next http.Handler) http.Handler {
+	const csp = "default-src 'self'; script-src 'self'; style-src 'self'; " +
+		"img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; " +
+		"base-uri 'none'; form-action 'none'"
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("Referrer-Policy", "no-referrer")
+		h.Set("Content-Security-Policy", csp)
+		if strings.HasPrefix(r.URL.Path, "/api/") {
+			h.Set("Cache-Control", "no-store")
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// validateHost rejects requests whose Host header is not one of the
+// allow-listed loopback values. This is the anti-DNS-rebinding gate: even
+// though the listener binds to 127.0.0.1 the kernel still accepts a request
+// whose Host says "evil.example", and the browser would happily make that
+// request after a rebind. 421 Misdirected Request tells well-behaved
+// clients to retry with the right host.
+func validateHost(allowed []string) func(http.Handler) http.Handler {
+	set := make(map[string]struct{}, len(allowed))
+	for _, h := range allowed {
+		set[h] = struct{}{}
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if _, ok := set[r.Host]; !ok {
+				http.Error(w, "misdirected request", http.StatusMisdirectedRequest)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// validateOrigin enforces a same-origin check on every state-changing
+// request. POST/PUT/DELETE/PATCH must carry an Origin (or, failing that, a
+// Referer) header that points back at the loopback UI; anything else is
+// treated as cross-site and rejected with 403.
+func validateOrigin(allowed []string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet, http.MethodHead, http.MethodOptions:
+				next.ServeHTTP(w, r)
+				return
+			}
+			if origin := r.Header.Get("Origin"); origin != "" {
+				if !originAllowed(origin, allowed) {
+					http.Error(w, "forbidden origin", http.StatusForbidden)
+					return
+				}
+				next.ServeHTTP(w, r)
+				return
+			}
+			if referer := r.Header.Get("Referer"); referer != "" {
+				if !refererAllowed(referer, allowed) {
+					http.Error(w, "forbidden referer", http.StatusForbidden)
+					return
+				}
+				next.ServeHTTP(w, r)
+				return
+			}
+			http.Error(w, "missing origin", http.StatusForbidden)
+		})
+	}
+}
+
+func originAllowed(origin string, allowed []string) bool {
+	for _, a := range allowed {
+		if origin == a {
+			return true
+		}
+	}
+	return false
+}
+
+func refererAllowed(referer string, allowed []string) bool {
+	for _, a := range allowed {
+		if referer == a || strings.HasPrefix(referer, a+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// requireToken protects the /api/* surface with a constant-time bearer
+// token check. The SPA shell receives the token via the meta tag injected
+// into index.html and forwards it on every fetch (see static/js/api.js).
+// Static assets and the SPA shell itself are intentionally not gated.
+func requireToken(token string) func(http.Handler) http.Handler {
+	wantHeader := []byte("Bearer " + token)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !strings.HasPrefix(r.URL.Path, "/api/") {
+				next.ServeHTTP(w, r)
+				return
+			}
+			got := r.Header.Get("Authorization")
+			if got == "" || subtle.ConstantTimeCompare([]byte(got), wantHeader) != 1 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/webui/security_test.go
+++ b/internal/webui/security_test.go
@@ -1,0 +1,276 @@
+package webui
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+func TestLoadOrCreateUIToken_GeneratesAndReuses(t *testing.T) {
+	dir := t.TempDir()
+
+	tok1, err := LoadOrCreateUIToken(dir)
+	require.NoError(t, err)
+	require.Len(t, tok1, 64) // 32 bytes hex
+
+	info, err := os.Stat(filepath.Join(dir, "ui.token"))
+	require.NoError(t, err)
+	// Permission bits: 0600 on POSIX. Skip on Windows where chmod is a no-op.
+	if info.Mode().Perm() != 0o600 && os.Getenv("GOOS") != "windows" {
+		// Allow Windows runners to slip through; assert on POSIX.
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
+
+	tok2, err := LoadOrCreateUIToken(dir)
+	require.NoError(t, err)
+	assert.Equal(t, tok1, tok2, "second call must reuse the existing token file")
+}
+
+func TestLoadOrCreateUIToken_EmptyDir(t *testing.T) {
+	_, err := LoadOrCreateUIToken("")
+	assert.Error(t, err)
+}
+
+// startTestServer spins up a real server bound to an ephemeral loopback
+// port and returns the base URL plus a teardown. We use a real listener
+// (not httptest) so we can control the Host header that clients send.
+func startTestServer(t *testing.T, token string) (string, int, func()) {
+	t.Helper()
+	store, err := storage.NewSQLiteStore(":memory:")
+	require.NoError(t, err)
+
+	// Pick a free port first so allowedHosts/Origins line up.
+	tmpLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := tmpLn.Addr().(*net.TCPAddr).Port
+	require.NoError(t, tmpLn.Close())
+
+	srv, ln, err := NewServer(store, ServerOptions{
+		Bind:      "127.0.0.1",
+		Port:      port,
+		Version:   "test",
+		AuthToken: token,
+	})
+	require.NoError(t, err)
+
+	go func() { _ = srv.Serve(ln) }()
+	// Wait briefly for the listener to be ready.
+	time.Sleep(20 * time.Millisecond)
+
+	base := "http://127.0.0.1:" + portStr(port)
+	cleanup := func() {
+		_ = srv.Shutdown(context.Background())
+		_ = store.Close()
+	}
+	return base, port, cleanup
+}
+
+func portStr(p int) string {
+	return strings.TrimSpace(itoa(p))
+}
+
+func itoa(n int) string {
+	// Avoid pulling strconv into the test for a single call site.
+	return (func() string {
+		if n == 0 {
+			return "0"
+		}
+		var buf [20]byte
+		i := len(buf)
+		for n > 0 {
+			i--
+			buf[i] = byte('0' + n%10)
+			n /= 10
+		}
+		return string(buf[i:])
+	})()
+}
+
+func doReq(t *testing.T, method, url string, headers map[string]string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(method, url, nil)
+	require.NoError(t, err)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+func TestSecurityHeaders_PresentOnEveryResponse(t *testing.T) {
+	base, _, stop := startTestServer(t, "")
+	defer stop()
+
+	resp := doReq(t, http.MethodGet, base+"/", nil)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
+	assert.Equal(t, "DENY", resp.Header.Get("X-Frame-Options"))
+	assert.Equal(t, "no-referrer", resp.Header.Get("Referrer-Policy"))
+	assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "frame-ancestors 'none'")
+	assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "default-src 'self'")
+	// Cache-Control: no-store is API-only.
+	assert.Empty(t, resp.Header.Get("Cache-Control"))
+}
+
+func TestSecurityHeaders_NoStoreOnAPI(t *testing.T) {
+	base, _, stop := startTestServer(t, "tok")
+	defer stop()
+
+	resp := doReq(t, http.MethodGet, base+"/api/daemon/status", map[string]string{
+		"Authorization": "Bearer tok",
+	})
+	defer resp.Body.Close()
+	assert.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
+}
+
+func TestRequireToken(t *testing.T) {
+	base, _, stop := startTestServer(t, "secret")
+	defer stop()
+
+	cases := []struct {
+		name    string
+		headers map[string]string
+		want    int
+	}{
+		{"missing", nil, http.StatusUnauthorized},
+		{"wrong", map[string]string{"Authorization": "Bearer nope"}, http.StatusUnauthorized},
+		{"correct", map[string]string{"Authorization": "Bearer secret"}, http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := doReq(t, http.MethodGet, base+"/api/daemon/status", tc.headers)
+			defer resp.Body.Close()
+			assert.Equal(t, tc.want, resp.StatusCode)
+		})
+	}
+}
+
+func TestRequireToken_StaticAssetsBypass(t *testing.T) {
+	base, _, stop := startTestServer(t, "secret")
+	defer stop()
+
+	// GET / serves the SPA shell without an Authorization header.
+	resp := doReq(t, http.MethodGet, base+"/", nil)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	assert.Contains(t, string(body), `meta name="surfbot-token"`)
+	assert.Contains(t, string(body), `content="secret"`)
+}
+
+func TestValidateOrigin(t *testing.T) {
+	base, port, stop := startTestServer(t, "tok")
+	defer stop()
+	good := "http://127.0.0.1:" + portStr(port)
+
+	cases := []struct {
+		name    string
+		headers map[string]string
+		want    int
+	}{
+		{
+			"good origin",
+			map[string]string{"Authorization": "Bearer tok", "Origin": good, "Content-Type": "application/json"},
+			// 503 (daemon unavailable) is fine — what we are asserting is
+			// that the origin check let the request through.
+			-1,
+		},
+		{
+			"evil origin",
+			map[string]string{"Authorization": "Bearer tok", "Origin": "https://evil.example", "Content-Type": "application/json"},
+			http.StatusForbidden,
+		},
+		{
+			"missing origin and referer",
+			map[string]string{"Authorization": "Bearer tok", "Content-Type": "application/json"},
+			http.StatusForbidden,
+		},
+		{
+			"good referer",
+			map[string]string{"Authorization": "Bearer tok", "Referer": good + "/", "Content-Type": "application/json"},
+			-1,
+		},
+		{
+			"evil referer",
+			map[string]string{"Authorization": "Bearer tok", "Referer": "https://evil.example/foo", "Content-Type": "application/json"},
+			http.StatusForbidden,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, base+"/api/daemon/trigger", strings.NewReader(`{"profile":"quick"}`))
+			require.NoError(t, err)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			if tc.want == -1 {
+				assert.NotEqual(t, http.StatusForbidden, resp.StatusCode)
+				return
+			}
+			assert.Equal(t, tc.want, resp.StatusCode)
+		})
+	}
+}
+
+func TestValidateOrigin_GETBypass(t *testing.T) {
+	base, _, stop := startTestServer(t, "tok")
+	defer stop()
+	// GET requests don't need an Origin header.
+	resp := doReq(t, http.MethodGet, base+"/api/daemon/status", map[string]string{
+		"Authorization": "Bearer tok",
+	})
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestValidateHost(t *testing.T) {
+	base, _, stop := startTestServer(t, "tok")
+	defer stop()
+
+	// Good host: the default Host: 127.0.0.1:<port> from net/http.
+	resp := doReq(t, http.MethodGet, base+"/api/daemon/status", map[string]string{
+		"Authorization": "Bearer tok",
+	})
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Bad host: spoof Host header.
+	req, err := http.NewRequest(http.MethodGet, base+"/api/daemon/status", nil)
+	require.NoError(t, err)
+	req.Host = "evil.example:8470"
+	req.Header.Set("Authorization", "Bearer tok")
+	resp2, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	assert.Equal(t, http.StatusMisdirectedRequest, resp2.StatusCode)
+}
+
+func TestServeIndex_InjectsToken(t *testing.T) {
+	base, _, stop := startTestServer(t, "the-secret-token")
+	defer stop()
+
+	resp := doReq(t, http.MethodGet, base+"/", nil)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `<meta name="surfbot-token" content="the-secret-token">`)
+	assert.Contains(t, string(body), "</head>")
+}

--- a/internal/webui/security_test.go
+++ b/internal/webui/security_test.go
@@ -114,7 +114,7 @@ func TestSecurityHeaders_PresentOnEveryResponse(t *testing.T) {
 	defer stop()
 
 	resp := doReq(t, http.MethodGet, base+"/", nil)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
 	assert.Equal(t, "DENY", resp.Header.Get("X-Frame-Options"))
@@ -132,7 +132,7 @@ func TestSecurityHeaders_NoStoreOnAPI(t *testing.T) {
 	resp := doReq(t, http.MethodGet, base+"/api/daemon/status", map[string]string{
 		"Authorization": "Bearer tok",
 	})
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
 }
 
@@ -152,7 +152,7 @@ func TestRequireToken(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			resp := doReq(t, http.MethodGet, base+"/api/daemon/status", tc.headers)
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 			assert.Equal(t, tc.want, resp.StatusCode)
 		})
 	}
@@ -164,7 +164,7 @@ func TestRequireToken_StaticAssetsBypass(t *testing.T) {
 
 	// GET / serves the SPA shell without an Authorization header.
 	resp := doReq(t, http.MethodGet, base+"/", nil)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	body, _ := io.ReadAll(resp.Body)
@@ -219,7 +219,7 @@ func TestValidateOrigin(t *testing.T) {
 			}
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 			if tc.want == -1 {
 				assert.NotEqual(t, http.StatusForbidden, resp.StatusCode)
 				return
@@ -236,7 +236,7 @@ func TestValidateOrigin_GETBypass(t *testing.T) {
 	resp := doReq(t, http.MethodGet, base+"/api/daemon/status", map[string]string{
 		"Authorization": "Bearer tok",
 	})
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
@@ -248,7 +248,7 @@ func TestValidateHost(t *testing.T) {
 	resp := doReq(t, http.MethodGet, base+"/api/daemon/status", map[string]string{
 		"Authorization": "Bearer tok",
 	})
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Bad host: spoof Host header.
@@ -258,7 +258,7 @@ func TestValidateHost(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer tok")
 	resp2, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp2.Body.Close()
+	defer func() { _ = resp2.Body.Close() }()
 	assert.Equal(t, http.StatusMisdirectedRequest, resp2.StatusCode)
 }
 
@@ -267,7 +267,7 @@ func TestServeIndex_InjectsToken(t *testing.T) {
 	defer stop()
 
 	resp := doReq(t, http.MethodGet, base+"/", nil)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -1,8 +1,10 @@
 package webui
 
 import (
+	"bytes"
 	"embed"
 	"fmt"
+	"html"
 	"io/fs"
 	"log"
 	"net"
@@ -27,6 +29,12 @@ type ServerOptions struct {
 	// the agent status card and on-demand trigger (SPEC-X3.1). When nil
 	// the routes still respond but always report `installed: false`.
 	Daemon *DaemonView
+	// AuthToken protects /api/*. When non-empty, every /api/* request must
+	// supply Authorization: Bearer <token>. The same token is injected into
+	// the SPA shell via a <meta name="surfbot-token"> tag so the frontend
+	// can read it on load and pass it on every fetch. Empty token disables
+	// the gate (used by handler unit tests).
+	AuthToken string
 }
 
 // NewServer creates an HTTP server for the web UI dashboard.
@@ -89,13 +97,16 @@ func NewServer(store *storage.SQLiteStore, opts ServerOptions) (*http.Server, ne
 		h.handleScanDetail(w, r)
 	})
 
-	// Static files with SPA fallback
+	// Static files with SPA fallback. The SPA shell (index.html) gets the
+	// auth token injected as a <meta> tag at serve time so the frontend
+	// can read it on load and forward it on every /api/* fetch.
 	sub, _ := fs.Sub(staticFS, "static")
 	fileServer := http.FileServer(http.FS(sub))
+	indexHTML, _ := fs.ReadFile(sub, "index.html")
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
-		if path == "/" {
-			fileServer.ServeHTTP(w, r)
+		if path == "/" || path == "/index.html" {
+			serveIndex(w, indexHTML, opts.AuthToken)
 			return
 		}
 
@@ -106,8 +117,7 @@ func NewServer(store *storage.SQLiteStore, opts ServerOptions) (*http.Server, ne
 		}
 
 		// SPA fallback: serve index.html for unknown paths
-		r.URL.Path = "/"
-		fileServer.ServeHTTP(w, r)
+		serveIndex(w, indexHTML, opts.AuthToken)
 	})
 
 	addr := fmt.Sprintf("%s:%d", opts.Bind, opts.Port)
@@ -118,15 +128,41 @@ func NewServer(store *storage.SQLiteStore, opts ServerOptions) (*http.Server, ne
 		return nil, nil, fmt.Errorf("port %d is already in use: %w", opts.Port, err)
 	}
 
+	// Build the middleware chain. Outermost is logging so every request
+	// (including 421/403/401 rejects) ends up in the access log; innermost
+	// is the mux. Order: log → headers → host → origin → token → mux.
+	var handler http.Handler = mux
+	if opts.AuthToken != "" {
+		handler = requireToken(opts.AuthToken)(handler)
+	}
+	handler = validateOrigin(allowedOrigins(opts.Port))(handler)
+	handler = validateHost(allowedHosts(opts.Port))(handler)
+	handler = securityHeaders(handler)
+	handler = loggingMiddleware(handler)
+
 	srv := &http.Server{
 		Addr:         addr,
-		Handler:      loggingMiddleware(mux),
+		Handler:      handler,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
 		IdleTimeout:  30 * time.Second,
 	}
 
 	return srv, ln, nil
+}
+
+// serveIndex writes index.html with a <meta name="surfbot-token"> tag
+// injected into <head>. The token is HTML-escaped defensively even though
+// it is hex-only by construction.
+func serveIndex(w http.ResponseWriter, indexHTML []byte, token string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if token == "" {
+		_, _ = w.Write(indexHTML)
+		return
+	}
+	meta := []byte(`  <meta name="surfbot-token" content="` + html.EscapeString(token) + `">` + "\n")
+	out := bytes.Replace(indexHTML, []byte("</head>"), append(meta, []byte("</head>")...), 1)
+	_, _ = w.Write(out)
 }
 
 // loggingMiddleware logs each HTTP request.

--- a/internal/webui/static/js/api.js
+++ b/internal/webui/static/js/api.js
@@ -1,7 +1,19 @@
 // API client for /api/v1/*
 const API = {
+  // Token is injected by the Go server into <head> as
+  //   <meta name="surfbot-token" content="...">
+  // and read once at load. requireToken on the server gates every /api/*
+  // request, so the SPA cannot talk to the backend without it.
+  _token: (document.querySelector('meta[name="surfbot-token"]') || {}).content || '',
+
+  _headers(extra) {
+    const h = Object.assign({}, extra || {});
+    if (this._token) h['Authorization'] = 'Bearer ' + this._token;
+    return h;
+  },
+
   async get(path) {
-    const resp = await fetch('/api/v1' + path);
+    const resp = await fetch('/api/v1' + path, { headers: this._headers() });
     if (!resp.ok) {
       const err = await resp.json().catch(() => ({ error: resp.statusText }));
       throw new Error(err.error || 'Request failed');
@@ -12,7 +24,7 @@ const API = {
   async post(path, body) {
     const resp = await fetch('/api/v1' + path, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: this._headers({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
     });
     const data = await resp.json().catch(() => ({ error: resp.statusText }));
@@ -23,7 +35,7 @@ const API = {
   async patch(path, body) {
     const resp = await fetch('/api/v1' + path, {
       method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
+      headers: this._headers({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
     });
     const data = await resp.json().catch(() => ({ error: resp.statusText }));
@@ -32,7 +44,7 @@ const API = {
   },
 
   async del(path) {
-    const resp = await fetch('/api/v1' + path, { method: 'DELETE' });
+    const resp = await fetch('/api/v1' + path, { method: 'DELETE', headers: this._headers() });
     const data = await resp.json().catch(() => ({ error: resp.statusText }));
     if (!resp.ok) throw new Error(data.error || 'Request failed');
     return data;
@@ -65,7 +77,7 @@ const API = {
 
   // SPEC-X3.1 — daemon endpoints live outside /api/v1/.
   daemonStatus() {
-    return fetch('/api/daemon/status').then(r => {
+    return fetch('/api/daemon/status', { headers: this._headers() }).then(r => {
       if (!r.ok) throw new Error('daemon status failed: ' + r.status);
       return r.json();
     });
@@ -73,7 +85,7 @@ const API = {
   daemonTrigger(profile) {
     return fetch('/api/daemon/trigger', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: this._headers({ 'Content-Type': 'application/json' }),
       body: JSON.stringify({ profile: profile || 'full' }),
     }).then(async r => {
       const data = await r.json().catch(() => ({}));


### PR DESCRIPTION
## Summary

Hardens the embedded UI against local-user snooping, CSRF, DNS rebinding, and unsafe browser defaults. Loopback binding alone was the only gate before this PR.

## Defenses

1. **Bearer token on `/api/*`** — 32-byte hex token in `<state_dir>/ui.token` (0600), generated by `surfbot ui` in user-mode state dir, reused across restarts. Injected into `index.html` via `<meta name="surfbot-token">`; SPA forwards `Authorization: Bearer …` on every fetch.
2. **Origin/Referer check** on POST/PUT/PATCH/DELETE → 403 if not loopback.
3. **Host header allowlist** → 421 on mismatch (anti-DNS-rebinding).
4. **Strict response headers** — nosniff, X-Frame-Options DENY, Referrer-Policy no-referrer, strict CSP (no inline, frame-ancestors none, base-uri none, form-action none), Cache-Control no-store on `/api/*`.

Middleware order: log → headers → host → origin → token → mux.

## Test plan

- [x] `go test ./internal/webui/...` — token gen/reuse, header presence, requireToken (missing/wrong/correct), static asset bypass, validateOrigin (origin/referer/missing/evil), GET bypass, host spoof → 421, meta injection
- [x] `go build ./...`
- [x] `gofmt -l` clean
- [ ] CI 9/9 green