### PR TITLE
add findings grouped-by-host endpoint and UI view

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1203,6 +1203,152 @@ func (s *SQLiteStore) CountAssetsByType(ctx context.Context) (map[model.AssetTyp
 	return counts, rows.Err()
 }
 
+// GroupedFindingOptions configures the host-grouped findings query.
+type GroupedFindingOptions struct {
+	Severity   model.Severity
+	SourceTool string
+	Host       string
+	SortBy     string // "last_seen", "severity", "affected_assets_count"
+	Limit      int
+	Offset     int
+}
+
+// GroupedFinding is one row of the host-aggregated findings view.
+type GroupedFinding struct {
+	Host                string   `json:"host"`
+	TemplateID          string   `json:"template_id"`
+	SourceTool          string   `json:"source_tool"`
+	Title               string   `json:"title"`
+	Severity            string   `json:"severity"`
+	FirstSeen           string   `json:"first_seen"`
+	LastSeen            string   `json:"last_seen"`
+	AffectedAssetsCount int      `json:"affected_assets_count"`
+	FindingIDs          []string `json:"finding_ids"`
+}
+
+// ListGroupedFindings returns findings grouped by (host, template_id, source_tool).
+// Host is derived from the asset value by stripping the ":port/tcp" suffix.
+func (s *SQLiteStore) ListGroupedFindings(ctx context.Context, opts GroupedFindingOptions) ([]GroupedFinding, error) {
+	if opts.Limit <= 0 {
+		opts.Limit = 50
+	}
+
+	// host = everything before the first ":" in asset.value, falling back
+	// to the full value when there's no colon (e.g. bare domains).
+	const hostExpr = `CASE WHEN instr(a.value,':')>0 THEN substr(a.value,1,instr(a.value,':')-1) ELSE a.value END`
+
+	query := `SELECT ` + hostExpr + ` AS host,
+		f.template_id, f.source_tool,
+		MAX(f.title) AS title, MAX(f.severity) AS severity,
+		MIN(f.first_seen) AS first_seen, MAX(f.last_seen) AS last_seen,
+		COUNT(DISTINCT f.asset_id) AS affected_assets_count,
+		GROUP_CONCAT(f.id) AS finding_ids
+		FROM findings f
+		JOIN assets a ON f.asset_id = a.id`
+
+	where := []string{}
+	args := []interface{}{}
+
+	if opts.Severity != "" {
+		where = append(where, "f.severity = ?")
+		args = append(args, string(opts.Severity))
+	}
+	if opts.SourceTool != "" {
+		where = append(where, "f.source_tool = ?")
+		args = append(args, opts.SourceTool)
+	}
+	if opts.Host != "" {
+		where = append(where, hostExpr+" LIKE ?")
+		args = append(args, "%"+opts.Host+"%")
+	}
+
+	if len(where) > 0 {
+		query += " WHERE " + strings.Join(where, " AND ")
+	}
+
+	query += ` GROUP BY host, f.template_id, f.source_tool`
+
+	switch opts.SortBy {
+	case "severity":
+		query += ` ORDER BY CASE MAX(f.severity)
+			WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2
+			WHEN 'low' THEN 3 WHEN 'info' THEN 4 END, MAX(f.last_seen) DESC`
+	case "affected_assets_count":
+		query += ` ORDER BY affected_assets_count DESC, MAX(f.last_seen) DESC`
+	default:
+		query += ` ORDER BY MAX(f.last_seen) DESC`
+	}
+
+	query += ` LIMIT ? OFFSET ?`
+	args = append(args, opts.Limit, opts.Offset)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("listing grouped findings: %w", err)
+	}
+	defer rows.Close()
+
+	results := make([]GroupedFinding, 0)
+	for rows.Next() {
+		var g GroupedFinding
+		var idsConcat string
+		if err := rows.Scan(&g.Host, &g.TemplateID, &g.SourceTool,
+			&g.Title, &g.Severity, &g.FirstSeen, &g.LastSeen,
+			&g.AffectedAssetsCount, &idsConcat); err != nil {
+			return nil, fmt.Errorf("scanning grouped finding row: %w", err)
+		}
+		g.FindingIDs = strings.Split(idsConcat, ",")
+		results = append(results, g)
+	}
+	return results, rows.Err()
+}
+
+// CountGroupedFindings returns the total number of grouped rows for pagination.
+func (s *SQLiteStore) CountGroupedFindings(ctx context.Context, opts GroupedFindingOptions) (int, error) {
+	const hostExpr = `CASE WHEN instr(a.value,':')>0 THEN substr(a.value,1,instr(a.value,':')-1) ELSE a.value END`
+
+	query := `SELECT COUNT(*) FROM (
+		SELECT 1 FROM findings f JOIN assets a ON f.asset_id = a.id`
+
+	where := []string{}
+	args := []interface{}{}
+
+	if opts.Severity != "" {
+		where = append(where, "f.severity = ?")
+		args = append(args, string(opts.Severity))
+	}
+	if opts.SourceTool != "" {
+		where = append(where, "f.source_tool = ?")
+		args = append(args, opts.SourceTool)
+	}
+	if opts.Host != "" {
+		where = append(where, hostExpr+" LIKE ?")
+		args = append(args, "%"+opts.Host+"%")
+	}
+
+	if len(where) > 0 {
+		query += " WHERE " + strings.Join(where, " AND ")
+	}
+
+	query += ` GROUP BY ` + hostExpr + `, f.template_id, f.source_tool)`
+
+	var n int
+	err := s.db.QueryRowContext(ctx, query, args...).Scan(&n)
+	return n, err
+}
+
+// CountUniqueFindingsByHost returns the number of distinct (host, template_id, source_tool)
+// tuples across all findings. Used by the dashboard to show de-duplicated count.
+func (s *SQLiteStore) CountUniqueFindingsByHost(ctx context.Context) (int, error) {
+	query := `SELECT COUNT(*) FROM (
+		SELECT 1 FROM findings f JOIN assets a ON f.asset_id = a.id
+		GROUP BY CASE WHEN instr(a.value,':')>0 THEN substr(a.value,1,instr(a.value,':')-1) ELSE a.value END,
+		f.template_id, f.source_tool)`
+	var n int
+	err := s.db.QueryRowContext(ctx, query).Scan(&n)
+	return n, err
+}
+
 // --- Helpers ---
 
 func detectTargetType(value string) (model.TargetType, error) {

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -70,6 +70,7 @@ type overviewResponse struct {
 	SecurityScore      int                     `json:"security_score"`
 	ScoreBreakdown     []scoreComponent        `json:"score_breakdown"`
 	TotalFindings      int                     `json:"total_findings"`
+	UniqueFindings     int                     `json:"unique_findings"`
 	FindingsBySeverity map[model.Severity]int  `json:"findings_by_severity"`
 	TotalAssets        int                     `json:"total_assets"`
 	AssetsByType       map[model.AssetType]int `json:"assets_by_type"`
@@ -137,6 +138,10 @@ func (h *handler) handleOverview(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errs = append(errs, fmt.Errorf("count types: %w", err))
 	}
+	uniqueFindings, err := h.store.CountUniqueFindingsByHost(ctx)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("count unique findings: %w", err))
+	}
 
 	if len(errs) > 0 {
 		for _, e := range errs {
@@ -157,6 +162,7 @@ func (h *handler) handleOverview(w http.ResponseWriter, r *http.Request) {
 		SecurityScore:      score,
 		ScoreBreakdown:     breakdown,
 		TotalFindings:      totalFindings,
+		UniqueFindings:     uniqueFindings,
 		FindingsBySeverity: sevCounts,
 		TotalAssets:        totalAssets,
 		AssetsByType:       typeCounts,
@@ -336,6 +342,58 @@ func (h *handler) handleFindingDetail(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"finding": finding,
 		"asset":   asset,
+	})
+}
+
+// --- Grouped Findings ---
+
+type groupedFindingsResponse struct {
+	Groups []storage.GroupedFinding `json:"groups"`
+	Total  int                     `json:"total"`
+	Page   int                     `json:"page"`
+	Limit  int                     `json:"limit"`
+}
+
+func (h *handler) handleFindingsGrouped(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	page := queryInt(r, "page", 1)
+	limit := queryInt(r, "limit", 50)
+	if limit > 250 {
+		limit = 250
+	}
+
+	opts := storage.GroupedFindingOptions{
+		Limit:  limit,
+		Offset: (page - 1) * limit,
+		SortBy: r.URL.Query().Get("sort"),
+	}
+	if sev := r.URL.Query().Get("severity"); sev != "" {
+		opts.Severity = model.Severity(sev)
+	}
+	if tool := r.URL.Query().Get("tool"); tool != "" {
+		opts.SourceTool = tool
+	}
+	if host := r.URL.Query().Get("host"); host != "" {
+		opts.Host = host
+	}
+
+	groups, err := h.store.ListGroupedFindings(r.Context(), opts)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list grouped findings")
+		return
+	}
+
+	total, _ := h.store.CountGroupedFindings(r.Context(), opts)
+
+	writeJSON(w, http.StatusOK, groupedFindingsResponse{
+		Groups: groups,
+		Total:  total,
+		Page:   page,
+		Limit:  limit,
 	})
 }
 

--- a/internal/webui/handlers_test.go
+++ b/internal/webui/handlers_test.go
@@ -603,6 +603,151 @@ func TestHandleUpdateFindingStatusNotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
+// --- Grouped Findings Tests ---
+
+// seedGroupedData creates 3 port_service assets for the same host and
+// 2 templates per asset, resulting in 6 raw findings but 2 grouped rows.
+func seedGroupedData(t *testing.T, s *storage.SQLiteStore) {
+	t.Helper()
+	ctx := context.Background()
+
+	target := &model.Target{Value: "grouped.example.com"}
+	require.NoError(t, s.CreateTarget(ctx, target))
+
+	now := time.Now().UTC()
+	started := now.Add(-5 * time.Minute)
+	scan := &model.Scan{
+		TargetID:   target.ID,
+		Type:       model.ScanTypeFull,
+		Status:     model.ScanStatusCompleted,
+		Phase:      "assessment",
+		Progress:   100,
+		StartedAt:  &started,
+		FinishedAt: &now,
+	}
+	require.NoError(t, s.CreateScan(ctx, scan))
+
+	ports := []string{"grouped.example.com:80/tcp", "grouped.example.com:443/tcp", "grouped.example.com:8080/tcp"}
+	templates := []struct {
+		id       string
+		name     string
+		title    string
+		severity model.Severity
+	}{
+		{"apache-detect", "Apache Detection", "Apache HTTP Server Detected", model.SeverityInfo},
+		{"http-missing-headers", "Missing Headers", "Missing Security Headers", model.SeverityMedium},
+	}
+
+	for _, port := range ports {
+		asset := &model.Asset{
+			TargetID: target.ID,
+			Type:     model.AssetTypePort,
+			Value:    port,
+			Status:   model.AssetStatusActive,
+		}
+		require.NoError(t, s.UpsertAsset(ctx, asset))
+
+		for _, tmpl := range templates {
+			f := &model.Finding{
+				AssetID:      asset.ID,
+				ScanID:       scan.ID,
+				TemplateID:   tmpl.id,
+				TemplateName: tmpl.name,
+				Severity:     tmpl.severity,
+				Title:        tmpl.title,
+				Status:       model.FindingStatusOpen,
+				SourceTool:   "nuclei",
+				Confidence:   80,
+			}
+			require.NoError(t, s.UpsertFinding(ctx, f))
+		}
+	}
+}
+
+func TestHandleFindingsGrouped(t *testing.T) {
+	h, s := newTestHandler(t)
+	seedGroupedData(t, s)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/findings/grouped", nil)
+	w := httptest.NewRecorder()
+	h.handleFindingsGrouped(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp groupedFindingsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	// 2 templates x 1 host = 2 grouped rows
+	assert.Equal(t, 2, resp.Total)
+	require.Len(t, resp.Groups, 2)
+
+	for _, g := range resp.Groups {
+		assert.Equal(t, "grouped.example.com", g.Host)
+		assert.Equal(t, "nuclei", g.SourceTool)
+		// Each template matched all 3 port assets
+		assert.Equal(t, 3, g.AffectedAssetsCount)
+		assert.Len(t, g.FindingIDs, 3)
+	}
+}
+
+func TestHandleFindingsGroupedSeverityFilter(t *testing.T) {
+	h, s := newTestHandler(t)
+	seedGroupedData(t, s)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/findings/grouped?severity=info", nil)
+	w := httptest.NewRecorder()
+	h.handleFindingsGrouped(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp groupedFindingsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+	require.Len(t, resp.Groups, 1)
+	assert.Equal(t, "apache-detect", resp.Groups[0].TemplateID)
+}
+
+func TestHandleFindingsRawUnchanged(t *testing.T) {
+	h, s := newTestHandler(t)
+	seedTestData(t, s)
+
+	// Raw endpoint unchanged — same response shape.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/findings", nil)
+	w := httptest.NewRecorder()
+	h.handleFindings(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp findingsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 2, len(resp.Findings))
+	assert.Equal(t, 2, resp.Total)
+	// Verify response has the expected fields (byte-compatible)
+	assert.NotEmpty(t, resp.Findings[0].ID)
+	assert.NotEmpty(t, resp.Findings[0].AssetID)
+}
+
+func TestHandleFindingsRawScanIDFilterStillWorks(t *testing.T) {
+	h, s := newTestHandler(t)
+	seedTestData(t, s)
+
+	// Get the scan ID from seed data
+	scans, err := s.ListScans(context.Background(), "", 1)
+	require.NoError(t, err)
+	require.NotEmpty(t, scans)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/findings?scan_id="+scans[0].ID, nil)
+	w := httptest.NewRecorder()
+	h.handleFindings(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp findingsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 2, resp.Total)
+	for _, f := range resp.Findings {
+		assert.Equal(t, scans[0].ID, f.ScanID)
+	}
+}
+
 // --- Scan Trigger Tests ---
 
 func TestHandleCreateScanNoRegistry(t *testing.T) {

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -58,7 +58,8 @@ func NewServer(store *storage.SQLiteStore, opts ServerOptions) (*http.Server, ne
 	mux.HandleFunc("/api/v1/tools/available", h.handleAvailableTools)
 	mux.HandleFunc("/api/v1/scans/status", h.handleScanStatus)
 
-	// Findings: GET list, GET detail, PATCH status
+	// Findings: GET list, GET grouped, GET detail, PATCH status
+	mux.HandleFunc("/api/v1/findings/grouped", h.handleFindingsGrouped)
 	mux.HandleFunc("/api/v1/findings", h.handleFindings)
 	mux.HandleFunc("/api/v1/findings/", func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/status") {

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -291,6 +291,27 @@ a:hover { color: var(--accent-hover); }
 .badge-low { background: var(--sev-low-bg); color: var(--sev-low); }
 .badge-info { background: var(--sev-info-bg); color: var(--sev-info); }
 
+.port-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 600;
+  background: var(--surface);
+  color: var(--text-muted);
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+.filter-input {
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 13px;
+}
+
 .badge-status {
   padding: 2px 8px;
   border-radius: 12px;

--- a/internal/webui/static/js/api.js
+++ b/internal/webui/static/js/api.js
@@ -53,6 +53,7 @@ const API = {
   // Read endpoints
   overview()            { return this.get('/overview'); },
   findings(params)      { return this.get('/findings' + toQuery(params)); },
+  findingsGrouped(params) { return this.get('/findings/grouped' + toQuery(params)); },
   finding(id)           { return this.get('/findings/' + id); },
   assets(params)        { return this.get('/assets' + toQuery(params)); },
   assetTree(targetId)   { return this.get('/assets/tree' + toQuery({ target_id: targetId })); },

--- a/internal/webui/static/js/pages/dashboard.js
+++ b/internal/webui/static/js/pages/dashboard.js
@@ -75,8 +75,11 @@ const DashboardPage = {
           ${Components.severityBars(d.findings_by_severity)}
         </div>
         <div class="card">
-          <div class="card-label">Total Findings</div>
-          <div class="card-value">${d.total_findings}</div>
+          <div class="card-label">Unique Findings</div>
+          <div class="card-value">${d.unique_findings != null ? d.unique_findings : d.total_findings}</div>
+          ${d.unique_findings != null && d.unique_findings !== d.total_findings
+            ? `<div class="card-sub">${d.total_findings} total across all ports</div>`
+            : ''}
         </div>
         <div class="card">
           <div class="card-label">Total Assets</div>

--- a/internal/webui/static/js/pages/findings.js
+++ b/internal/webui/static/js/pages/findings.js
@@ -1,31 +1,119 @@
-// Findings page
+// Findings page — grouped-by-host default, toggle to raw per-asset view.
 const FindingsPage = {
   async render(app, params) {
     if (params && params.id) {
       return this.renderDetail(app, params.id);
     }
 
-    app.innerHTML = '<div class="loading">Loading findings...</div>';
+    const view = params?.view || 'grouped';
+    if (view === 'grouped') {
+      return this.renderGrouped(app, params);
+    }
+    return this.renderRaw(app, params);
+  },
 
+  // --- Grouped view (default) ---
+
+  async renderGrouped(app, params) {
+    app.innerHTML = '<div class="loading">Loading findings...</div>';
+    try {
+      const data = await API.findingsGrouped({
+        severity: params?.severity,
+        tool: params?.tool,
+        host: params?.host,
+        sort: params?.sort || 'last_seen',
+        page: params?.page || 1,
+        limit: 50,
+      });
+      app.innerHTML = this.groupedTemplate(data, params);
+    } catch (err) {
+      app.innerHTML = Components.emptyState('Error', 'Failed to load findings: ' + err.message);
+    }
+  },
+
+  groupedTemplate(data, params) {
+    if (data.groups.length === 0 && !params?.severity && !params?.host) {
+      return `
+        <div class="page-header"><h2>Findings</h2></div>
+        ${this.viewToggle('grouped')}
+        ${Components.emptyState('No findings', 'No vulnerabilities detected. Run a scan to discover findings.')}
+      `;
+    }
+
+    const rows = data.groups.map(g => {
+      const badge = g.affected_assets_count > 1
+        ? `<span class="port-badge">${g.affected_assets_count} ports</span>`
+        : '';
+      const drillHref = '#/findings?view=raw&host=' + encodeURIComponent(g.host)
+        + '&template_id=' + encodeURIComponent(g.template_id);
+      return `
+        <tr>
+          <td>${Components.severityBadge(g.severity)}</td>
+          <td class="text-truncate">${escapeHtml(g.title)} ${badge}</td>
+          <td class="mono">${escapeHtml(g.host)}</td>
+          <td class="mono">${escapeHtml(g.source_tool)}</td>
+          <td class="mono text-muted">${Components.timeAgo(g.last_seen)}</td>
+        </tr>
+      `;
+    }).join('');
+
+    const totalPages = Math.ceil(data.total / data.limit);
+    const page = data.page;
+
+    return `
+      <div class="page-header">
+        <h2>Findings</h2>
+        <p>${data.total} unique finding${data.total !== 1 ? 's' : ''}${params?.severity ? ' (' + params.severity + ')' : ''}</p>
+      </div>
+      ${this.viewToggle('grouped')}
+      ${this.groupedFiltersHtml(params)}
+      ${Components.table(['Severity', 'Title', 'Host', 'Tool', 'Last Seen'], [rows])}
+      ${totalPages > 1 ? this.paginationHtml(page, totalPages, params) : ''}
+    `;
+  },
+
+  groupedFiltersHtml(params) {
+    const sev = params?.severity || '';
+    const host = params?.host || '';
+    return `<div class="filters">
+      <select class="filter-select" id="filter-severity" onchange="FindingsPage.applyFilters()">
+        <option value="">All severities</option>
+        <option value="critical" ${sev==='critical'?'selected':''}>Critical</option>
+        <option value="high" ${sev==='high'?'selected':''}>High</option>
+        <option value="medium" ${sev==='medium'?'selected':''}>Medium</option>
+        <option value="low" ${sev==='low'?'selected':''}>Low</option>
+        <option value="info" ${sev==='info'?'selected':''}>Info</option>
+      </select>
+      <input class="filter-input" id="filter-host" placeholder="Filter by host..." value="${escapeHtml(host)}"
+        onkeydown="if(event.key==='Enter')FindingsPage.applyFilters()" />
+    </div>`;
+  },
+
+  // --- Raw view (per-asset findings) ---
+
+  async renderRaw(app, params) {
+    app.innerHTML = '<div class="loading">Loading findings...</div>';
     try {
       const data = await API.findings({
         severity: params?.severity,
         tool: params?.tool,
         status: params?.status,
         target_id: params?.target_id,
+        scan_id: params?.scan_id,
         page: params?.page || 1,
         limit: 50,
       });
-      app.innerHTML = this.template(data, params);
+      app.innerHTML = this.rawTemplate(data, params);
     } catch (err) {
       app.innerHTML = Components.emptyState('Error', 'Failed to load findings: ' + err.message);
     }
   },
 
-  template(data, params) {
+  rawTemplate(data, params) {
     if (data.findings.length === 0 && !params?.severity && !params?.status) {
       return `
         <div class="page-header"><h2>Findings</h2></div>
+        ${this.viewToggle('raw')}
         ${Components.emptyState('No findings', 'No vulnerabilities detected. Run a scan to discover findings.')}
       `;
     }
@@ -56,13 +144,14 @@ const FindingsPage = {
         <h2>Findings</h2>
         <p>${data.total} finding${data.total !== 1 ? 's' : ''}${params?.severity ? ' (' + params.severity + ')' : ''}</p>
       </div>
-      ${this.filtersHtml(params)}
+      ${this.viewToggle('raw')}
+      ${this.rawFiltersHtml(params)}
       ${Components.table(['Severity', 'Title', 'Tool', 'Status', 'Last Seen'], [rows])}
       ${totalPages > 1 ? this.paginationHtml(page, totalPages, params) : ''}
     `;
   },
 
-  filtersHtml(params) {
+  rawFiltersHtml(params) {
     const sev = params?.severity || '';
     const status = params?.status || '';
     return `<div class="filters">
@@ -85,6 +174,40 @@ const FindingsPage = {
     </div>`;
   },
 
+  // --- View toggle ---
+
+  viewToggle(active) {
+    const groupedCls = active === 'grouped' ? 'btn-accent' : 'btn-ghost';
+    const rawCls = active === 'raw' ? 'btn-accent' : 'btn-ghost';
+    return `<div class="view-toggle" style="margin-bottom:12px;display:flex;gap:8px">
+      <button class="btn btn-sm ${groupedCls}" onclick="FindingsPage.switchView('grouped')">Group by host</button>
+      <button class="btn btn-sm ${rawCls}" onclick="FindingsPage.switchView('raw')">Show all</button>
+    </div>`;
+  },
+
+  switchView(view) {
+    const params = parseQueryParams();
+    // Reset page when switching views
+    const q = ['view=' + view];
+    if (params.severity) q.push('severity=' + params.severity);
+    location.hash = '#/findings?' + q.join('&');
+  },
+
+  // --- Shared helpers ---
+
+  applyFilters() {
+    const severity = document.getElementById('filter-severity')?.value || '';
+    const status = document.getElementById('filter-status')?.value || '';
+    const host = document.getElementById('filter-host')?.value || '';
+    const params = parseQueryParams();
+    const view = params.view || 'grouped';
+    const q = ['view=' + view];
+    if (severity) q.push('severity=' + severity);
+    if (status) q.push('status=' + status);
+    if (host) q.push('host=' + host);
+    location.hash = '#/findings?' + q.join('&');
+  },
+
   paginationHtml(page, totalPages, params) {
     let html = '<div style="display:flex;gap:8px;justify-content:center;margin-top:16px">';
     if (page > 1) {
@@ -96,16 +219,6 @@ const FindingsPage = {
     }
     html += '</div>';
     return html;
-  },
-
-  applyFilters() {
-    const severity = document.getElementById('filter-severity')?.value || '';
-    const status = document.getElementById('filter-status')?.value || '';
-    const parts = ['#/findings'];
-    const q = [];
-    if (severity) q.push('severity=' + severity);
-    if (status) q.push('status=' + status);
-    location.hash = parts[0] + (q.length ? '?' + q.join('&') : '');
   },
 
   goToPage(page) {
@@ -132,7 +245,6 @@ const FindingsPage = {
   async changeStatusFromDetail(id, newStatus) {
     try {
       await API.updateFindingStatus(id, newStatus);
-      // Re-render detail to reflect the change
       this.renderDetail(document.getElementById('app'), id);
     } catch (err) {
       alert('Failed to update status: ' + err.message);


### PR DESCRIPTION
## Summary
- New `GET /api/v1/findings/grouped` endpoint aggregates findings by `(host, template_id, source_tool)` with a JOIN to assets. Returns host, severity, first/last seen (MIN/MAX), affected_assets_count, and finding_ids array for drill-down. Paginated, sortable by last_seen (default), severity, or affected_assets_count. Filterable by severity, source_tool, host.
- Findings UI (`/#/findings`) defaults to grouped-by-host view. Each row shows the template once with a "(N ports)" badge when `affected_assets_count > 1`. Toggle "Group by host / Show all" switches between grouped and raw views.
- Dashboard widget renamed to "Unique Findings" showing host-grouped count; raw total shown as subtitle.
- Scan detail view (`/#/scans/<id>`) untouched — still shows raw per-asset findings.

## What's NOT changed
- Write path, upsert logic, finding_repo, findings schema, naabu.go — read-only additions only.
- `GET /api/v1/findings` response is byte-compatible with before (regression tested).
- `?scan_id=` filter (PR #4 fix) still works (regression tested).

## Test plan
- [x] `TestHandleFindingsGrouped` — seeds 3 assets same host, 2 templates, verifies 2 grouped rows with `affected_assets_count=3`
- [x] `TestHandleFindingsGroupedSeverityFilter` — verifies severity filter narrows grouped results
- [x] `TestHandleFindingsRawUnchanged` — regression: raw endpoint returns same shape
- [x] `TestHandleFindingsRawScanIDFilterStillWorks` — regression: scan_id filter works
- [x] `go test ./... -race` green
- [x] `go vet ./...` clean (aside from pre-existing naabu.go:86)

Closes SUR-231