### PR TITLE
fix(webui): a11y polish, SPA fallback restriction, HEAD support

### DIFF
--- a/internal/webui/daemon_status.go
+++ b/internal/webui/daemon_status.go
@@ -141,8 +141,15 @@ type windowBlock struct {
 // any error fields before returning. Always 200 — failure modes are
 // expressed in the body.
 func (h *handler) handleDaemonStatus(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if r.Method == http.MethodHead {
+		// HEAD is useful for liveness probes (curl -I, k8s readiness)
+		// without parsing JSON. Same status, no body.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 	if h.daemon == nil || h.daemon.DaemonStatePath == "" {

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -116,7 +116,14 @@ func NewServer(store *storage.SQLiteStore, opts ServerOptions) (*http.Server, ne
 			return
 		}
 
-		// SPA fallback: serve index.html for unknown paths
+		// SPA fallback: serve index.html for unknown *route* paths only.
+		// Asset directories must 404 cleanly so that a typo'd image or
+		// missing JS file does not silently return the HTML shell — that
+		// would mask bugs and let MIME-sniffing edge cases bite us.
+		if isAssetPath(path) {
+			http.NotFound(w, r)
+			return
+		}
 		serveIndex(w, indexHTML, opts.AuthToken)
 	})
 
@@ -149,6 +156,18 @@ func NewServer(store *storage.SQLiteStore, opts ServerOptions) (*http.Server, ne
 	}
 
 	return srv, ln, nil
+}
+
+// isAssetPath reports whether a request path lives under one of the
+// static-asset directory prefixes the SPA serves. The SPA fallback skips
+// these so that missing assets return 404 instead of HTML.
+func isAssetPath(p string) bool {
+	for _, pfx := range []string{"/static/", "/js/", "/css/", "/img/", "/assets/", "/fonts/"} {
+		if strings.HasPrefix(p, pfx) {
+			return true
+		}
+	}
+	return false
 }
 
 // serveIndex writes index.html with a <meta name="surfbot-token"> tag

--- a/internal/webui/spa_fallback_test.go
+++ b/internal/webui/spa_fallback_test.go
@@ -1,0 +1,55 @@
+package webui
+
+// Tests for the SPA fallback restriction and HEAD support added in PR4.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsAssetPath(t *testing.T) {
+	cases := map[string]bool{
+		"/static/foo.png": true,
+		"/js/app.js":      true,
+		"/css/main.css":   true,
+		"/img/logo.svg":   true,
+		"/assets/x":       true,
+		"/fonts/a.woff2":  true,
+		"/":               false,
+		"/findings":       false,
+		"/scans/abc":      false,
+		"/api/v1/scans":   false,
+	}
+	for p, want := range cases {
+		if got := isAssetPath(p); got != want {
+			t.Errorf("isAssetPath(%q) = %v, want %v", p, got, want)
+		}
+	}
+}
+
+func TestHandleDaemonStatus_HEAD(t *testing.T) {
+	h := &handler{daemon: nil}
+	req := httptest.NewRequest(http.MethodHead, "/api/daemon/status", nil)
+	rec := httptest.NewRecorder()
+	h.handleDaemonStatus(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("HEAD status = %d", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("HEAD body should be empty, got %d bytes", rec.Body.Len())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct == "" {
+		t.Error("HEAD should set Content-Type")
+	}
+}
+
+func TestHandleDaemonStatus_RejectsPUT(t *testing.T) {
+	h := &handler{daemon: nil}
+	req := httptest.NewRequest(http.MethodPut, "/api/daemon/status", nil)
+	rec := httptest.NewRecorder()
+	h.handleDaemonStatus(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("PUT status = %d, want 405", rec.Code)
+	}
+}

--- a/internal/webui/static/js/app.js
+++ b/internal/webui/static/js/app.js
@@ -22,6 +22,13 @@ const Router = {
       else if (hash.startsWith('#/' + page)) link.classList.add('active');
     });
 
+    // Stop the AgentCard poll loop on every navigation. Dashboard
+    // re-mounts it; every other route leaves it stopped so the
+    // background fetch does not leak across pages.
+    if (typeof AgentCard !== 'undefined' && AgentCard.unmount) {
+      AgentCard.unmount();
+    }
+
     for (const route of this.routes) {
       const match = hash.match(route.pattern);
       if (match) {

--- a/internal/webui/static/js/components.js
+++ b/internal/webui/static/js/components.js
@@ -90,7 +90,9 @@ const Components = {
   },
 
   table(headers, rows, opts = {}) {
-    const ths = headers.map(h => `<th>${h}</th>`).join('');
+    // scope="col" lets screen readers announce the column header for
+    // every cell underneath, which is the WCAG-recommended marker.
+    const ths = headers.map(h => `<th scope="col">${h}</th>`).join('');
     const trs = rows.length === 0
       ? `<tr><td colspan="${headers.length}" class="empty-state">No data</td></tr>`
       : rows.join('');

--- a/internal/webui/static/js/pages/agent_card.js
+++ b/internal/webui/static/js/pages/agent_card.js
@@ -32,7 +32,7 @@ const AgentCard = {
   },
 
   skeleton() {
-    return `<section class="card agent-card" aria-label="Agent status">
+    return `<section class="card agent-card" aria-label="Agent status" aria-live="polite">
       <div class="card-label">Agent</div>
       <div class="text-muted" style="padding:8px 0">Loading…</div>
     </section>`;
@@ -71,7 +71,7 @@ const AgentCard = {
         : this.schedulerHtml(sched);
 
     const uptime = this.formatUptime(d.uptime_seconds || 0);
-    return `<section class="card agent-card" aria-label="Agent status">
+    return `<section class="card agent-card" aria-label="Agent status" aria-live="polite">
       <div class="agent-header">
         <div class="card-label">Agent</div>
         <div class="agent-status">${srOnly}${dot}<span>running</span></div>
@@ -163,7 +163,7 @@ const AgentCard = {
     const docsLink = h.docs_url
       ? ` <a href="${escapeHtml(h.docs_url)}" target="_blank" rel="noopener noreferrer">docs</a>`
       : '';
-    return `<section class="card agent-card" aria-label="Agent status">
+    return `<section class="card agent-card" aria-label="Agent status" aria-live="polite">
       <div class="agent-header">
         <div class="card-label">Agent</div>
         <div class="agent-status">
@@ -184,7 +184,7 @@ const AgentCard = {
   },
 
   errorTemplate(msg) {
-    return `<section class="card agent-card" aria-label="Agent status">
+    return `<section class="card agent-card" aria-label="Agent status" aria-live="polite">
       <div class="card-label">Agent</div>
       <p class="text-muted">UI can't read agent state: ${escapeHtml(msg)}</p>
     </section>`;

--- a/internal/webui/static/js/pages/scans.js
+++ b/internal/webui/static/js/pages/scans.js
@@ -197,7 +197,7 @@ const ScansPage = {
         <div class="detail-panel">
           <div class="detail-header">
             ${Components.statusBadge(s.status)}
-            <h3>Scan ${Components.truncateID(s.id)}</h3>
+            <h2>Scan ${Components.truncateID(s.id)}</h2>
           </div>
           <div class="detail-grid">
             <span class="detail-label">ID</span>


### PR DESCRIPTION
## Summary

Bundles the small audit findings that don't fit anywhere else.

## Changes

- **a11y — table headers**: \`Components.table\` now emits \`<th scope=\"col\">\`. WCAG-recommended marker so screen readers announce the column header for every cell underneath.
- **a11y — scan detail heading level**: \`Scan <id>\` was an \`<h3>\` even though it is the page's top-level heading. Promoted to \`<h2>\` so the heading hierarchy is consistent across pages.
- **a11y — AgentCard live region**: added \`aria-live=\"polite\"\` so screen readers announce status transitions (running ↔ stopped) without interrupting other speech.
- **AgentCard interval leak**: the dashboard mounted the card and started its 8s poll, but navigating to another page never called \`AgentCard.unmount()\`, so the timer kept firing on /findings, /scans, etc. The router now calls \`unmount()\` on every navigation; the dashboard re-mounts when it loads.
- **SPA fallback restriction**: an unknown URL under \`/static/\`, \`/js/\`, \`/css/\`, \`/img/\`, \`/assets/\`, \`/fonts/\` used to fall through to \`index.html\`, masking missing-asset bugs and risking MIME-sniff edge cases. Those prefixes now return \`404\`. Route-shaped paths (\`/findings\`, \`/scans/abc\`) still get the SPA shell.
- **HEAD on \`/api/daemon/status\`**: simple liveness probes (\`curl -I\`, k8s readiness) shouldn't have to parse JSON. HEAD now returns 200 with empty body and the right Content-Type.

## Test plan

- [x] \`TestIsAssetPath\` — table-driven coverage of every prefix and a few negatives
- [x] \`TestHandleDaemonStatus_HEAD\` — 200, empty body, content-type set
- [x] \`TestHandleDaemonStatus_RejectsPUT\` — 405 still enforced for other methods
- [x] full \`go test ./internal/webui/...\` green; \`gofmt\` clean; \`go build ./...\` clean
- [ ] CI 9/9 green