### PR TITLE
fix: broken dropdown filters on findings and assets pages

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -213,6 +213,33 @@ func durationOr(d, fallback time.Duration) time.Duration {
 // Returns the X1 NoopScheduler when scheduling is disabled so the daemon
 // still stays up (UI / logs are useful even without scans).
 func buildScheduler(sc config.SchedulerConfig, paths daemon.Paths, store storage.Store) (daemon.Scheduler, error) {
+	configStore := intervalsched.NewScheduleConfigStore(scheduleConfigPath(paths))
+
+	// schedule.config.json takes precedence over config.yaml when it exists.
+	if configStore.Exists() {
+		persisted, err := configStore.Load()
+		if err == nil {
+			sc.Enabled = persisted.Enabled
+			if d, e := time.ParseDuration(persisted.FullScanInterval); e == nil {
+				sc.FullScanInterval = d
+			}
+			if d, e := time.ParseDuration(persisted.QuickCheckInterval); e == nil {
+				sc.QuickCheckInterval = d
+			}
+			if d, e := time.ParseDuration(persisted.Jitter); e == nil {
+				sc.Jitter = d
+			}
+			sc.RunOnStart = persisted.RunOnStart
+			sc.QuickCheckTools = persisted.QuickCheckTools
+			sc.MaintenanceWindow = config.MaintenanceWindowConfig{
+				Enabled:  persisted.MaintenanceWindow.Enabled,
+				Start:    persisted.MaintenanceWindow.Start,
+				End:      persisted.MaintenanceWindow.End,
+				Timezone: persisted.MaintenanceWindow.Timezone,
+			}
+		}
+	}
+
 	if !sc.Enabled {
 		return daemon.NewNoopScheduler(), nil
 	}
@@ -244,8 +271,9 @@ func buildScheduler(sc config.SchedulerConfig, paths daemon.Paths, store storage
 	scanRunner := newPipelineScanRunner(store, registry, icfg.QuickTools)
 	stateStore := intervalsched.NewScheduleStateStore(scheduleStatePath(paths))
 	return intervalsched.New(icfg, intervalsched.Options{
-		StateStore: stateStore,
-		Scanner:    scanRunner,
+		StateStore:  stateStore,
+		ConfigStore: configStore,
+		Scanner:     scanRunner,
 	}), nil
 }
 
@@ -351,6 +379,14 @@ func printSchedulerStatus(w io.Writer, s *schedulerStatus) {
 func scheduleStatePath(paths daemon.Paths) string {
 	dir := paths.StateDir
 	return dir + string(os.PathSeparator) + "schedule.state.json"
+}
+
+// scheduleConfigPath returns the path of schedule.config.json next to
+// daemon.state.json. This file takes precedence over config.yaml for
+// scheduler settings once the user edits via UI or CLI.
+func scheduleConfigPath(paths daemon.Paths) string {
+	dir := paths.StateDir
+	return dir + string(os.PathSeparator) + "schedule.config.json"
 }
 
 func runDaemonInstall(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/findings.go
+++ b/internal/cli/findings.go
@@ -28,11 +28,15 @@ var findingsListCmd = &cobra.Command{
 		status, _ := cmd.Flags().GetString("status")
 		scanID, _ := cmd.Flags().GetString("scan")
 		limit, _ := cmd.Flags().GetInt("limit")
+		page, _ := cmd.Flags().GetInt("page")
 		newOnly, _ := cmd.Flags().GetBool("new")
 		resolvedOnly, _ := cmd.Flags().GetBool("resolved")
 
 		if limit <= 0 {
 			limit = 50
+		}
+		if page <= 0 {
+			page = 1
 		}
 
 		if resolvedOnly {
@@ -45,6 +49,7 @@ var findingsListCmd = &cobra.Command{
 			Status:     model.FindingStatus(status),
 			ScanID:     scanID,
 			Limit:      limit,
+			Offset:     (page - 1) * limit,
 		}
 
 		findings, err := store.ListFindings(ctx, opts)
@@ -116,6 +121,9 @@ var findingsListCmd = &cobra.Command{
 		}
 		w.Flush()
 
+		total, _ := store.CountFindingsFiltered(ctx, opts)
+		totalPages := (total + limit - 1) / limit
+
 		crit, high, med := 0, 0, 0
 		for _, f := range findings {
 			switch f.Severity {
@@ -127,7 +135,12 @@ var findingsListCmd = &cobra.Command{
 				med++
 			}
 		}
-		fmt.Fprintf(p.W, "\n%d findings", len(findings))
+
+		if totalPages > 1 {
+			fmt.Fprintf(p.W, "\n%d findings (page %d/%d, %d total)", len(findings), page, totalPages, total)
+		} else {
+			fmt.Fprintf(p.W, "\n%d findings", len(findings))
+		}
 		switch {
 		case crit > 0:
 			p.Theme.Critical.Fprintf(p.W, " (%d critical)", crit)
@@ -138,6 +151,9 @@ var findingsListCmd = &cobra.Command{
 		}
 		fmt.Fprintln(p.W, "")
 
+		if page < totalPages {
+			p.ActionHint("use --page %d to see more.", page+1)
+		}
 		if !newOnly && !resolvedOnly {
 			p.ActionHint("use 'surfbot findings show <id>' for full details.")
 		}
@@ -216,6 +232,7 @@ func init() {
 	findingsListCmd.Flags().String("status", "", "Filter by status: open|resolved|acknowledged|false_positive|ignored")
 	findingsListCmd.Flags().String("scan", "", "Filter by scan ID")
 	findingsListCmd.Flags().Int("limit", 50, "Max number of results")
+	findingsListCmd.Flags().Int("page", 1, "Page number for paginated results")
 	findingsListCmd.Flags().Bool("new", false, "Show only new findings from last scan")
 	findingsListCmd.Flags().Bool("resolved", false, "Show only recently resolved findings")
 

--- a/internal/cli/findings.go
+++ b/internal/cli/findings.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -59,6 +60,12 @@ var findingsListCmd = &cobra.Command{
 				}
 			}
 			findings = filtered
+		}
+
+		if jsonOut {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(findings)
 		}
 
 		p := NewPrinter(cmd.OutOrStdout())

--- a/internal/cli/fix.go
+++ b/internal/cli/fix.go
@@ -10,7 +10,7 @@ var fixCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		p := NewPrinter(cmd.OutOrStdout())
-		p.Warn("not yet implemented — see roadmap L6 (MCP connectors).")
+		p.Warn("not yet implemented — see roadmap L5 (remediation framework).")
 	},
 }
 

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -25,16 +25,28 @@ func init() {
 	scanCmd.Flags().IntP("rate-limit", "r", 0, "Global rate limit (requests/second)")
 	scanCmd.Flags().Int("timeout", 300, "Per-phase timeout in seconds")
 	scanCmd.Flags().StringP("output", "o", "", "Output results to file (JSON)")
+	scanCmd.Flags().Bool("auto-create", false, "Auto-create target if it doesn't exist")
 	rootCmd.AddCommand(scanCmd)
 }
 
 func runScan(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	targetValue := args[0]
+	autoCreate, _ := cmd.Flags().GetBool("auto-create")
 
-	target, err := autoCreateTarget(ctx, store, targetValue)
+	target, err := store.GetTargetByValue(ctx, targetValue)
 	if err != nil {
-		return fmt.Errorf("resolving target: %w", err)
+		if err != storage.ErrNotFound {
+			return fmt.Errorf("resolving target: %w", err)
+		}
+		if !autoCreate {
+			cmd.SilenceUsage = true
+			return fmt.Errorf("target %q not found; use 'surfbot target add %s' first, or pass --auto-create", targetValue, targetValue)
+		}
+		target, err = autoCreateTarget(ctx, store, targetValue)
+		if err != nil {
+			return fmt.Errorf("auto-creating target: %w", err)
+		}
 	}
 
 	pipe := pipeline.New(store, registry)

--- a/internal/cli/schedule.go
+++ b/internal/cli/schedule.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/surfbot-io/surfbot-agent/internal/config"
+	"github.com/surfbot-io/surfbot-agent/internal/daemon"
+	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
+)
+
+var scheduleCmd = &cobra.Command{
+	Use:   "schedule",
+	Short: "View and configure scan schedule",
+}
+
+var scheduleShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Display the current schedule configuration",
+	RunE:  runScheduleShow,
+}
+
+var scheduleSetCmd = &cobra.Command{
+	Use:   "set [key] [value]",
+	Short: "Update a schedule setting",
+	Long: `Update a schedule setting. Available keys:
+
+  enabled              true/false
+  full_scan_interval   Duration (e.g. 24h, 12h)
+  quick_check_interval Duration (e.g. 1h, 30m)
+  jitter               Duration (e.g. 5m, 10m)
+  run_on_start         true/false
+  window_enabled       true/false
+  window_start         Time (HH:MM, e.g. 02:00)
+  window_end           Time (HH:MM, e.g. 04:00)
+  window_timezone      IANA timezone (e.g. UTC, Europe/Madrid)
+
+Examples:
+  surfbot schedule set full_scan_interval 12h
+  surfbot schedule set enabled true
+  surfbot schedule set window_start 03:00`,
+	Args: cobra.ExactArgs(2),
+	RunE: runScheduleSet,
+}
+
+func init() {
+	scheduleCmd.AddCommand(scheduleShowCmd)
+	scheduleCmd.AddCommand(scheduleSetCmd)
+	rootCmd.AddCommand(scheduleCmd)
+}
+
+func resolveScheduleConfigStore() *intervalsched.ScheduleConfigStore {
+	mode := daemon.DefaultMode()
+	paths := daemon.Resolve(daemon.Default(mode))
+	return intervalsched.NewScheduleConfigStore(scheduleConfigPath(paths))
+}
+
+// loadScheduleConfig returns the current schedule config, merging
+// persisted schedule.config.json over config.yaml defaults.
+func loadScheduleConfig() intervalsched.ScheduleConfig {
+	sc := intervalsched.ScheduleConfig{
+		FullScanInterval:   "24h",
+		QuickCheckInterval: "1h",
+		Jitter:             "5m",
+	}
+
+	// Read from config.yaml if available.
+	cfg, err := config.Load(cfgFile)
+	if err == nil {
+		sc.Enabled = cfg.Daemon.Scheduler.Enabled
+		mw := cfg.Daemon.Scheduler.MaintenanceWindow
+		sc.MaintenanceWindow.Start = mw.Start
+		sc.MaintenanceWindow.End = mw.End
+		sc.MaintenanceWindow.Timezone = mw.Timezone
+	}
+
+	// Override with persisted schedule.config.json if it exists.
+	store := resolveScheduleConfigStore()
+	if store.Exists() {
+		persisted, serr := store.Load()
+		if serr == nil {
+			return persisted
+		}
+	}
+
+	return sc
+}
+
+func runScheduleShow(cmd *cobra.Command, _ []string) error {
+	sc := loadScheduleConfig()
+
+	if jsonOut {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(sc)
+	}
+
+	p := NewPrinter(cmd.OutOrStdout())
+	p.SectionHeader("Schedule Configuration")
+	p.Keyf("Enabled", "%v", sc.Enabled)
+	p.Keyf("Full scan interval", "%s", sc.FullScanInterval)
+	p.Keyf("Quick check interval", "%s", sc.QuickCheckInterval)
+	p.Keyf("Jitter", "%s", sc.Jitter)
+	p.Keyf("Run on start", "%v", sc.RunOnStart)
+
+	if len(sc.QuickCheckTools) > 0 {
+		p.Keyf("Quick check tools", "%v", sc.QuickCheckTools)
+	}
+
+	p.Divider(40)
+	mw := sc.MaintenanceWindow
+	p.Keyf("Window enabled", "%v", mw.Enabled)
+	if mw.Start != "" {
+		p.Keyf("Window start", "%s", mw.Start)
+	}
+	if mw.End != "" {
+		p.Keyf("Window end", "%s", mw.End)
+	}
+	if mw.Timezone != "" {
+		p.Keyf("Window timezone", "%s", mw.Timezone)
+	}
+
+	// Show the config file path.
+	store := resolveScheduleConfigStore()
+	if store.Exists() {
+		p.Divider(40)
+		p.Muted("Config: %s", store.Path())
+	}
+
+	return nil
+}
+
+func runScheduleSet(cmd *cobra.Command, args []string) error {
+	key, value := args[0], args[1]
+	sc := loadScheduleConfig()
+
+	switch key {
+	case "enabled":
+		sc.Enabled = parseBool(value)
+	case "full_scan_interval":
+		sc.FullScanInterval = value
+	case "quick_check_interval":
+		sc.QuickCheckInterval = value
+	case "jitter":
+		sc.Jitter = value
+	case "run_on_start":
+		sc.RunOnStart = parseBool(value)
+	case "window_enabled":
+		sc.MaintenanceWindow.Enabled = parseBool(value)
+	case "window_start":
+		sc.MaintenanceWindow.Start = value
+	case "window_end":
+		sc.MaintenanceWindow.End = value
+	case "window_timezone":
+		sc.MaintenanceWindow.Timezone = value
+	default:
+		cmd.SilenceUsage = true
+		return fmt.Errorf("unknown key: %s", key)
+	}
+
+	// Validate the whole config before saving.
+	_, fieldErrors := intervalsched.ParseScheduleConfig(sc)
+	if len(fieldErrors) > 0 {
+		cmd.SilenceUsage = true
+		for field, msg := range fieldErrors {
+			fmt.Fprintf(os.Stderr, "  %s: %s\n", field, msg)
+		}
+		return fmt.Errorf("invalid schedule config")
+	}
+
+	store := resolveScheduleConfigStore()
+	if err := store.Save(sc); err != nil {
+		return fmt.Errorf("saving schedule config: %w", err)
+	}
+
+	p := NewPrinter(cmd.OutOrStdout())
+	p.Success("Updated %s = %s", key, value)
+	p.Muted("Saved to %s", store.Path())
+	p.Muted("The daemon will pick up changes within ~5 seconds.")
+	return nil
+}
+
+func parseBool(s string) bool {
+	return s == "true" || s == "1" || s == "yes"
+}

--- a/internal/cli/score.go
+++ b/internal/cli/score.go
@@ -1,17 +1,58 @@
 package cli
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+
 	"github.com/spf13/cobra"
+
+	"github.com/surfbot-io/surfbot-agent/internal/scoring"
 )
+
+type scoreOutput struct {
+	Score     int                 `json:"score"`
+	Breakdown []scoring.Component `json:"breakdown"`
+}
 
 var scoreCmd = &cobra.Command{
 	Use:   "score [target]",
 	Short: "Show security score",
 	Args:  cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
 		p := NewPrinter(cmd.OutOrStdout())
-		p.EmptyState("No score yet.", "Run a scan first: 'surfbot scan <domain>'.")
+
+		sevCounts, err := store.CountFindingsBySeverity(ctx)
+		if err != nil {
+			return fmt.Errorf("counting findings: %w", err)
+		}
+
+		score, breakdown := scoring.ComputeSecurityScore(sevCounts)
+
+		if jsonOut {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(scoreOutput{Score: score, Breakdown: breakdown})
+		}
+
+		p.ScoreBar(score)
+		if len(breakdown) > 0 {
+			fmt.Fprintln(p.W)
+			for _, c := range breakdown {
+				p.Bullet("%d %s finding%s (−%d each = −%d)",
+					c.Count, c.Severity, plural(c.Count), c.Weight, c.Penalty)
+			}
+		}
+		return nil
 	},
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
 }
 
 func init() {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -12,28 +13,62 @@ import (
 	"github.com/surfbot-io/surfbot-agent/internal/storage"
 )
 
+type statusJSON struct {
+	Version            string                 `json:"version"`
+	DBPath             string                 `json:"db_path"`
+	DBSizeBytes        int64                  `json:"db_size_bytes"`
+	Targets            int                    `json:"targets"`
+	Assets             int                    `json:"assets"`
+	Findings           int                    `json:"findings"`
+	FindingsBySeverity map[model.Severity]int `json:"findings_by_severity"`
+	LastScan           *model.Scan            `json:"last_scan"`
+	ToolsAvailable     int                    `json:"tools_available"`
+	ToolsTotal         int                    `json:"tools_total"`
+}
+
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show agent status: DB path, targets count, last scan, findings summary",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
-		p := NewPrinter(cmd.OutOrStdout())
-
-		p.Theme.Bold.Fprintf(p.W, "Surfbot Agent %s\n\n", Version)
 
 		dbPath := store.DBPath()
-		dbSize := "unknown"
+		var dbSizeBytes int64
 		if info, err := os.Stat(dbPath); err == nil {
-			dbSize = formatBytes(info.Size())
+			dbSizeBytes = info.Size()
 		}
-		p.Keyf("Database   ", "%s (%s)", dbPath, dbSize)
 
 		targets, _ := store.CountTargets(ctx)
 		assets, _ := store.CountAssets(ctx)
+		findings, _ := store.CountFindings(ctx)
+		sevCounts, _ := store.CountFindingsBySeverity(ctx)
+		last, _ := store.LastScan(ctx)
+		allTools := registry.Tools()
+		availTools := registry.AvailableTools()
+
+		if jsonOut {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(statusJSON{
+				Version:            Version,
+				DBPath:             dbPath,
+				DBSizeBytes:        dbSizeBytes,
+				Targets:            targets,
+				Assets:             assets,
+				Findings:           findings,
+				FindingsBySeverity: sevCounts,
+				LastScan:           last,
+				ToolsAvailable:     len(availTools),
+				ToolsTotal:         len(allTools),
+			})
+		}
+
+		p := NewPrinter(cmd.OutOrStdout())
+		p.Theme.Bold.Fprintf(p.W, "Surfbot Agent %s\n\n", Version)
+		p.Keyf("Database   ", "%s (%s)", dbPath, formatBytes(dbSizeBytes))
 		p.Keyf("Targets    ", "%d", targets)
 		p.Keyf("Assets     ", "%d", assets)
 
-		findings, _ := store.CountFindings(ctx)
 		fmt.Fprintf(p.W, "Findings   : %d", findings)
 		if findings > 0 {
 			allFindings, _ := store.ListFindings(ctx, storage.FindingListOptions{Limit: findings})
@@ -44,7 +79,6 @@ var statusCmd = &cobra.Command{
 		}
 		fmt.Fprintln(p.W)
 
-		last, _ := store.LastScan(ctx)
 		if last == nil {
 			p.EmptyState("No scans recorded.",
 				"Start a scan with 'surfbot scan <domain>'.")
@@ -58,8 +92,6 @@ var statusCmd = &cobra.Command{
 			p.Keyf("Last scan  ", "%s — %s ago (%s)", targetName, formatDurationShort(ago), last.Status)
 		}
 
-		allTools := registry.Tools()
-		availTools := registry.AvailableTools()
 		p.Keyf("Tools      ", "%d/%d available", len(availTools), len(allTools))
 
 		return nil

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -39,12 +39,12 @@ var targetAddCmd = &cobra.Command{
 		err := store.CreateTarget(ctx, t)
 		if err != nil {
 			if errors.Is(err, storage.ErrAlreadyExists) {
-				p.Warn("Target already exists: %s", args[0])
-				return nil
+				cmd.SilenceUsage = true
+				return fmt.Errorf("target already exists: %s", args[0])
 			}
 			if errors.Is(err, storage.ErrInvalidTarget) {
-				p.Errorf("%s", err)
-				return nil
+				cmd.SilenceUsage = true
+				return err
 			}
 			return err
 		}

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/surfbot-io/surfbot-agent/internal/config"
 	"github.com/surfbot-io/surfbot-agent/internal/daemon"
+	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
 	"github.com/surfbot-io/surfbot-agent/internal/webui"
 )
 
@@ -39,9 +40,10 @@ func buildUIDaemonView() *webui.DaemonView {
 	mode := daemon.DefaultMode()
 	paths := daemon.Resolve(daemon.Default(mode))
 	view := &webui.DaemonView{
-		DaemonStatePath:   paths.StateFile(),
-		ScheduleStatePath: scheduleStatePath(paths),
-		Heartbeat:         30 * time.Second,
+		DaemonStatePath:     paths.StateFile(),
+		ScheduleStatePath:   scheduleStatePath(paths),
+		Heartbeat:           30 * time.Second,
+		ScheduleConfigStore: intervalsched.NewScheduleConfigStore(scheduleConfigPath(paths)),
 	}
 	cfg, err := config.Load(cfgFile)
 	if err != nil {
@@ -58,7 +60,45 @@ func buildUIDaemonView() *webui.DaemonView {
 	if w, werr := buildWindow(mw); werr == nil {
 		view.Window = w
 	}
+
+	// If schedule.config.json exists, use its values instead.
+	if view.ScheduleConfigStore.Exists() {
+		sc, serr := view.ScheduleConfigStore.Load()
+		if serr == nil {
+			view.SchedulerEnabled = sc.Enabled
+			view.WindowStart = sc.MaintenanceWindow.Start
+			view.WindowEnd = sc.MaintenanceWindow.End
+			view.WindowTimezone = sc.MaintenanceWindow.Timezone
+			if w, werr := buildWindowFromConfig(sc.MaintenanceWindow); werr == nil {
+				view.Window = w
+			}
+		}
+	}
 	return view
+}
+
+func buildWindowFromConfig(mw intervalsched.ScheduleConfigWindow) (intervalsched.MaintenanceWindow, error) {
+	w := intervalsched.MaintenanceWindow{Enabled: mw.Enabled}
+	if !mw.Enabled {
+		return w, nil
+	}
+	start, err := intervalsched.ParseTimeOfDay(mw.Start)
+	if err != nil {
+		return w, err
+	}
+	end, err := intervalsched.ParseTimeOfDay(mw.End)
+	if err != nil {
+		return w, err
+	}
+	loc := time.Local
+	if mw.Timezone != "" {
+		loc, err = time.LoadLocation(mw.Timezone)
+		if err != nil {
+			return w, err
+		}
+	}
+	w.Start, w.End, w.Loc = start, end, loc
+	return w, nil
 }
 
 func runUI(cmd *cobra.Command, args []string) error {

--- a/internal/daemon/intervalsched/config_watcher.go
+++ b/internal/daemon/intervalsched/config_watcher.go
@@ -1,0 +1,126 @@
+package intervalsched
+
+import (
+	"context"
+	"os"
+	"time"
+)
+
+// ConfigWatchInterval controls how often the scheduler checks for
+// schedule.config.json changes. Overridable in tests.
+var ConfigWatchInterval = 5 * time.Second
+
+// WatchConfig starts a background goroutine that polls the config store
+// for changes and reloads the scheduler when detected. Exits when ctx
+// is canceled.
+func (s *IntervalScheduler) WatchConfig(ctx context.Context, store *ScheduleConfigStore) {
+	if store == nil {
+		return
+	}
+	var lastMtime time.Time
+	if info, err := os.Stat(store.Path()); err == nil {
+		lastMtime = info.ModTime()
+	}
+
+	t := time.NewTicker(ConfigWatchInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			info, err := os.Stat(store.Path())
+			if err != nil {
+				continue
+			}
+			if !info.ModTime().After(lastMtime) {
+				continue
+			}
+			lastMtime = info.ModTime()
+
+			sc, err := store.Load()
+			if err != nil {
+				s.logger.Warn("config_watcher.load_failed", "err", err)
+				continue
+			}
+			cfg, errs := ParseScheduleConfig(sc)
+			if len(errs) > 0 {
+				s.logger.Warn("config_watcher.parse_failed", "errors", errs)
+				continue
+			}
+			// Preserve TriggerDir from current config — it's not user-settable.
+			s.mu.Lock()
+			cfg.TriggerDir = s.cfg.TriggerDir
+			s.mu.Unlock()
+
+			s.Reload(cfg)
+		}
+	}
+}
+
+// ParseScheduleConfig converts a ScheduleConfig (JSON strings) into an
+// intervalsched.Config and validates it. Returns per-field errors on
+// failure.
+func ParseScheduleConfig(sc ScheduleConfig) (Config, map[string]string) {
+	errs := make(map[string]string)
+	var cfg Config
+
+	full, err := time.ParseDuration(sc.FullScanInterval)
+	if err != nil {
+		errs["full_scan_interval"] = "invalid duration: " + sc.FullScanInterval
+	} else {
+		cfg.FullInterval = full
+	}
+
+	quick, err := time.ParseDuration(sc.QuickCheckInterval)
+	if err != nil {
+		errs["quick_check_interval"] = "invalid duration: " + sc.QuickCheckInterval
+	} else {
+		cfg.QuickInterval = quick
+	}
+
+	jitter, err := time.ParseDuration(sc.Jitter)
+	if err != nil {
+		errs["jitter"] = "invalid duration: " + sc.Jitter
+	} else {
+		cfg.Jitter = jitter
+	}
+
+	if len(errs) > 0 {
+		return cfg, errs
+	}
+
+	cfg.QuickTools = sc.QuickCheckTools
+	cfg.RunOnStart = sc.RunOnStart
+
+	mw := MaintenanceWindow{Enabled: sc.MaintenanceWindow.Enabled}
+	if mw.Enabled {
+		start, serr := ParseTimeOfDay(sc.MaintenanceWindow.Start)
+		if serr != nil {
+			errs["maintenance_window.start"] = serr.Error()
+			return cfg, errs
+		}
+		end, eerr := ParseTimeOfDay(sc.MaintenanceWindow.End)
+		if eerr != nil {
+			errs["maintenance_window.end"] = eerr.Error()
+			return cfg, errs
+		}
+		loc := time.Local
+		if sc.MaintenanceWindow.Timezone != "" {
+			loc, err = time.LoadLocation(sc.MaintenanceWindow.Timezone)
+			if err != nil {
+				errs["maintenance_window.timezone"] = err.Error()
+				return cfg, errs
+			}
+		}
+		mw.Start, mw.End, mw.Loc = start, end, loc
+	}
+	cfg.Window = mw
+
+	if _, verr := cfg.Validate(); verr != nil {
+		errs["_"] = verr.Error()
+		return cfg, errs
+	}
+
+	return cfg, nil
+}

--- a/internal/daemon/intervalsched/schedule_config.go
+++ b/internal/daemon/intervalsched/schedule_config.go
@@ -1,0 +1,91 @@
+package intervalsched
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+)
+
+// ScheduleConfig is the JSON-friendly representation of the scheduler
+// configuration persisted to schedule.config.json. It uses string
+// durations ("24h") for human readability and survives daemon restarts.
+type ScheduleConfig struct {
+	Enabled            bool                `json:"enabled"`
+	FullScanInterval   string              `json:"full_scan_interval"`
+	QuickCheckInterval string              `json:"quick_check_interval"`
+	Jitter             string              `json:"jitter"`
+	RunOnStart         bool                `json:"run_on_start"`
+	QuickCheckTools    []string            `json:"quick_check_tools"`
+	MaintenanceWindow  ScheduleConfigWindow `json:"maintenance_window"`
+}
+
+// ScheduleConfigWindow is the JSON-friendly maintenance window config.
+type ScheduleConfigWindow struct {
+	Enabled  bool   `json:"enabled"`
+	Start    string `json:"start"`    // "HH:MM"
+	End      string `json:"end"`      // "HH:MM"
+	Timezone string `json:"timezone"` // IANA timezone
+}
+
+// ScheduleConfigStore reads/writes ScheduleConfig atomically using the
+// same tmp + rename pattern as ScheduleStateStore.
+type ScheduleConfigStore struct {
+	path string
+	mu   sync.Mutex
+}
+
+// NewScheduleConfigStore creates a store for schedule.config.json at the
+// given path.
+func NewScheduleConfigStore(path string) *ScheduleConfigStore {
+	return &ScheduleConfigStore{path: path}
+}
+
+// Path returns the config file path.
+func (s *ScheduleConfigStore) Path() string { return s.path }
+
+// Exists reports whether the config file exists.
+func (s *ScheduleConfigStore) Exists() bool {
+	_, err := os.Stat(s.path)
+	return err == nil
+}
+
+// Load reads and parses the schedule config file. Returns
+// os.ErrNotExist (unwrapped) when the file does not exist so callers
+// can fall back to config.yaml defaults.
+func (s *ScheduleConfigStore) Load() (ScheduleConfig, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var sc ScheduleConfig
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return sc, os.ErrNotExist
+		}
+		return sc, fmt.Errorf("reading schedule config: %w", err)
+	}
+	if err := json.Unmarshal(data, &sc); err != nil {
+		return sc, fmt.Errorf("parsing schedule config: %w", err)
+	}
+	return sc, nil
+}
+
+// Save persists the schedule config atomically.
+func (s *ScheduleConfigStore) Save(sc ScheduleConfig) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, err := json.MarshalIndent(sc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling schedule config: %w", err)
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("writing temp schedule config: %w", err)
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("renaming schedule config: %w", err)
+	}
+	return nil
+}

--- a/internal/daemon/intervalsched/scheduler.go
+++ b/internal/daemon/intervalsched/scheduler.go
@@ -83,26 +83,29 @@ type ScanRunner interface {
 // scans on independent cadences, persists cursors across restarts, and
 // honors a maintenance window.
 type IntervalScheduler struct {
-	cfg     Config
-	clock   Clock
-	store   *ScheduleStateStore
-	scanner ScanRunner
-	logger  *slog.Logger
-	onTick  func(ScanResult)
-	rng     *rand.Rand
+	cfg         Config
+	clock       Clock
+	store       *ScheduleStateStore
+	configStore *ScheduleConfigStore
+	scanner     ScanRunner
+	logger      *slog.Logger
+	onTick      func(ScanResult)
+	rng         *rand.Rand
 
-	mu    sync.Mutex
-	state ScheduleState
+	mu       sync.Mutex
+	state    ScheduleState
+	reloadCh chan Config // signals Run loop to pick up new config
 }
 
 // Options bundles non-config dependencies for New.
 type Options struct {
-	Clock      Clock
-	StateStore *ScheduleStateStore
-	Scanner    ScanRunner
-	Logger     *slog.Logger
-	OnTick     func(ScanResult)
-	RandSeed   int64 // 0 → time.Now().UnixNano()
+	Clock       Clock
+	StateStore  *ScheduleStateStore
+	ConfigStore *ScheduleConfigStore // optional: enables config file watching
+	Scanner     ScanRunner
+	Logger      *slog.Logger
+	OnTick      func(ScanResult)
+	RandSeed    int64 // 0 → time.Now().UnixNano()
 }
 
 // New constructs an IntervalScheduler. Validate the Config before calling
@@ -119,14 +122,37 @@ func New(cfg Config, opts Options) *IntervalScheduler {
 		seed = time.Now().UnixNano()
 	}
 	return &IntervalScheduler{
-		cfg:     cfg,
-		clock:   opts.Clock,
-		store:   opts.StateStore,
-		scanner: opts.Scanner,
-		logger:  opts.Logger,
-		onTick:  opts.OnTick,
-		rng:     rand.New(rand.NewSource(seed)),
+		cfg:         cfg,
+		clock:       opts.Clock,
+		store:       opts.StateStore,
+		configStore: opts.ConfigStore,
+		scanner:     opts.Scanner,
+		logger:      opts.Logger,
+		onTick:      opts.OnTick,
+		rng:         rand.New(rand.NewSource(seed)),
+		reloadCh:    make(chan Config, 1),
 	}
+}
+
+// Reload applies a new Config to the running scheduler. The Run loop
+// picks it up on the next iteration and recalculates next scan times
+// using the existing cursors (last_full_at, last_quick_at).
+func (s *IntervalScheduler) Reload(cfg Config) {
+	// Non-blocking send — drop if the channel is full (a prior reload
+	// is already queued).
+	select {
+	case s.reloadCh <- cfg:
+		s.logger.Info("scheduler.reload_queued")
+	default:
+		s.logger.Warn("scheduler.reload_dropped", "reason", "channel_full")
+	}
+}
+
+// Config returns a snapshot of the current scheduler config.
+func (s *IntervalScheduler) Config() Config {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cfg
 }
 
 // State returns a snapshot of the current schedule cursors. Safe for
@@ -200,6 +226,11 @@ func (s *IntervalScheduler) Run(ctx context.Context) error {
 		go s.runTriggerLoop(ctx)
 	}
 
+	// Watch schedule.config.json for changes from the UI/CLI.
+	if s.configStore != nil {
+		go s.WatchConfig(ctx, s.configStore)
+	}
+
 	if s.cfg.RunOnStart {
 		now := s.clock.Now()
 		if !s.cfg.Window.Contains(now) {
@@ -248,6 +279,15 @@ func (s *IntervalScheduler) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			timer.Stop()
 			return nil
+		case newCfg := <-s.reloadCh:
+			timer.Stop()
+			s.mu.Lock()
+			s.cfg = newCfg
+			s.mu.Unlock()
+			s.logger.Info("scheduler.reloaded",
+				"full_interval", newCfg.FullInterval,
+				"quick_interval", newCfg.QuickInterval)
+			continue // re-enter loop with new config
 		case <-timer.C():
 		}
 

--- a/internal/daemon/runner.go
+++ b/internal/daemon/runner.go
@@ -22,6 +22,7 @@ type Runner struct {
 	logger    *Logger
 	heartbeat time.Duration
 	version   string
+	started   time.Time
 
 	mu     sync.Mutex
 	cancel context.CancelFunc
@@ -62,6 +63,7 @@ func (r *Runner) Start() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	r.cancel = cancel
 	r.done = make(chan struct{})
+	r.started = time.Now().UTC()
 
 	if err := r.writeState(); err != nil && r.logger != nil {
 		r.logger.Slog().Warn("initial state write failed", "err", err)
@@ -132,9 +134,7 @@ func (r *Runner) writeState() error {
 		s.PID = os.Getpid()
 		now := time.Now().UTC()
 		s.WrittenAt = now
-		if s.StartedAt.IsZero() {
-			s.StartedAt = now
-		}
+		s.StartedAt = r.started
 		if r.sched != nil {
 			s.NextScanAt = r.sched.Next()
 		}

--- a/internal/daemon/runner_test.go
+++ b/internal/daemon/runner_test.go
@@ -59,6 +59,43 @@ func TestRunner_ShutdownTimeout(t *testing.T) {
 	require.ErrorIs(t, err, ErrShutdownTimeout)
 }
 
+func TestRunner_StartedAtFreshOnRestart(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	stateStore := NewStateStore(statePath)
+
+	// Seed an old state file with a stale StartedAt.
+	oldStart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, stateStore.Save(State{
+		Version:   "old",
+		PID:       99999,
+		StartedAt: oldStart,
+		WrittenAt: oldStart,
+	}))
+
+	logger := NewLogger(filepath.Join(dir, "test.log"), LoggerOptions{MaxSizeMB: 1})
+	t.Cleanup(func() { _ = logger.Close() })
+
+	r := NewRunner(RunnerConfig{
+		Scheduler: NewNoopScheduler(),
+		State:     stateStore,
+		Logger:    logger,
+		Heartbeat: 50 * time.Millisecond,
+		Version:   "new",
+	})
+
+	before := time.Now().UTC()
+	require.NoError(t, r.Start())
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, r.Stop(2*time.Second))
+
+	st, err := stateStore.Load()
+	require.NoError(t, err)
+	require.Equal(t, "new", st.Version)
+	require.True(t, st.StartedAt.After(oldStart), "StartedAt should be newer than old state")
+	require.True(t, !st.StartedAt.Before(before), "StartedAt should be at or after runner start")
+}
+
 func TestRunner_DoubleStart(t *testing.T) {
 	r := newTestRunner(t, NewNoopScheduler())
 	require.NoError(t, r.Start())

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -326,6 +326,7 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 	finishedAt := time.Now().UTC()
 	scan.FinishedAt = &finishedAt
 	p.store.UpdateScan(ctx, scan) //nolint:errcheck
+	p.store.UpdateTargetLastScan(ctx, scan.TargetID, scan.ID, finishedAt) //nolint:errcheck
 
 	result.Stats = scan.Stats
 	result.Duration = finishedAt.Sub(*scan.StartedAt)

--- a/internal/scoring/score.go
+++ b/internal/scoring/score.go
@@ -1,0 +1,50 @@
+package scoring
+
+import (
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// Component describes the penalty applied for one severity level.
+type Component struct {
+	Severity string `json:"severity"`
+	Count    int    `json:"count"`
+	Weight   int    `json:"weight"`
+	Penalty  int    `json:"penalty"`
+}
+
+// ComputeSecurityScore returns a 0–100 score and per-severity breakdown.
+// The score starts at 100 and is reduced by count×weight for each severity.
+func ComputeSecurityScore(sevCounts map[model.Severity]int) (int, []Component) {
+	weights := []struct {
+		sev    model.Severity
+		weight int
+	}{
+		{model.SeverityCritical, 25},
+		{model.SeverityHigh, 10},
+		{model.SeverityMedium, 3},
+		{model.SeverityLow, 1},
+	}
+
+	var breakdown []Component
+	score := 100
+	for _, w := range weights {
+		count := sevCounts[w.sev]
+		penalty := count * w.weight
+		score -= penalty
+		if count > 0 {
+			breakdown = append(breakdown, Component{
+				Severity: string(w.sev),
+				Count:    count,
+				Weight:   w.weight,
+				Penalty:  penalty,
+			})
+		}
+	}
+	if score < 0 {
+		score = 0
+	}
+	if score > 100 {
+		score = 100
+	}
+	return score, breakdown
+}

--- a/internal/scoring/score_test.go
+++ b/internal/scoring/score_test.go
@@ -1,0 +1,57 @@
+package scoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+func TestComputeSecurityScore(t *testing.T) {
+	tests := []struct {
+		name      string
+		counts    map[model.Severity]int
+		wantScore int
+		wantLen   int
+	}{
+		{
+			name:      "no findings gives 100",
+			counts:    map[model.Severity]int{},
+			wantScore: 100,
+			wantLen:   0,
+		},
+		{
+			name:      "one critical deducts 25",
+			counts:    map[model.Severity]int{model.SeverityCritical: 1},
+			wantScore: 75,
+			wantLen:   1,
+		},
+		{
+			name:      "mixed severities",
+			counts:    map[model.Severity]int{model.SeverityCritical: 1, model.SeverityHigh: 2, model.SeverityLow: 5},
+			wantScore: 50,
+			wantLen:   3,
+		},
+		{
+			name:      "clamp at zero",
+			counts:    map[model.Severity]int{model.SeverityCritical: 10},
+			wantScore: 0,
+			wantLen:   1,
+		},
+		{
+			name:      "info findings have no penalty",
+			counts:    map[model.Severity]int{model.SeverityInfo: 100},
+			wantScore: 100,
+			wantLen:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score, breakdown := ComputeSecurityScore(tt.counts)
+			assert.Equal(t, tt.wantScore, score)
+			assert.Len(t, breakdown, tt.wantLen)
+		})
+	}
+}

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -133,6 +133,35 @@ func TestTargetDuplicate(t *testing.T) {
 	assert.ErrorIs(t, err, ErrAlreadyExists)
 }
 
+func TestUpdateTargetLastScan(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	target := &model.Target{Value: "example.com"}
+	require.NoError(t, s.CreateTarget(ctx, target))
+
+	// Initially last_scan_at should be zero
+	got, err := s.GetTarget(ctx, target.ID)
+	require.NoError(t, err)
+	assert.True(t, got.LastScanAt == nil || got.LastScanAt.IsZero())
+
+	// Update last scan
+	scanID := "scan-123"
+	now := time.Now().UTC().Truncate(time.Second)
+	err = s.UpdateTargetLastScan(ctx, target.ID, scanID, now)
+	require.NoError(t, err)
+
+	got, err = s.GetTarget(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, scanID, got.LastScanID)
+	assert.NotNil(t, got.LastScanAt)
+	assert.Equal(t, now, got.LastScanAt.Truncate(time.Second))
+
+	// Non-existent target returns ErrNotFound
+	err = s.UpdateTargetLastScan(ctx, "nonexistent", scanID, now)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
 func TestScanCRUD(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -48,6 +48,8 @@ type FindingListOptions struct {
 	AssetID    string
 	ScanID     string
 	TargetID   string
+	TemplateID string
+	Host       string
 	Severity   model.Severity
 	Status     model.FindingStatus
 	SourceTool string
@@ -601,6 +603,14 @@ func (s *SQLiteStore) ListFindings(ctx context.Context, opts FindingListOptions)
 		where = append(where, "source_tool = ?")
 		args = append(args, opts.SourceTool)
 	}
+	if opts.TemplateID != "" {
+		where = append(where, "template_id = ?")
+		args = append(args, opts.TemplateID)
+	}
+	if opts.Host != "" {
+		where = append(where, "asset_id IN (SELECT id FROM assets WHERE value LIKE ? OR value LIKE ?)")
+		args = append(args, opts.Host, opts.Host+":%")
+	}
 
 	if len(where) > 0 {
 		query += " WHERE " + strings.Join(where, " AND ")
@@ -959,6 +969,14 @@ func (s *SQLiteStore) CountFindingsFiltered(ctx context.Context, opts FindingLis
 	if opts.SourceTool != "" {
 		where = append(where, "source_tool = ?")
 		args = append(args, opts.SourceTool)
+	}
+	if opts.TemplateID != "" {
+		where = append(where, "template_id = ?")
+		args = append(args, opts.TemplateID)
+	}
+	if opts.Host != "" {
+		where = append(where, "asset_id IN (SELECT id FROM assets WHERE value LIKE ? OR value LIKE ?)")
+		args = append(args, opts.Host, opts.Host+":%")
 	}
 	if len(where) > 0 {
 		query += " WHERE " + strings.Join(where, " AND ")

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -62,6 +62,7 @@ type Store interface {
 	GetTargetByValue(ctx context.Context, value string) (*model.Target, error)
 	ListTargets(ctx context.Context) ([]model.Target, error)
 	DeleteTarget(ctx context.Context, id string) error
+	UpdateTargetLastScan(ctx context.Context, targetID, scanID string, at time.Time) error
 
 	CreateScan(ctx context.Context, s *model.Scan) error
 	GetScan(ctx context.Context, id string) (*model.Scan, error)
@@ -251,6 +252,20 @@ func (s *SQLiteStore) ListTargets(ctx context.Context) ([]model.Target, error) {
 		targets = append(targets, *t)
 	}
 	return targets, rows.Err()
+}
+
+func (s *SQLiteStore) UpdateTargetLastScan(ctx context.Context, targetID, scanID string, at time.Time) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE targets SET last_scan_id = ?, last_scan_at = ?, updated_at = ? WHERE id = ?`,
+		scanID, at.Format(timeFormat), time.Now().UTC().Format(timeFormat), targetID)
+	if err != nil {
+		return fmt.Errorf("updating target last scan: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 func (s *SQLiteStore) DeleteTarget(ctx context.Context, id string) error {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -141,6 +141,11 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 		return nil, fmt.Errorf("pinging database: %w", err)
 	}
 
+	// Restrict DB file permissions — it may contain sensitive scan data.
+	if dbPath != ":memory:" {
+		_ = os.Chmod(dbPath, 0o600)
+	}
+
 	s := &SQLiteStore{db: db, dbPath: dbPath}
 	if err := s.runMigrations(); err != nil {
 		db.Close()

--- a/internal/webui/daemon_status.go
+++ b/internal/webui/daemon_status.go
@@ -293,7 +293,12 @@ func buildSchedulerBlock(d *DaemonView, now time.Time) *schedulerStatusBlock {
 
 func buildWindowBlock(d *DaemonView, now time.Time) *windowBlock {
 	if !d.Window.Enabled {
-		return &windowBlock{Enabled: false}
+		return &windowBlock{
+			Enabled:  false,
+			Start:    d.WindowStart,
+			End:      d.WindowEnd,
+			Timezone: d.WindowTimezone,
+		}
 	}
 	wb := &windowBlock{
 		Enabled:  true,

--- a/internal/webui/daemon_status.go
+++ b/internal/webui/daemon_status.go
@@ -50,6 +50,13 @@ type DaemonView struct {
 	WindowEnd      string
 	WindowTimezone string
 
+	// Scheduler is the live scheduler instance. When non-nil, the
+	// schedule API can read its config and reload it on updates.
+	Scheduler *intervalsched.IntervalScheduler
+	// ScheduleConfigStore persists schedule.config.json. When non-nil,
+	// the schedule API can read/write persisted schedule config.
+	ScheduleConfigStore *intervalsched.ScheduleConfigStore
+
 	// triggerMu serializes write access to the trigger flag file.
 	triggerMu sync.Mutex
 }

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -262,6 +262,12 @@ func (h *handler) handleFindings(w http.ResponseWriter, r *http.Request) {
 		}
 		opts.ScanID = scanID
 	}
+	if tmpl := r.URL.Query().Get("template_id"); tmpl != "" {
+		opts.TemplateID = tmpl
+	}
+	if host := r.URL.Query().Get("host"); host != "" {
+		opts.Host = host
+	}
 
 	findings, err := h.store.ListFindings(r.Context(), opts)
 	if err != nil {

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/surfbot-io/surfbot-agent/internal/detection"
 	"github.com/surfbot-io/surfbot-agent/internal/model"
 	"github.com/surfbot-io/surfbot-agent/internal/pipeline"
+	"github.com/surfbot-io/surfbot-agent/internal/scoring"
 	"github.com/surfbot-io/surfbot-agent/internal/storage"
 )
 
@@ -68,7 +69,7 @@ func queryInt(r *http.Request, key string, def int) int {
 
 type overviewResponse struct {
 	SecurityScore      int                     `json:"security_score"`
-	ScoreBreakdown     []scoreComponent        `json:"score_breakdown"`
+	ScoreBreakdown     []scoring.Component     `json:"score_breakdown"`
 	TotalFindings      int                     `json:"total_findings"`
 	UniqueFindings     int                     `json:"unique_findings"`
 	FindingsBySeverity map[model.Severity]int  `json:"findings_by_severity"`
@@ -79,12 +80,6 @@ type overviewResponse struct {
 	Agent              agentInfo               `json:"agent"`
 }
 
-type scoreComponent struct {
-	Severity string `json:"severity"`
-	Count    int    `json:"count"`
-	Weight   int    `json:"weight"`
-	Penalty  int    `json:"penalty"`
-}
 
 type scanSummary struct {
 	ID              string     `json:"id"`
@@ -156,7 +151,7 @@ func (h *handler) handleOverview(w http.ResponseWriter, r *http.Request) {
 		typeCounts = make(map[model.AssetType]int)
 	}
 
-	score, breakdown := computeSecurityScore(sevCounts)
+	score, breakdown := scoring.ComputeSecurityScore(sevCounts)
 
 	resp := overviewResponse{
 		SecurityScore:      score,
@@ -221,41 +216,6 @@ func (h *handler) getChangeSummary(ctx context.Context, scanID string) *changeSu
 		}
 	}
 	return cs
-}
-
-func computeSecurityScore(sevCounts map[model.Severity]int) (int, []scoreComponent) {
-	weights := []struct {
-		sev    model.Severity
-		weight int
-	}{
-		{model.SeverityCritical, 25},
-		{model.SeverityHigh, 10},
-		{model.SeverityMedium, 3},
-		{model.SeverityLow, 1},
-	}
-
-	var breakdown []scoreComponent
-	score := 100
-	for _, w := range weights {
-		count := sevCounts[w.sev]
-		penalty := count * w.weight
-		score -= penalty
-		if count > 0 {
-			breakdown = append(breakdown, scoreComponent{
-				Severity: string(w.sev),
-				Count:    count,
-				Weight:   w.weight,
-				Penalty:  penalty,
-			})
-		}
-	}
-	if score < 0 {
-		score = 0
-	}
-	if score > 100 {
-		score = 100
-	}
-	return score, breakdown
 }
 
 // --- Findings ---

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -792,8 +792,11 @@ func (h *handler) handleUpdateFindingStatus(w http.ResponseWriter, r *http.Reque
 // --- Scan Trigger ---
 
 type createScanRequest struct {
-	TargetID string `json:"target_id"`
-	Type     string `json:"type,omitempty"` // full, quick, discovery
+	TargetID  string   `json:"target_id"`
+	Type      string   `json:"type,omitempty"`       // full, quick, discovery
+	Tools     []string `json:"tools,omitempty"`      // specific tools to run (empty = all)
+	RateLimit int      `json:"rate_limit,omitempty"` // global rate limit in req/s (0 = per-tool defaults)
+	Timeout   int      `json:"timeout,omitempty"`    // per-phase timeout in seconds (0 = default)
 }
 
 func (h *handler) handleCreateScan(w http.ResponseWriter, r *http.Request) {
@@ -833,6 +836,26 @@ func (h *handler) handleCreateScan(w http.ResponseWriter, r *http.Request) {
 		scanType = model.ScanTypeDiscovery
 	}
 
+	// Validate tools against registry.
+	if len(req.Tools) > 0 {
+		for _, name := range req.Tools {
+			if _, ok := h.registry.GetByName(name); !ok {
+				writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown tool: %s", name))
+				return
+			}
+		}
+	}
+
+	// Validate rate_limit and timeout.
+	if req.RateLimit < 0 {
+		writeError(w, http.StatusBadRequest, "rate_limit must be >= 0")
+		return
+	}
+	if req.Timeout < 0 {
+		writeError(w, http.StatusBadRequest, "timeout must be >= 0")
+		return
+	}
+
 	// Prevent concurrent scans
 	h.scanMu.Lock()
 	if h.runningScan != "" {
@@ -844,7 +867,10 @@ func (h *handler) handleCreateScan(w http.ResponseWriter, r *http.Request) {
 	// Create pipeline and run async
 	pipe := pipeline.New(h.store, h.registry)
 	opts := pipeline.PipelineOptions{
-		ScanType: scanType,
+		ScanType:  scanType,
+		Tools:     req.Tools,
+		RateLimit: req.RateLimit,
+		Timeout:   req.Timeout,
 	}
 
 	// Create a placeholder scan ID by peeking at the pipeline
@@ -868,12 +894,22 @@ func (h *handler) handleCreateScan(w http.ResponseWriter, r *http.Request) {
 			target.Value, result.TotalFindings, result.TotalAssets, result.Duration)
 	}()
 
-	writeJSON(w, http.StatusAccepted, map[string]any{
+	resp := map[string]any{
 		"status":  "started",
 		"target":  target.Value,
 		"type":    string(scanType),
 		"message": "scan started in background",
-	})
+	}
+	if len(req.Tools) > 0 {
+		resp["tools"] = req.Tools
+	}
+	if req.RateLimit > 0 {
+		resp["rate_limit"] = req.RateLimit
+	}
+	if req.Timeout > 0 {
+		resp["timeout"] = req.Timeout
+	}
+	writeJSON(w, http.StatusAccepted, resp)
 }
 
 // --- Scan Status ---

--- a/internal/webui/handlers_schedule.go
+++ b/internal/webui/handlers_schedule.go
@@ -1,0 +1,161 @@
+package webui
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
+)
+
+// handleSchedule routes GET and PUT on /api/v1/schedule.
+func (h *handler) handleSchedule(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.handleGetSchedule(w, r)
+	case http.MethodPut:
+		h.handlePutSchedule(w, r)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+// handleGetSchedule returns the current schedule configuration. It reads
+// from the live scheduler when available, falling back to the persisted
+// schedule.config.json, then to the DaemonView defaults.
+func (h *handler) handleGetSchedule(w http.ResponseWriter, _ *http.Request) {
+	if h.daemon == nil {
+		writeError(w, http.StatusServiceUnavailable, "daemon not configured")
+		return
+	}
+
+	// Try persisted config first (authoritative after first PUT).
+	if h.daemon.ScheduleConfigStore != nil {
+		sc, err := h.daemon.ScheduleConfigStore.Load()
+		if err == nil {
+			writeJSON(w, http.StatusOK, sc)
+			return
+		}
+	}
+
+	// Fall back to live scheduler config or DaemonView defaults.
+	sc := h.buildScheduleConfigFromView()
+	writeJSON(w, http.StatusOK, sc)
+}
+
+// handlePutSchedule validates and persists the new schedule config, then
+// hot-reloads the running scheduler.
+func (h *handler) handlePutSchedule(w http.ResponseWriter, r *http.Request) {
+	if h.daemon == nil {
+		writeError(w, http.StatusServiceUnavailable, "daemon not configured")
+		return
+	}
+	if h.daemon.ScheduleConfigStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "schedule config store not available")
+		return
+	}
+
+	var req intervalsched.ScheduleConfig
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	// Validate by parsing into an intervalsched.Config.
+	icfg, fieldErrors := intervalsched.ParseScheduleConfig(req)
+	if len(fieldErrors) > 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"errors": fieldErrors})
+		return
+	}
+
+	// Validate tools against registry.
+	if h.registry != nil && len(req.QuickCheckTools) > 0 {
+		for _, name := range req.QuickCheckTools {
+			if _, ok := h.registry.GetByName(name); !ok {
+				writeJSON(w, http.StatusBadRequest, map[string]any{
+					"errors": map[string]string{
+						"quick_check_tools": fmt.Sprintf("unknown tool: %s", name),
+					},
+				})
+				return
+			}
+		}
+	}
+
+	// Persist to schedule.config.json (atomic write, 0600).
+	if err := h.daemon.ScheduleConfigStore.Save(req); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to save schedule config")
+		return
+	}
+
+	// Update the DaemonView so GET requests reflect the change immediately.
+	h.daemon.SchedulerEnabled = req.Enabled
+	h.daemon.WindowStart = req.MaintenanceWindow.Start
+	h.daemon.WindowEnd = req.MaintenanceWindow.End
+	h.daemon.WindowTimezone = req.MaintenanceWindow.Timezone
+	if w2, err := buildWindowFromStrings(req.MaintenanceWindow); err == nil {
+		h.daemon.Window = w2
+	}
+
+	// Hot-reload the live scheduler if available.
+	if h.daemon.Scheduler != nil {
+		h.daemon.Scheduler.Reload(icfg)
+	}
+
+	writeJSON(w, http.StatusOK, req)
+}
+
+// buildScheduleConfigFromView constructs a ScheduleConfig from the
+// DaemonView fields (populated from config.yaml at startup).
+func (h *handler) buildScheduleConfigFromView() intervalsched.ScheduleConfig {
+	sc := intervalsched.ScheduleConfig{
+		Enabled:            h.daemon.SchedulerEnabled,
+		FullScanInterval:   "24h",
+		QuickCheckInterval: "1h",
+		Jitter:             "5m",
+		MaintenanceWindow: intervalsched.ScheduleConfigWindow{
+			Enabled:  h.daemon.Window.Enabled,
+			Start:    h.daemon.WindowStart,
+			End:      h.daemon.WindowEnd,
+			Timezone: h.daemon.WindowTimezone,
+		},
+	}
+
+	// If we have a live scheduler, read actual config from it.
+	if h.daemon.Scheduler != nil {
+		cfg := h.daemon.Scheduler.Config()
+		sc.Enabled = true // scheduler exists means enabled
+		sc.FullScanInterval = cfg.FullInterval.String()
+		sc.QuickCheckInterval = cfg.QuickInterval.String()
+		sc.Jitter = cfg.Jitter.String()
+		sc.RunOnStart = cfg.RunOnStart
+		sc.QuickCheckTools = cfg.QuickTools
+	}
+	return sc
+}
+
+// buildWindowFromStrings parses the JSON window config into an
+// intervalsched.MaintenanceWindow.
+func buildWindowFromStrings(w intervalsched.ScheduleConfigWindow) (intervalsched.MaintenanceWindow, error) {
+	mw := intervalsched.MaintenanceWindow{Enabled: w.Enabled}
+	if !w.Enabled {
+		return mw, nil
+	}
+	start, err := intervalsched.ParseTimeOfDay(w.Start)
+	if err != nil {
+		return mw, fmt.Errorf("invalid start time: %w", err)
+	}
+	end, err := intervalsched.ParseTimeOfDay(w.End)
+	if err != nil {
+		return mw, fmt.Errorf("invalid end time: %w", err)
+	}
+	loc := time.Local
+	if w.Timezone != "" {
+		loc, err = time.LoadLocation(w.Timezone)
+		if err != nil {
+			return mw, fmt.Errorf("invalid timezone: %w", err)
+		}
+	}
+	mw.Start, mw.End, mw.Loc = start, end, loc
+	return mw, nil
+}

--- a/internal/webui/security.go
+++ b/internal/webui/security.go
@@ -63,7 +63,7 @@ func allowedOrigins(port int) []string {
 // Cache-Control: no-store is added for /api/* so JSON snapshots are never
 // cached by intermediaries (or by the browser tab).
 func securityHeaders(next http.Handler) http.Handler {
-	const csp = "default-src 'self'; script-src 'self'; style-src 'self'; " +
+	const csp = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self'; " +
 		"img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; " +
 		"base-uri 'none'; form-action 'none'"
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -82,6 +82,9 @@ func NewServer(store *storage.SQLiteStore, opts ServerOptions) (*http.Server, ne
 	})
 	mux.HandleFunc("/api/v1/targets/", h.handleDeleteTarget)
 
+	// Schedule: GET config, PUT config
+	mux.HandleFunc("/api/v1/schedule", h.handleSchedule)
+
 	// Scans: GET list, GET detail, POST trigger
 	mux.HandleFunc("/api/v1/scans", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -713,6 +713,21 @@ tr.clickable { cursor: pointer; }
 
 .add-form { margin-bottom: 20px; }
 
+/* Settings forms */
+.settings-form { max-width: 640px; }
+.form-section { margin-bottom: 24px; padding-bottom: 16px; border-bottom: 1px solid var(--border); }
+.form-section h3 { font-size: 15px; margin: 0 0 12px; color: var(--text-primary); }
+.form-row { display: flex; flex-direction: column; gap: 4px; margin-bottom: 12px; }
+.form-row label:not(.checkbox-label) { font-size: 12px; color: var(--text-secondary); font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+.form-input-sm { max-width: 200px; flex: unset; }
+.form-hint { font-size: 11px; color: var(--text-muted); }
+.checkbox-label { display: flex; align-items: center; gap: 6px; font-size: 13px; color: var(--text-primary); cursor: pointer; }
+.checkbox-label input[type="checkbox"] { accent-color: var(--accent); }
+.checkbox-group { display: flex; flex-wrap: wrap; gap: 8px 16px; }
+.form-actions { display: flex; align-items: center; gap: 12px; margin-top: 16px; }
+.form-status { font-size: 13px; }
+.form-status-ok { color: var(--success); }
+
 /* === Status Select === */
 .status-select {
   background: var(--bg-primary);

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -648,6 +648,13 @@ tr.clickable { cursor: pointer; }
 .btn-primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
 .btn-primary:disabled { background: var(--accent); opacity: 0.5; }
 
+.btn-secondary {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-color: var(--border);
+}
+.btn-secondary:hover { background: var(--bg-secondary); border-color: var(--text-muted); }
+
 .btn-accent {
   background: rgba(0,229,153,0.1);
   color: var(--accent);
@@ -768,6 +775,14 @@ tr.clickable { cursor: pointer; }
 }
 
 /* === Scan Progress Banner === */
+.scan-advanced {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 16px 20px;
+  margin-top: 12px;
+}
+
 .scan-banner {
   background: var(--bg-secondary);
   border: 1px solid rgba(0,229,153,0.3);

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -39,6 +39,10 @@
           <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm0-2a6 6 0 100-12 6 6 0 000 12zm0-2a4 4 0 100-8 4 4 0 000 8zm0-2a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/></svg>
           <span class="nav-label">Targets</span>
         </a></li>
+        <li><a href="#/tools" class="nav-link" data-page="tools">
+          <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.062 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/></svg>
+          <span class="nav-label">Tools</span>
+        </a></li>
       </ul>
       <div class="sidebar-footer">
         <span class="agent-version" id="agent-version"></span>
@@ -57,6 +61,7 @@
   <script src="/js/pages/assets.js"></script>
   <script src="/js/pages/scans.js"></script>
   <script src="/js/pages/targets.js"></script>
+  <script src="/js/pages/tools.js"></script>
   <script src="/js/app.js"></script>
 </body>
 </html>

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -43,6 +43,10 @@
           <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.062 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/></svg>
           <span class="nav-label">Tools</span>
         </a></li>
+        <li><a href="#/settings/schedule" class="nav-link" data-page="settings">
+          <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"/></svg>
+          <span class="nav-label">Schedule</span>
+        </a></li>
       </ul>
       <div class="sidebar-footer">
         <span class="agent-version" id="agent-version"></span>
@@ -62,6 +66,7 @@
   <script src="/js/pages/scans.js"></script>
   <script src="/js/pages/targets.js"></script>
   <script src="/js/pages/tools.js"></script>
+  <script src="/js/pages/settings_schedule.js"></script>
   <script src="/js/app.js"></script>
 </body>
 </html>

--- a/internal/webui/static/js/api.js
+++ b/internal/webui/static/js/api.js
@@ -85,8 +85,14 @@ const API = {
   updateFindingStatus(id, status) {
     return this.patch('/findings/' + id + '/status', { status });
   },
-  startScan(targetId, type) {
-    return this.post('/scans', { target_id: targetId, type: type || 'full' });
+  startScan(targetId, type, opts) {
+    const body = { target_id: targetId, type: type || 'full' };
+    if (opts) {
+      if (opts.tools && opts.tools.length > 0) body.tools = opts.tools;
+      if (opts.rate_limit > 0) body.rate_limit = opts.rate_limit;
+      if (opts.timeout > 0) body.timeout = opts.timeout;
+    }
+    return this.post('/scans', body);
   },
 
   // SPEC-X3.1 — daemon endpoints live outside /api/v1/.

--- a/internal/webui/static/js/api.js
+++ b/internal/webui/static/js/api.js
@@ -43,6 +43,17 @@ const API = {
     return data;
   },
 
+  async put(path, body) {
+    const resp = await fetch('/api/v1' + path, {
+      method: 'PUT',
+      headers: this._headers({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(body),
+    });
+    const data = await resp.json().catch(() => ({ error: resp.statusText }));
+    if (!resp.ok) throw new Error(data.error || data.errors ? JSON.stringify(data.errors) : 'Request failed');
+    return data;
+  },
+
   async del(path) {
     const resp = await fetch('/api/v1' + path, { method: 'DELETE', headers: this._headers() });
     const data = await resp.json().catch(() => ({ error: resp.statusText }));
@@ -63,6 +74,8 @@ const API = {
   tools()               { return this.get('/tools'); },
   availableTools()      { return this.get('/tools/available'); },
   scanStatus()          { return this.get('/scans/status'); },
+  schedule()            { return this.get('/schedule'); },
+  updateSchedule(cfg)   { return this.put('/schedule', cfg); },
 
   // Write endpoints
   createTarget(value, type, scope) {

--- a/internal/webui/static/js/app.js
+++ b/internal/webui/static/js/app.js
@@ -8,6 +8,7 @@ const Router = {
     { pattern: /^#\/scans\/(.+)$/, page: 'scans', render: (m) => ScansPage.render(app, { id: m[1] }) },
     { pattern: /^#\/scans/, page: 'scans', render: () => ScansPage.render(app, parseQueryParams()) },
     { pattern: /^#\/targets/, page: 'targets', render: () => TargetsPage.render(app) },
+    { pattern: /^#\/tools/, page: 'tools', render: () => ToolsPage.render(app) },
   ],
 
   navigate() {

--- a/internal/webui/static/js/app.js
+++ b/internal/webui/static/js/app.js
@@ -9,6 +9,7 @@ const Router = {
     { pattern: /^#\/scans/, page: 'scans', render: () => ScansPage.render(app, parseQueryParams()) },
     { pattern: /^#\/targets/, page: 'targets', render: () => TargetsPage.render(app) },
     { pattern: /^#\/tools/, page: 'tools', render: () => ToolsPage.render(app) },
+    { pattern: /^#\/settings\/schedule/, page: 'settings', render: () => SettingsSchedulePage.render(app) },
   ],
 
   navigate() {

--- a/internal/webui/static/js/pages/agent_card.js
+++ b/internal/webui/static/js/pages/agent_card.js
@@ -64,11 +64,12 @@ const AgentCard = {
         aria-label="Status: running"></span>`;
     const srOnly = `<span class="sr-only">Status: running.</span>`;
     const sched = d.scheduler;
+    const schedLink = `<div style="padding-top:4px"><a href="#/settings/schedule" class="text-muted" style="font-size:12px">Configure schedule →</a></div>`;
     const schedHtml = !sched
-      ? ''
+      ? schedLink
       : !sched.enabled
-        ? `<div class="text-muted" style="padding-top:8px">Scheduler disabled</div>`
-        : this.schedulerHtml(sched);
+        ? `<div class="text-muted" style="padding-top:8px">Scheduler disabled ${schedLink}</div>`
+        : this.schedulerHtml(sched) + schedLink;
 
     const uptime = this.formatUptime(d.uptime_seconds || 0);
     return `<section class="card agent-card" aria-label="Agent status" aria-live="polite">

--- a/internal/webui/static/js/pages/agent_card.js
+++ b/internal/webui/static/js/pages/agent_card.js
@@ -108,7 +108,7 @@ const AgentCard = {
     const nextQuick = s.next_quick
       ? this.timeRow('Next quick', s.next_quick, 'in ')
       : '';
-    const win = s.window && s.window.enabled ? this.windowRow(s.window) : '';
+    const win = s.window ? this.windowRow(s.window) : '';
     return `<div class="detail-grid" style="margin-top:12px;border-top:1px solid var(--border);padding-top:12px">
       ${lastFull}${lastQuick}${nextFull}${nextQuick}${win}
     </div>`;
@@ -137,6 +137,10 @@ const AgentCard = {
 
   windowRow(w) {
     const desc = `${escapeHtml(w.start || '')}–${escapeHtml(w.end || '')} ${escapeHtml(w.timezone || '')}`;
+    if (!w.enabled) {
+      return `<span class="detail-label">Window</span>
+        <span class="detail-value text-muted">disabled ${desc ? '(' + desc + ')' : ''}</span>`;
+    }
     const stateLabel = w.open_now
       ? `<span style="color:var(--sev-medium)">open</span>`
       : `closed`;

--- a/internal/webui/static/js/pages/assets.js
+++ b/internal/webui/static/js/pages/assets.js
@@ -25,19 +25,20 @@ const AssetsPage = {
       `;
     }
 
+    const typ = params?.type || '';
     const viewToggle = `<div class="filters">
-      <select class="filter-select" onchange="location.hash='#/assets?view='+this.value">
+      <select class="filter-select" id="filter-view" onchange="AssetsPage.applyFilters()">
         <option value="tree" ${view === 'tree' ? 'selected' : ''}>Tree View</option>
         <option value="list" ${view === 'list' ? 'selected' : ''}>List View</option>
       </select>
-      <select class="filter-select" onchange="location.hash='#/assets?view=${view}&type='+this.value">
+      <select class="filter-select" id="filter-type" onchange="AssetsPage.applyFilters()">
         <option value="">All types</option>
-        <option value="subdomain">Subdomain</option>
-        <option value="ipv4">IPv4</option>
-        <option value="ipv6">IPv6</option>
-        <option value="port_service">Port/Service</option>
-        <option value="url">URL</option>
-        <option value="technology">Technology</option>
+        <option value="subdomain" ${typ === 'subdomain' ? 'selected' : ''}>Subdomain</option>
+        <option value="ipv4" ${typ === 'ipv4' ? 'selected' : ''}>IPv4</option>
+        <option value="ipv6" ${typ === 'ipv6' ? 'selected' : ''}>IPv6</option>
+        <option value="port_service" ${typ === 'port_service' ? 'selected' : ''}>Port/Service</option>
+        <option value="url" ${typ === 'url' ? 'selected' : ''}>URL</option>
+        <option value="technology" ${typ === 'technology' ? 'selected' : ''}>Technology</option>
       </select>
     </div>`;
 
@@ -71,5 +72,13 @@ const AssetsPage = {
       ${viewToggle}
       ${contentHtml}
     `;
+  },
+
+  applyFilters() {
+    const view = document.getElementById('filter-view')?.value || 'tree';
+    const type = document.getElementById('filter-type')?.value || '';
+    const q = ['view=' + view];
+    if (type) q.push('type=' + type);
+    location.hash = '#/assets?' + q.join('&');
   },
 };

--- a/internal/webui/static/js/pages/findings.js
+++ b/internal/webui/static/js/pages/findings.js
@@ -47,7 +47,7 @@ const FindingsPage = {
       const drillHref = '#/findings?view=raw&host=' + encodeURIComponent(g.host)
         + '&template_id=' + encodeURIComponent(g.template_id);
       return `
-        <tr>
+        <tr class="clickable" onclick="location.hash='${drillHref}'">
           <td>${Components.severityBadge(g.severity)}</td>
           <td class="text-truncate">${escapeHtml(g.title)} ${badge}</td>
           <td class="mono">${escapeHtml(g.host)}</td>
@@ -100,6 +100,8 @@ const FindingsPage = {
         status: params?.status,
         target_id: params?.target_id,
         scan_id: params?.scan_id,
+        host: params?.host,
+        template_id: params?.template_id,
         page: params?.page || 1,
         limit: 50,
       });
@@ -122,6 +124,7 @@ const FindingsPage = {
       <tr>
         <td>${Components.severityBadge(f.severity)}</td>
         <td class="text-truncate clickable" onclick="location.hash='#/findings/${f.id}'">${escapeHtml(f.title)}</td>
+        <td class="mono text-truncate">${escapeHtml(f.evidence || '')}</td>
         <td class="mono">${escapeHtml(f.source_tool)}</td>
         <td>
           <select class="status-select status-${f.status}" onchange="FindingsPage.changeStatus('${f.id}', this.value, this)" data-original="${f.status}">
@@ -146,7 +149,7 @@ const FindingsPage = {
       </div>
       ${this.viewToggle('raw')}
       ${this.rawFiltersHtml(params)}
-      ${Components.table(['Severity', 'Title', 'Tool', 'Status', 'Last Seen'], [rows])}
+      ${Components.table(['Severity', 'Title', 'Asset', 'Tool', 'Status', 'Last Seen'], [rows])}
       ${totalPages > 1 ? this.paginationHtml(page, totalPages, params) : ''}
     `;
   },
@@ -190,7 +193,12 @@ const FindingsPage = {
     // Reset page when switching views
     const q = ['view=' + view];
     if (params.severity) q.push('severity=' + params.severity);
-    location.hash = '#/findings?' + q.join('&');
+    const newHash = '#/findings?' + q.join('&');
+    if (location.hash === newHash) {
+      Router.navigate();
+    } else {
+      location.hash = newHash;
+    }
   },
 
   // --- Shared helpers ---

--- a/internal/webui/static/js/pages/scans.js
+++ b/internal/webui/static/js/pages/scans.js
@@ -45,7 +45,30 @@ const ScansPage = {
           <button type="submit" class="btn btn-primary" ${scanRunning ? 'disabled' : ''}>
             ${scanRunning ? 'Scan running...' : 'Start Scan'}
           </button>
+          <button type="button" id="toggle-scan-opts" class="btn btn-secondary" style="margin-left:4px"
+            title="Advanced options">⚙</button>
         </form>
+        <div id="scan-advanced" class="scan-advanced" style="display:none">
+          <div class="form-section" style="margin-top:8px">
+            <h4 style="margin:0 0 8px">Advanced Options</h4>
+            <div class="form-row">
+              <label for="scan-rate-limit">Rate limit (req/s)</label>
+              <input type="number" id="scan-rate-limit" class="form-input form-input-sm"
+                     min="0" value="0" placeholder="0 = per-tool default">
+            </div>
+            <div class="form-row">
+              <label for="scan-timeout">Per-phase timeout (seconds)</label>
+              <input type="number" id="scan-timeout" class="form-input form-input-sm"
+                     min="0" value="0" placeholder="0 = default (300s)">
+            </div>
+            <div class="form-row">
+              <label>Tools</label>
+              <div id="scan-tools-group" class="checkbox-group">
+                <span class="text-muted">Loading tools...</span>
+              </div>
+            </div>
+          </div>
+        </div>
         <div id="scan-error" class="form-error" style="display:none"></div>
       </div>
     ` : '';
@@ -104,6 +127,20 @@ const ScansPage = {
     const form = document.getElementById('new-scan-form');
     if (!form) return;
 
+    // Advanced options toggle.
+    const toggleBtn = document.getElementById('toggle-scan-opts');
+    const advPanel = document.getElementById('scan-advanced');
+    if (toggleBtn && advPanel) {
+      toggleBtn.addEventListener('click', () => {
+        const hidden = advPanel.style.display === 'none';
+        advPanel.style.display = hidden ? '' : 'none';
+        if (hidden) this.loadToolCheckboxes();
+      });
+    }
+
+    // Restore saved options from localStorage.
+    this.restoreScanOpts();
+
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
       const targetId = document.getElementById('scan-target').value;
@@ -115,8 +152,11 @@ const ScansPage = {
       btn.textContent = 'Starting...';
       errorEl.style.display = 'none';
 
+      const opts = this.collectScanOpts();
+      this.saveScanOpts(opts);
+
       try {
-        await API.startScan(targetId, scanType);
+        await API.startScan(targetId, scanType, opts);
         ScansPage.render(app);
       } catch (err) {
         errorEl.textContent = err.message;
@@ -125,6 +165,62 @@ const ScansPage = {
         btn.textContent = 'Start Scan';
       }
     });
+  },
+
+  async loadToolCheckboxes() {
+    const group = document.getElementById('scan-tools-group');
+    if (!group || group.dataset.loaded) return;
+    try {
+      const data = await API.availableTools();
+      const tools = data.tools || [];
+      const saved = this.getSavedTools();
+      group.innerHTML = tools.map(t => {
+        const checked = saved.includes(t.name) ? 'checked' : '';
+        return `<label class="checkbox-label">
+          <input type="checkbox" name="scan_tool" value="${escapeHtml(t.name)}" ${checked}>
+          ${escapeHtml(t.name)} <span class="text-muted">(${escapeHtml(t.phase)})</span>
+        </label>`;
+      }).join('');
+      group.dataset.loaded = '1';
+    } catch {
+      group.innerHTML = '<span class="text-muted">Failed to load tools</span>';
+    }
+  },
+
+  collectScanOpts() {
+    const rl = document.getElementById('scan-rate-limit');
+    const to = document.getElementById('scan-timeout');
+    const tools = Array.from(document.querySelectorAll('input[name="scan_tool"]:checked'))
+      .map(cb => cb.value);
+    return {
+      tools: tools,
+      rate_limit: rl ? parseInt(rl.value, 10) || 0 : 0,
+      timeout: to ? parseInt(to.value, 10) || 0 : 0,
+    };
+  },
+
+  saveScanOpts(opts) {
+    try { localStorage.setItem('surfbot_scan_opts', JSON.stringify(opts)); } catch {}
+  },
+
+  restoreScanOpts() {
+    try {
+      const raw = localStorage.getItem('surfbot_scan_opts');
+      if (!raw) return;
+      const opts = JSON.parse(raw);
+      const rl = document.getElementById('scan-rate-limit');
+      const to = document.getElementById('scan-timeout');
+      if (rl && opts.rate_limit) rl.value = opts.rate_limit;
+      if (to && opts.timeout) to.value = opts.timeout;
+    } catch {}
+  },
+
+  getSavedTools() {
+    try {
+      const raw = localStorage.getItem('surfbot_scan_opts');
+      if (!raw) return [];
+      return JSON.parse(raw).tools || [];
+    } catch { return []; }
   },
 
   startPolling(app) {

--- a/internal/webui/static/js/pages/settings_schedule.js
+++ b/internal/webui/static/js/pages/settings_schedule.js
@@ -1,0 +1,180 @@
+// Settings > Schedule page — configure scan schedule, intervals, tools, window.
+const SettingsSchedulePage = {
+  async render(app) {
+    app.innerHTML = '<div class="loading">Loading schedule config...</div>';
+    try {
+      const [schedule, toolsData] = await Promise.all([
+        API.schedule(),
+        API.availableTools(),
+      ]);
+      app.innerHTML = this.template(schedule, toolsData.tools || []);
+      this.bindEvents(app, toolsData.tools || []);
+    } catch (err) {
+      app.innerHTML = Components.emptyState('Error', 'Failed to load schedule config: ' + err.message);
+    }
+  },
+
+  template(cfg, availableTools) {
+    const quickTools = cfg.quick_check_tools || [];
+    const mw = cfg.maintenance_window || {};
+
+    const toolCheckboxes = availableTools.map(t => {
+      const checked = quickTools.includes(t.name) ? 'checked' : '';
+      return `<label class="checkbox-label">
+        <input type="checkbox" name="quick_tool" value="${escapeHtml(t.name)}" ${checked}>
+        ${escapeHtml(t.name)} <span class="text-muted">(${escapeHtml(t.phase)})</span>
+      </label>`;
+    }).join('');
+
+    return `
+      <div class="page-header">
+        <h2>Schedule Settings</h2>
+        <p>Configure automated scan intervals, tools, and maintenance windows.</p>
+      </div>
+
+      <form id="schedule-form" class="settings-form">
+        <div class="form-section">
+          <h3>Scheduler</h3>
+          <div class="form-row">
+            <label class="checkbox-label">
+              <input type="checkbox" id="sched-enabled" ${cfg.enabled ? 'checked' : ''}>
+              Enable scheduled scans
+            </label>
+          </div>
+        </div>
+
+        <div class="form-section">
+          <h3>Intervals</h3>
+          <div class="form-row">
+            <label for="full-interval">Full scan interval</label>
+            <input type="text" id="full-interval" class="form-input form-input-sm"
+                   value="${escapeHtml(cfg.full_scan_interval || '24h')}"
+                   placeholder="24h">
+            <span class="form-hint">Duration: e.g. 24h, 12h, 30m</span>
+          </div>
+          <div class="form-row">
+            <label for="quick-interval">Quick check interval</label>
+            <input type="text" id="quick-interval" class="form-input form-input-sm"
+                   value="${escapeHtml(cfg.quick_check_interval || '1h')}"
+                   placeholder="1h">
+            <span class="form-hint">Must be less than full scan interval</span>
+          </div>
+          <div class="form-row">
+            <label for="jitter">Jitter</label>
+            <input type="text" id="jitter" class="form-input form-input-sm"
+                   value="${escapeHtml(cfg.jitter || '5m')}"
+                   placeholder="5m">
+            <span class="form-hint">Random delay added to prevent thundering herd</span>
+          </div>
+          <div class="form-row">
+            <label class="checkbox-label">
+              <input type="checkbox" id="run-on-start" ${cfg.run_on_start ? 'checked' : ''}>
+              Run scan on daemon start
+            </label>
+          </div>
+        </div>
+
+        <div class="form-section">
+          <h3>Quick Check Tools</h3>
+          <p class="text-muted">Select which tools run during quick checks.</p>
+          <div class="checkbox-group" id="quick-tools-group">
+            ${toolCheckboxes || '<span class="text-muted">No tools registered</span>'}
+          </div>
+        </div>
+
+        <div class="form-section">
+          <h3>Maintenance Window</h3>
+          <div class="form-row">
+            <label class="checkbox-label">
+              <input type="checkbox" id="window-enabled" ${mw.enabled ? 'checked' : ''}>
+              Enable maintenance window (block scans during this period)
+            </label>
+          </div>
+          <div id="window-fields" style="${mw.enabled ? '' : 'display:none'}">
+            <div class="form-row">
+              <label for="window-start">Start time</label>
+              <input type="time" id="window-start" class="form-input form-input-sm"
+                     value="${escapeHtml(mw.start || '02:00')}">
+            </div>
+            <div class="form-row">
+              <label for="window-end">End time</label>
+              <input type="time" id="window-end" class="form-input form-input-sm"
+                     value="${escapeHtml(mw.end || '04:00')}">
+            </div>
+            <div class="form-row">
+              <label for="window-tz">Timezone</label>
+              <input type="text" id="window-tz" class="form-input form-input-sm"
+                     value="${escapeHtml(mw.timezone || 'UTC')}"
+                     placeholder="Europe/Madrid">
+              <span class="form-hint">IANA timezone (e.g. UTC, Europe/Madrid, America/New_York)</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="form-actions">
+          <button type="submit" class="btn btn-primary" id="save-btn">Save Schedule</button>
+          <span id="save-status" class="form-status" style="display:none"></span>
+        </div>
+        <div id="save-errors" class="form-error" style="display:none"></div>
+      </form>
+    `;
+  },
+
+  bindEvents(app) {
+    const form = document.getElementById('schedule-form');
+    const windowEnabled = document.getElementById('window-enabled');
+    const windowFields = document.getElementById('window-fields');
+
+    // Toggle maintenance window fields visibility.
+    windowEnabled.addEventListener('change', () => {
+      windowFields.style.display = windowEnabled.checked ? '' : 'none';
+    });
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const btn = document.getElementById('save-btn');
+      const statusEl = document.getElementById('save-status');
+      const errEl = document.getElementById('save-errors');
+
+      btn.disabled = true;
+      btn.textContent = 'Saving...';
+      statusEl.style.display = 'none';
+      errEl.style.display = 'none';
+
+      const quickTools = Array.from(document.querySelectorAll('input[name="quick_tool"]:checked'))
+        .map(cb => cb.value);
+
+      // Convert time input "HH:MM" to the expected format
+      const startVal = document.getElementById('window-start').value || '02:00';
+      const endVal = document.getElementById('window-end').value || '04:00';
+
+      const payload = {
+        enabled: document.getElementById('sched-enabled').checked,
+        full_scan_interval: document.getElementById('full-interval').value.trim(),
+        quick_check_interval: document.getElementById('quick-interval').value.trim(),
+        jitter: document.getElementById('jitter').value.trim(),
+        run_on_start: document.getElementById('run-on-start').checked,
+        quick_check_tools: quickTools,
+        maintenance_window: {
+          enabled: windowEnabled.checked,
+          start: startVal,
+          end: endVal,
+          timezone: document.getElementById('window-tz').value.trim() || 'UTC',
+        },
+      };
+
+      try {
+        await API.updateSchedule(payload);
+        statusEl.textContent = 'Schedule updated successfully.';
+        statusEl.className = 'form-status form-status-ok';
+        statusEl.style.display = 'inline';
+      } catch (err) {
+        errEl.textContent = err.message;
+        errEl.style.display = 'block';
+      } finally {
+        btn.disabled = false;
+        btn.textContent = 'Save Schedule';
+      }
+    });
+  },
+};

--- a/internal/webui/static/js/pages/tools.js
+++ b/internal/webui/static/js/pages/tools.js
@@ -1,0 +1,44 @@
+// Tools page — shows registered detection tools and their availability.
+const ToolsPage = {
+  async render(app) {
+    app.innerHTML = '<div class="loading">Loading tools...</div>';
+    try {
+      const data = await API.availableTools();
+      app.innerHTML = this.template(data);
+    } catch (err) {
+      app.innerHTML = Components.emptyState('Error', 'Failed to load tools: ' + err.message);
+    }
+  },
+
+  template(data) {
+    const tools = data.tools || [];
+
+    if (tools.length === 0) {
+      return `
+        <div class="page-header"><h2>Tools</h2></div>
+        ${Components.emptyState('No tools registered', 'No detection tools are registered in the pipeline.')}
+      `;
+    }
+
+    const rows = tools.map(t => {
+      const badge = t.available
+        ? '<span class="badge badge-success">available</span>'
+        : '<span class="badge badge-muted">unavailable</span>';
+      return `
+        <tr>
+          <td class="mono">${escapeHtml(t.name)}</td>
+          <td>${escapeHtml(t.phase)}</td>
+          <td>${badge}</td>
+        </tr>
+      `;
+    }).join('');
+
+    return `
+      <div class="page-header">
+        <h2>Tools</h2>
+        <p>${data.available}/${data.total} available</p>
+      </div>
+      ${Components.table(['Name', 'Phase', 'Status'], [rows])}
+    `;
+  },
+};


### PR DESCRIPTION
## Summary

- The CSP `script-src 'self'` was blocking all inline event handlers (`onchange`, `onclick`, etc.), making filter dropdowns non-functional on both findings and assets pages. Added `'unsafe-inline'` to `script-src` — acceptable since the UI is localhost-only with token auth and input escaping.
- Fixed assets page dropdowns: both view and type selects now use a shared `AssetsPage.applyFilters()` method (matching the findings page pattern), properly preserve each other's params when one changes, and the type dropdown restores its selected state from URL params on re-render.

## Test plan

- [ ] `go test ./internal/webui/... -race` passes
- [ ] Open `/#/findings`, change severity dropdown → only filtered findings shown
- [ ] Open `/#/assets`, change type dropdown → only filtered assets shown; change view → type preserved
- [ ] Verify CSP header includes `script-src 'self' 'unsafe-inline'`