### PR TITLE
docs(webui): align /api/daemon/status response shape with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,11 @@ The dashboard's top card mirrors `surfbot daemon status`. It polls
 2. **Running, window open** — same, but the "Window" line shows `open`.
 3. **Running, scheduler disabled** — header is green; scheduler block
    collapses to "Scheduler disabled".
-4. **Stopped or not installed** — red/amber dot with the exact command
-   `surfbot daemon start` and a one-click copy-to-clipboard button.
+4. **Stopped or not installed** — red/amber dot with a one-click
+   copy-to-clipboard button. The exact command shown is supplied by the
+   server in the `install_hint` block (see the response shape below) so
+   the UI never has to guess between `install` / `start` or whether to
+   prefix `sudo`.
 
 The endpoint never shells out to systemctl/launchctl. Liveness is
 inferred from the freshness of `daemon.state.json`'s `written_at` field;
@@ -180,6 +183,63 @@ the daemon is reported as stopped when the heartbeat is older than
 Sensitive substrings (`api_key=`, `Authorization: Bearer …`, long
 opaque blobs) in the scheduler's `last_error` fields are redacted server
 side before being returned.
+
+#### `/api/daemon/status` response shape
+
+The endpoint always returns 200; failure modes are expressed in the
+body. `HEAD` is also accepted for liveness probes (no body, same status
+code).
+
+```json
+{
+  "installed": true,
+  "running": true,
+  "pid": 4317,
+  "version": "0.4.0",
+  "started_at": "2026-04-08T08:12:03Z",
+  "uptime_seconds": 7421,
+  "scheduler": {
+    "enabled": true,
+    "last_full":  { "at": "2026-04-07T03:00:11Z", "status": "ok" },
+    "last_quick": { "at": "2026-04-08T09:30:02Z", "status": "ok" },
+    "next_full":  "2026-04-08T03:00:00Z",
+    "next_quick": "2026-04-08T10:30:00Z",
+    "window": {
+      "enabled":   true,
+      "start":     "02:00",
+      "end":       "06:00",
+      "timezone":  "Europe/Madrid",
+      "open_now":  false,
+      "next_open": "2026-04-09T02:00:00+02:00"
+    }
+  }
+}
+```
+
+When the daemon is not running, `running` is `false`, the `scheduler`
+block is omitted, and an `install_hint` block is attached:
+
+```json
+{
+  "installed": false,
+  "running": false,
+  "install_hint": {
+    "install_command": "sudo surfbot daemon install",
+    "start_command":   "sudo surfbot daemon start",
+    "docs_url":        "https://github.com/surfbot-io/surfbot-agent#run-as-a-service",
+    "requires_admin":  true
+  }
+}
+```
+
+`install_hint.install_command` is empty when the daemon is installed but
+stopped — only `start_command` is meaningful in that case. The strings
+are derived server-side from `runtime.GOOS`: Linux gets `sudo` prefixes
+and `requires_admin: true`; macOS gets unprefixed user-mode commands and
+`requires_admin: false`; Windows gets unprefixed commands but
+`requires_admin: true` because the binary cannot self-elevate from the
+CLI (the UI surfaces a "run from an elevated terminal" hint instead of
+inventing a `sudo` equivalent).
 
 ### Scan now
 
@@ -201,10 +261,15 @@ button itself is also disabled for one poll cycle after firing.
 
 ### Endpoints
 
-| Method | Path                  | Notes                                              |
-| ------ | --------------------- | -------------------------------------------------- |
-| GET    | `/api/daemon/status`  | always 200; status in body                         |
-| POST   | `/api/daemon/trigger` | body: `{"profile":"full"\|"quick"}`; 202 / 409     |
+| Method     | Path                  | Notes                                              |
+| ---------- | --------------------- | -------------------------------------------------- |
+| GET / HEAD | `/api/daemon/status`  | always 200; status in body (HEAD has empty body)   |
+| POST       | `/api/daemon/trigger` | body: `{"profile":"full"\|"quick"}`; 202 / 409     |
+
+Both endpoints sit behind the same loopback token and CSRF / Host /
+header defenses described in the [Security model](#security-model)
+section. `/api/daemon/trigger` is a mutating route, so it additionally
+requires a same-origin `Origin` (or `Referer`) header.
 
 These live outside `/api/v1/` because they describe the daemon process,
 not versioned domain data.


### PR DESCRIPTION
## Summary

The README's Agent card section described an old, hand-waved version of \`/api/daemon/status\`. It mentioned fields that don't exist in the actual response (\`mode\`, top-level \`last_scan_at\` / \`next_scan_at\` / \`window_open\`) and said nothing about the \`scheduler.{last_full,last_quick,next_full,next_quick,window}\` shape the handler actually emits. After PR3 it also missed the new \`install_hint\` block, and after PR4 it didn't mention HEAD support.

This PR is **docs only** — no behavior change. It rewrites the section to match \`internal/webui/daemon_status.go\` exactly:

- Documents the running response with the real \`scheduler\` block (\`last_full\` / \`last_quick\` as \`{at,status}\`, \`next_full\` / \`next_quick\` as ISO strings, \`window\` with \`open_now\` / \`next_open\`).
- Documents the not-running response and the \`install_hint\` block introduced in PR3, including the per-OS rules (sudo on linux, no sudo on darwin/windows, \`requires_admin\` flag).
- Notes that \`install_command\` is empty when the daemon is installed-but-stopped.
- Adds HEAD to the endpoints table (PR4).
- Cross-links the trigger endpoint to the Security model section so readers know about the loopback token and Origin requirement.
- Drops the line that hardcoded \`surfbot daemon start\` as the only command — the server now decides.

## Note

I considered whether the *old* contract (a flat \`mode\` / \`last_scan_at\` / \`next_scan_at\`) was actually nicer for clients than the nested \`scheduler.{...}\` block. The flat shape is simpler but throws away the distinction between full and quick scans, which the UI does need. The current nested shape is the right one — this PR aligns the docs with it rather than the other way around.

## Test plan

- [x] Read the rendered README diff to confirm the fields match \`daemonStatusResponse\` / \`schedulerStatusBlock\` / \`windowBlock\` / \`installHint\` in \`internal/webui/daemon_status.go\`.
- [x] No code changes, so \`go build\` / \`go test\` were not required, but \`go build ./...\` still passes from previous PR's working tree.