### PR TITLE
feat(webui): server-side install_hint for missing/stopped daemon

### DIFF
--- a/internal/webui/daemon_status.go
+++ b/internal/webui/daemon_status.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sync"
 	"time"
 
@@ -64,6 +65,47 @@ type daemonStatusResponse struct {
 	StartedAt     *time.Time            `json:"started_at,omitempty"`
 	UptimeSeconds int64                 `json:"uptime_seconds,omitempty"`
 	Scheduler     *schedulerStatusBlock `json:"scheduler,omitempty"`
+	InstallHint   *installHint          `json:"install_hint,omitempty"`
+}
+
+// installHint tells the UI exactly which command to surface when the
+// daemon is not installed or not running. The server is the source of
+// truth: it knows the OS and install mode, the UI does not.
+type installHint struct {
+	InstallCommand string `json:"install_command,omitempty"`
+	StartCommand   string `json:"start_command,omitempty"`
+	DocsURL        string `json:"docs_url,omitempty"`
+	RequiresAdmin  bool   `json:"requires_admin"`
+}
+
+const docsRunAsService = "https://github.com/surfbot-io/surfbot-agent#run-as-a-service"
+
+// buildInstallHint returns the install/start commands for the current OS
+// and install mode. Linux defaults to system-mode (sudo), macOS to user-
+// mode (no sudo), Windows always to system-mode but the binary cannot
+// self-elevate from the CLI — the UI is told via requires_admin so it
+// can render an "elevated PowerShell" hint instead of inventing a prefix.
+func buildInstallHint(installed bool) *installHint {
+	hint := &installHint{DocsURL: docsRunAsService}
+	switch runtime.GOOS {
+	case "linux":
+		hint.RequiresAdmin = true
+		hint.InstallCommand = "sudo surfbot daemon install"
+		hint.StartCommand = "sudo surfbot daemon start"
+	case "windows":
+		hint.RequiresAdmin = true
+		hint.InstallCommand = "surfbot daemon install"
+		hint.StartCommand = "surfbot daemon start"
+	default: // darwin and others fall through to user-mode
+		hint.RequiresAdmin = false
+		hint.InstallCommand = "surfbot daemon install"
+		hint.StartCommand = "surfbot daemon start"
+	}
+	if installed {
+		// Already installed: only the start command is meaningful.
+		hint.InstallCommand = ""
+	}
+	return hint
 }
 
 type schedulerStatusBlock struct {
@@ -104,11 +146,15 @@ func (h *handler) handleDaemonStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if h.daemon == nil || h.daemon.DaemonStatePath == "" {
-		writeJSON(w, http.StatusOK, daemonStatusResponse{Installed: false})
+		writeJSON(w, http.StatusOK, daemonStatusResponse{
+			Installed:   false,
+			InstallHint: buildInstallHint(false),
+		})
 		return
 	}
 
 	resp := buildDaemonStatus(h.daemon, time.Now())
+	attachInstallHint(&resp)
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -173,6 +219,17 @@ func buildDaemonStatus(d *DaemonView, now time.Time) daemonStatusResponse {
 
 	resp.Scheduler = buildSchedulerBlock(d, now)
 	return resp
+}
+
+// attachInstallHint fills in the install_hint block on responses where
+// the daemon is missing or stopped. Kept separate from buildDaemonStatus
+// so the existing tests on the pure status payload don't have to deal
+// with the OS-dependent string.
+func attachInstallHint(resp *daemonStatusResponse) {
+	if resp.Running {
+		return
+	}
+	resp.InstallHint = buildInstallHint(resp.Installed)
 }
 
 func buildSchedulerBlock(d *DaemonView, now time.Time) *schedulerStatusBlock {

--- a/internal/webui/install_hint_test.go
+++ b/internal/webui/install_hint_test.go
@@ -1,0 +1,119 @@
+package webui
+
+// Tests for the install_hint contract added in PR3. The hint is the
+// server's authoritative answer to "what should the user run?" — the UI
+// must never invent these strings, so we lock the per-OS branches here.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBuildInstallHint_NotInstalled(t *testing.T) {
+	h := buildInstallHint(false)
+	if h == nil {
+		t.Fatal("hint should not be nil")
+	}
+	if h.InstallCommand == "" {
+		t.Error("install_command should be set when not installed")
+	}
+	if h.StartCommand == "" {
+		t.Error("start_command should also be set when not installed")
+	}
+	if h.DocsURL == "" {
+		t.Error("docs_url should be set")
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if !h.RequiresAdmin {
+			t.Error("linux should require admin")
+		}
+		if !strings.HasPrefix(h.InstallCommand, "sudo ") {
+			t.Errorf("linux install_command should start with sudo, got %q", h.InstallCommand)
+		}
+		if !strings.HasPrefix(h.StartCommand, "sudo ") {
+			t.Errorf("linux start_command should start with sudo, got %q", h.StartCommand)
+		}
+	case "darwin":
+		if h.RequiresAdmin {
+			t.Error("darwin should not require admin")
+		}
+		if strings.Contains(h.InstallCommand, "sudo") {
+			t.Errorf("darwin install_command must not contain sudo, got %q", h.InstallCommand)
+		}
+	case "windows":
+		if !h.RequiresAdmin {
+			t.Error("windows should require admin")
+		}
+		if strings.Contains(h.InstallCommand, "sudo") {
+			t.Errorf("windows install_command must not contain sudo, got %q", h.InstallCommand)
+		}
+	}
+}
+
+func TestBuildInstallHint_Installed(t *testing.T) {
+	h := buildInstallHint(true)
+	if h.InstallCommand != "" {
+		t.Errorf("install_command should be empty when already installed, got %q", h.InstallCommand)
+	}
+	if h.StartCommand == "" {
+		t.Error("start_command should still be set when installed but stopped")
+	}
+}
+
+func TestAttachInstallHint_OnlyWhenNotRunning(t *testing.T) {
+	running := daemonStatusResponse{Installed: true, Running: true}
+	attachInstallHint(&running)
+	if running.InstallHint != nil {
+		t.Error("running daemon should never get an install_hint")
+	}
+
+	stopped := daemonStatusResponse{Installed: true, Running: false}
+	attachInstallHint(&stopped)
+	if stopped.InstallHint == nil {
+		t.Fatal("stopped daemon should get an install_hint")
+	}
+	if stopped.InstallHint.InstallCommand != "" {
+		t.Error("stopped (already installed) hint must omit install_command")
+	}
+	if stopped.InstallHint.StartCommand == "" {
+		t.Error("stopped hint must include start_command")
+	}
+
+	missing := daemonStatusResponse{Installed: false, Running: false}
+	attachInstallHint(&missing)
+	if missing.InstallHint == nil || missing.InstallHint.InstallCommand == "" {
+		t.Error("not-installed hint must include install_command")
+	}
+}
+
+func TestHandleDaemonStatus_NotInstalledIncludesHint(t *testing.T) {
+	h := &handler{daemon: nil}
+	req := httptest.NewRequest(http.MethodGet, "/api/daemon/status", nil)
+	rec := httptest.NewRecorder()
+	h.handleDaemonStatus(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var resp daemonStatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Installed || resp.Running {
+		t.Errorf("expected installed=false running=false, got %+v", resp)
+	}
+	if resp.InstallHint == nil {
+		t.Fatal("install_hint missing on not-installed response")
+	}
+	if resp.InstallHint.InstallCommand == "" {
+		t.Error("install_hint.install_command is empty")
+	}
+	if resp.InstallHint.DocsURL == "" {
+		t.Error("install_hint.docs_url is empty")
+	}
+}

--- a/internal/webui/static/js/pages/agent_card.js
+++ b/internal/webui/static/js/pages/agent_card.js
@@ -51,10 +51,10 @@ const AgentCard = {
   // template() renders the four spec §2 states from a status payload.
   template(d) {
     if (!d.installed) {
-      return this.stoppedTemplate('Agent is not installed.', false);
+      return this.stoppedTemplate('Agent is not installed.', false, d.install_hint);
     }
     if (!d.running) {
-      return this.stoppedTemplate(d.reason || 'Agent is not running.', true);
+      return this.stoppedTemplate(d.reason || 'Agent is not running.', true, d.install_hint);
     }
     return this.runningTemplate(d);
   },
@@ -144,10 +144,25 @@ const AgentCard = {
       <span class="detail-value">${desc} <span class="text-muted">${stateLabel}</span></span>`;
   },
 
-  stoppedTemplate(reason, installed) {
-    const cmd = 'surfbot daemon start';
+  stoppedTemplate(reason, installed, hint) {
     const dotClass = installed ? 'agent-dot-err' : 'agent-dot-warn';
     const headerLabel = installed ? 'stopped' : 'not installed';
+    // Server-supplied commands. The UI never invents flags or sudo
+    // prefixes — different OSes need different things.
+    const h = hint || {};
+    const cmd = installed
+      ? (h.start_command || 'surfbot daemon start')
+      : (h.install_command || 'surfbot daemon install');
+    const adminNote = h.requires_admin
+      ? `<div class="text-muted" style="margin-top:4px;font-size:12px">${
+          installed
+            ? 'Run from a terminal with administrator privileges.'
+            : 'Run from a terminal with administrator privileges, then start the service.'
+        }</div>`
+      : '';
+    const docsLink = h.docs_url
+      ? ` <a href="${escapeHtml(h.docs_url)}" target="_blank" rel="noopener noreferrer">docs</a>`
+      : '';
     return `<section class="card agent-card" aria-label="Agent status">
       <div class="agent-header">
         <div class="card-label">Agent</div>
@@ -159,11 +174,12 @@ const AgentCard = {
       </div>
       <p class="text-muted" style="margin-top:8px">${escapeHtml(reason)}</p>
       <p style="margin-top:8px">
-        Run <code id="agent-start-cmd">${cmd}</code>
-        <button id="agent-copy-cmd" class="refresh-btn" data-cmd="${cmd}"
+        Run <code id="agent-start-cmd">${escapeHtml(cmd)}</code>
+        <button id="agent-copy-cmd" class="refresh-btn" data-cmd="${escapeHtml(cmd)}"
           aria-label="Copy command to clipboard">Copy</button>
-        <span id="agent-copy-feedback" class="text-muted" style="margin-left:6px"></span>
+        <span id="agent-copy-feedback" class="text-muted" style="margin-left:6px"></span>${docsLink}
       </p>
+      ${adminNote}
     </section>`;
   },
 


### PR DESCRIPTION
## Summary

Fixes the audit finding where the Agent card hardcoded `surfbot daemon start` even when the daemon was **not installed** (where the correct first step is `install`, not `start`), and where the Linux case was missing `sudo`.

The server is now the source of truth: it knows the OS and install mode, the UI does not. A new \`install_hint\` block on \`/api/daemon/status\` carries the exact strings.

## Contract

\`\`\`json
{
  "installed": false,
  "running": false,
  "install_hint": {
    "install_command": "sudo surfbot daemon install",
    "start_command":   "sudo surfbot daemon start",
    "docs_url":        "https://github.com/surfbot-io/surfbot-agent#run-as-a-service",
    "requires_admin":  true
  }
}
\`\`\`

Per-OS strings (matches \`daemonCmd.Long\` in \`internal/cli/daemon.go\`):

| OS      | install_command                | start_command                | requires_admin |
| ------- | ------------------------------ | ---------------------------- | -------------- |
| linux   | \`sudo surfbot daemon install\` | \`sudo surfbot daemon start\` | true           |
| darwin  | \`surfbot daemon install\`      | \`surfbot daemon start\`      | false          |
| windows | \`surfbot daemon install\`      | \`surfbot daemon start\`      | true           |

\`install_hint\` is only attached when \`running=false\`. When \`installed=true && running=false\` only \`start_command\` is populated. The UI surfaces a \"Run from a terminal with administrator privileges\" note when \`requires_admin\` is true (Windows has no CLI self-elevation, so a \`sudo\` prefix would be a lie).

## Test plan

- [x] \`TestBuildInstallHint_NotInstalled\` — per-OS branches (sudo on linux, no sudo elsewhere, requires_admin on linux+windows)
- [x] \`TestBuildInstallHint_Installed\` — install_command empty, start_command populated
- [x] \`TestAttachInstallHint_OnlyWhenNotRunning\` — running daemon never gets a hint
- [x] \`TestHandleDaemonStatus_NotInstalledIncludesHint\` — end-to-end via the handler
- [x] \`go build ./...\`, \`gofmt -l\` clean, full \`go test ./internal/webui/...\` green
- [ ] CI 9/9 green