### PR TITLE
redesign scan detail view with pipeline visualization

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -164,7 +164,30 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 				phaseTimeout = 5 * time.Minute
 			}
 		}
-		phaseCtx, cancel := context.WithTimeout(ctx, phaseTimeout)
+		phaseCtx, phaseCancel := context.WithTimeout(ctx, phaseTimeout)
+
+		// Poll DB for external cancellation while the tool runs.
+		// When detected, phaseCancel() kills the tool subprocess.
+		cancelDone := make(chan struct{})
+		go func() {
+			defer close(cancelDone)
+			ticker := time.NewTicker(2 * time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-phaseCtx.Done():
+					return
+				case <-ticker.C:
+					if fresh, err := p.store.GetScan(context.Background(), scan.ID); err == nil {
+						if fresh.Status == model.ScanStatusCancelled {
+							pp.warn("Scan cancelled externally — killing %s", tool.Name())
+							phaseCancel()
+							return
+						}
+					}
+				}
+			}
+		}()
 
 		runOpts := detection.RunOptions{
 			RateLimit: opts.RateLimit,
@@ -181,7 +204,22 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 		startTime := time.Now()
 		toolResult, toolErr := tool.Run(phaseCtx, inputs, runOpts)
 		duration := time.Since(startTime)
-		cancel()
+		phaseCancel()
+		<-cancelDone // wait for poll goroutine to exit
+
+		// If the tool was killed by external cancellation, stop immediately
+		if toolErr != nil {
+			if fresh, fErr := p.store.GetScan(context.Background(), scan.ID); fErr == nil && fresh.Status == model.ScanStatusCancelled {
+				p.recordToolRun(ctx, tool, scan.ID, startTime, duration, len(inputs), 0, model.ToolRunFailed, "cancelled")
+				scan.Status = model.ScanStatusCancelled
+				scan.Phase = "cancelled"
+				nowt := time.Now().UTC()
+				scan.FinishedAt = &nowt
+				p.store.UpdateScan(context.Background(), scan) //nolint:errcheck
+				pp.warn("Scan cancelled — %s terminated", tool.Name())
+				return nil, fmt.Errorf("scan cancelled")
+			}
+		}
 
 		pr := PhaseResult{
 			ToolName:   tool.Name(),

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -124,6 +124,19 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 		default:
 		}
 
+		// Check for external cancellation (e.g., API DELETE from another process)
+		if fresh, err := p.store.GetScan(ctx, scan.ID); err == nil {
+			if fresh.Status == model.ScanStatusCancelled {
+				scan.Status = model.ScanStatusCancelled
+				scan.Phase = "cancelled"
+				nowt := time.Now().UTC()
+				scan.FinishedAt = &nowt
+				p.store.UpdateScan(context.Background(), scan) //nolint:errcheck
+				pp.warn("Scan cancelled externally")
+				return nil, fmt.Errorf("scan cancelled")
+			}
+		}
+
 		if shouldSkip(tool, opts) {
 			pr := PhaseResult{
 				ToolName: tool.Name(),

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -983,7 +983,18 @@ func (h *handler) handleCancelScan(w http.ResponseWriter, r *http.Request) {
 	h.scanMu.Unlock()
 
 	if cancel != nil {
+		// Scan started by this process — cancel via context
 		cancel()
+	} else {
+		// Scan started externally (daemon/CLI) — mark as cancelled in DB.
+		// The pipeline checks scan status at each tool boundary.
+		scan.Status = model.ScanStatusCancelled
+		scan.Phase = "cancelled"
+		now := time.Now().UTC()
+		scan.FinishedAt = &now
+		if err := h.store.UpdateScan(r.Context(), scan); err != nil {
+			log.Printf("[webui] cancel scan DB update error: %v", err)
+		}
 	}
 
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -28,9 +28,10 @@ type handler struct {
 	registry *detection.Registry
 	daemon   *DaemonView // optional: SPEC-X3.1 agent card data source
 
-	// scanMu protects runningScan to prevent concurrent scans.
+	// scanMu protects runningScan and cancelFunc to prevent concurrent scans.
 	scanMu      sync.Mutex
-	runningScan string // scan ID of the currently running scan, empty if idle
+	runningScan string             // scan ID of the currently running scan, empty if idle
+	cancelFunc  context.CancelFunc // cancel function for the running scan
 }
 
 // --- JSON helpers ---
@@ -873,17 +874,17 @@ func (h *handler) handleCreateScan(w http.ResponseWriter, r *http.Request) {
 		Timeout:   req.Timeout,
 	}
 
-	// Create a placeholder scan ID by peeking at the pipeline
-	// We start the pipeline in a goroutine and return immediately
+	scanCtx, scanCancel := context.WithCancel(context.Background())
 	h.runningScan = "starting"
+	h.cancelFunc = scanCancel
 	h.scanMu.Unlock()
 
 	go func() {
-		ctx := context.Background()
-		result, err := pipe.Run(ctx, target.ID, opts)
+		result, err := pipe.Run(scanCtx, target.ID, opts)
 
 		h.scanMu.Lock()
 		h.runningScan = ""
+		h.cancelFunc = nil
 		h.scanMu.Unlock()
 
 		if err != nil {
@@ -950,6 +951,42 @@ func (h *handler) handleScanStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// --- Cancel Scan ---
+
+func (h *handler) handleCancelScan(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	id := strings.TrimPrefix(r.URL.Path, "/api/v1/scans/")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing scan id")
+		return
+	}
+
+	scan, err := h.store.GetScan(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "scan not found")
+		return
+	}
+
+	if scan.Status != model.ScanStatusRunning {
+		writeError(w, http.StatusBadRequest, "scan is not running")
+		return
+	}
+
+	h.scanMu.Lock()
+	cancel := h.cancelFunc
+	h.scanMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }
 
 // --- Available Tools ---

--- a/internal/webui/handlers_test.go
+++ b/internal/webui/handlers_test.go
@@ -803,3 +803,68 @@ func TestHandleAvailableTools(t *testing.T) {
 	tools := resp["tools"].([]interface{})
 	assert.Equal(t, 0, len(tools))
 }
+
+// --- Cancel Scan Tests ---
+
+func TestHandleCancelScanNotRunning(t *testing.T) {
+	h, s := newTestHandler(t)
+	seedTestData(t, s) // seeds a completed scan
+
+	scans, _ := s.ListScans(context.Background(), "", 1)
+	require.NotEmpty(t, scans)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/scans/"+scans[0].ID, nil)
+	w := httptest.NewRecorder()
+	h.handleCancelScan(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "scan is not running", resp["error"])
+}
+
+func TestHandleCancelScanNotFound(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/scans/nonexistent-id", nil)
+	w := httptest.NewRecorder()
+	h.handleCancelScan(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleCancelScanRunning(t *testing.T) {
+	h, s := newTestHandler(t)
+	ctx := context.Background()
+
+	target := &model.Target{Value: "cancel-test.com"}
+	require.NoError(t, s.CreateTarget(ctx, target))
+
+	now := time.Now().UTC()
+	scan := &model.Scan{
+		TargetID:  target.ID,
+		Type:      model.ScanTypeFull,
+		Status:    model.ScanStatusRunning,
+		Phase:     "discovery",
+		Progress:  25,
+		StartedAt: &now,
+	}
+	require.NoError(t, s.CreateScan(ctx, scan))
+
+	// Simulate a running scan with a cancel func
+	cancelled := false
+	h.scanMu.Lock()
+	h.runningScan = scan.ID
+	h.cancelFunc = func() { cancelled = true }
+	h.scanMu.Unlock()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/scans/"+scan.ID, nil)
+	w := httptest.NewRecorder()
+	h.handleCancelScan(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]bool
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp["ok"])
+	assert.True(t, cancelled, "cancel function should have been called")
+}

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -98,7 +98,14 @@ func NewServer(store *storage.SQLiteStore, opts ServerOptions) (*http.Server, ne
 	})
 	mux.HandleFunc("/api/v1/scans/", func(w http.ResponseWriter, r *http.Request) {
 		// /api/v1/scans/status is handled above by the more specific route
-		h.handleScanDetail(w, r)
+		switch r.Method {
+		case http.MethodGet:
+			h.handleScanDetail(w, r)
+		case http.MethodDelete:
+			h.handleCancelScan(w, r)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
 	})
 
 	// Static files with SPA fallback. The SPA shell (index.html) gets the

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -938,6 +938,15 @@ tr.clickable { cursor: pointer; }
   color: var(--bg-primary);
 }
 
+.phase-circle.phase-skipped {
+  border-style: dashed;
+  border-color: var(--text-muted);
+  color: var(--text-muted);
+  opacity: 0.5;
+}
+
+.phase-step.skipped .phase-label { color: var(--text-muted); opacity: 0.5; }
+
 .phase-label {
   font-size: 10px;
   color: var(--text-muted);

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -882,3 +882,197 @@ tr.clickable { cursor: pointer; }
   white-space: nowrap;
   border: 0;
 }
+
+/* === Phase Indicator === */
+.phase-indicator {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  margin: 20px 0;
+  gap: 0;
+}
+
+.phase-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.phase-circle {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 600;
+  border: 2px solid var(--border);
+  color: var(--text-muted);
+  background: var(--bg-secondary);
+  flex-shrink: 0;
+}
+
+.phase-circle.phase-done {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #0d1117;
+}
+
+.phase-circle.phase-active {
+  border-color: var(--accent);
+  color: var(--accent);
+  animation: phase-pulse 2s ease-in-out infinite;
+}
+
+.phase-circle.phase-failed {
+  background: var(--danger);
+  border-color: var(--danger);
+  color: #fff;
+}
+
+.phase-circle.phase-cancelled {
+  background: var(--text-muted);
+  border-color: var(--text-muted);
+  color: var(--bg-primary);
+}
+
+.phase-label {
+  font-size: 10px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.phase-step.active .phase-label { color: var(--accent); font-weight: 600; }
+.phase-step.done .phase-label { color: var(--text-secondary); }
+
+.phase-line {
+  width: 40px;
+  height: 2px;
+  background: var(--border);
+  margin: 15px 4px 0;
+  flex-shrink: 0;
+}
+
+.phase-line.phase-line-done { background: var(--accent); }
+
+@keyframes phase-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(0, 229, 153, 0.4); }
+  50% { box-shadow: 0 0 0 8px rgba(0, 229, 153, 0); }
+}
+
+/* === Progress Bar === */
+.progress-bar-container { margin-bottom: 16px; }
+
+.progress-bar-header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.progress-bar-track {
+  height: 4px;
+  background: var(--bg-tertiary);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  transition: width 0.5s ease;
+}
+
+.progress-shimmer {
+  background: linear-gradient(90deg, var(--bg-tertiary) 0%, var(--accent) 50%, var(--bg-tertiary) 100%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* === Pipeline View === */
+.pipeline-view { padding: 12px 0 0; }
+
+.pipeline-node {
+  display: flex;
+  gap: 12px;
+}
+
+.pipeline-connector {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 20px;
+  flex-shrink: 0;
+}
+
+.pipeline-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--border);
+  z-index: 1;
+  flex-shrink: 0;
+}
+
+.pipeline-node.status-completed .pipeline-dot { background: var(--success); }
+.pipeline-node.status-running .pipeline-dot { background: var(--accent); animation: phase-pulse 2s ease-in-out infinite; }
+.pipeline-node.status-failed .pipeline-dot { background: var(--danger); }
+.pipeline-node.status-timeout .pipeline-dot { background: var(--sev-high); }
+.pipeline-node.status-skipped .pipeline-dot { background: var(--text-muted); }
+
+.pipeline-vline {
+  width: 2px;
+  flex: 1;
+  background: var(--border);
+  min-height: 12px;
+}
+
+.pipeline-node.status-completed .pipeline-vline { background: var(--success); }
+.pipeline-node.status-running .pipeline-vline { background: var(--accent); }
+.pipeline-node.status-failed .pipeline-vline { background: var(--danger); }
+
+.pipeline-content {
+  flex: 1;
+  padding-bottom: 16px;
+}
+
+.pipeline-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tool-icon { font-size: 14px; line-height: 1; }
+.tool-name { font-weight: 600; font-size: 13px; }
+.tool-duration { font-size: 12px; color: var(--text-secondary); margin-left: auto; }
+
+.pipeline-stats {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+  padding-left: 22px;
+}
+
+.stat-badge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+}
+
+.stat-badge-finding {
+  background: rgba(168, 85, 247, 0.15);
+  color: #a855f7;
+}

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -398,13 +398,21 @@ tr.clickable { cursor: pointer; }
   border-color: var(--accent);
 }
 
+/* === Scan Detail Stack === */
+.scan-detail-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+.scan-detail-stack .table-container { margin-bottom: 0; }
+.scan-detail-stack .detail-panel { margin-bottom: 0; }
+
 /* === Detail Panel === */
 .detail-panel {
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: 24px;
-  margin-bottom: 24px;
 }
 
 .detail-header {

--- a/internal/webui/static/js/api.js
+++ b/internal/webui/static/js/api.js
@@ -82,6 +82,7 @@ const API = {
     return this.post('/targets', { value, type: type || '', scope: scope || 'external' });
   },
   deleteTarget(id)      { return this.del('/targets/' + id); },
+  cancelScan(id)        { return this.del('/scans/' + id); },
   updateFindingStatus(id, status) {
     return this.patch('/findings/' + id + '/status', { status });
   },

--- a/internal/webui/static/js/pages/scans.js
+++ b/internal/webui/static/js/pages/scans.js
@@ -407,7 +407,7 @@ const ScansPage = {
       </div>`;
     }).join('');
 
-    return `<div class="card" style="margin-bottom:16px">
+    return `<div class="card">
       <div class="card-label">Pipeline</div>
       <div class="pipeline-view">${nodes}</div>
     </div>`;
@@ -415,7 +415,7 @@ const ScansPage = {
 
   renderFindings(findings, scanId) {
     if (!findings || findings.length === 0) {
-      return `<div class="card" style="margin-bottom:16px">
+      return `<div class="card">
         <div class="card-label">Findings</div>
         <div style="padding:12px 0;color:var(--text-muted);font-size:13px">No findings recorded for this scan.</div>
       </div>`;
@@ -431,7 +431,7 @@ const ScansPage = {
       </tr>
     `).join('');
 
-    return `<div class="card" style="margin-bottom:16px">
+    return `<div class="card">
       <div class="card-label">Findings <span class="text-muted" style="font-weight:400;text-transform:none">(${findings.length})</span></div>
       <div class="table-container" style="border:none;margin:8px 0 0">
         <table>
@@ -464,7 +464,7 @@ const ScansPage = {
     };
     const hasSev = Object.values(sevs).some(v => v > 0);
 
-    return `<div class="card" style="margin-bottom:16px">
+    return `<div class="card">
       <div class="card-label">Scan Stats</div>
       <div class="detail-grid" style="margin-top:8px">
         ${items.map(i => `<span class="detail-label">${i.label}</span><span class="detail-value">${i.value}</span>`).join('')}
@@ -508,7 +508,7 @@ const ScansPage = {
     if (s.finished_at) timestamps.push(`Finished ${Components.formatDate(s.finished_at)}`);
 
     const errorCard = s.error
-      ? `<div class="card" style="margin-bottom:16px;border-color:rgba(248,81,73,0.3)">
+      ? `<div class="card" style="border-color:rgba(248,81,73,0.3)">
           <div style="color:var(--sev-critical);font-size:13px">${escapeHtml(s.error)}</div>
         </div>`
       : '';
@@ -524,32 +524,36 @@ const ScansPage = {
 
     app.innerHTML = `
       ${Components.backLink('#/scans', 'Back to scans')}
-      <div class="detail-panel">
-        <div class="detail-header">
-          ${Components.statusBadge(s.status)}
-          <h2>Scan ${Components.truncateID(s.id)}</h2>
-          ${typeBadge}
-          <span class="text-muted mono" style="font-size:12px;margin-left:8px">${escapeHtml(data.target)}</span>
-          <span class="text-muted" style="font-size:12px;margin-left:4px">${dur}</span>
-          <div style="margin-left:auto">${cancelBtn}</div>
+      <div class="scan-detail-stack">
+        <div class="detail-panel">
+          <div class="detail-header">
+            ${Components.statusBadge(s.status)}
+            <h2>Scan ${Components.truncateID(s.id)}</h2>
+            ${typeBadge}
+            <span class="text-muted mono" style="font-size:12px;margin-left:8px">${escapeHtml(data.target)}</span>
+            <span class="text-muted" style="font-size:12px;margin-left:4px">${dur}</span>
+            <div style="margin-left:auto">${cancelBtn}</div>
+          </div>
+          ${timestamps.length > 0 ? `<div class="text-muted" style="font-size:11px;margin-top:4px">${timestamps.join(' \u00B7 ')}</div>` : ''}
+
+          ${this.renderPhaseIndicator(s, data.tool_runs)}
+          ${this.renderProgressBar(s)}
+          ${errorCard}
         </div>
-        ${timestamps.length > 0 ? `<div class="text-muted" style="font-size:11px;margin-top:4px">${timestamps.join(' \u00B7 ')}</div>` : ''}
 
-        ${this.renderPhaseIndicator(s, data.tool_runs)}
-        ${this.renderProgressBar(s)}
-        ${errorCard}
+        ${this.renderPipeline(data.tool_runs, s.id)}
+
+        ${this.renderFindings(findings, s.id)}
+
+        ${this.renderScanStats(s.stats)}
+
+        ${data.changes.length > 0 ? `
+          <div>
+            <h3 style="margin-bottom:16px">Asset Changes <span class="text-muted" style="font-size:13px;font-weight:400">(${data.changes.length})</span></h3>
+            ${Components.table(['Change', 'Type', 'Value', 'Summary'], [changeRows])}
+          </div>
+        ` : ''}
       </div>
-
-      ${this.renderPipeline(data.tool_runs, s.id)}
-
-      ${this.renderFindings(findings, s.id)}
-
-      ${this.renderScanStats(s.stats)}
-
-      ${data.changes.length > 0 ? `
-        <h3 style="margin-bottom:12px">Asset Changes <span class="text-muted" style="font-size:13px;font-weight:400">(${data.changes.length})</span></h3>
-        ${Components.table(['Change', 'Type', 'Value', 'Summary'], [changeRows])}
-      ` : ''}
     `;
 
     // Bind cancel button

--- a/internal/webui/static/js/pages/scans.js
+++ b/internal/webui/static/js/pages/scans.js
@@ -253,6 +253,248 @@ const ScansPage = {
       clearInterval(this.pollTimer);
       this.pollTimer = null;
     }
+    if (this._elapsedTimer) {
+      clearInterval(this._elapsedTimer);
+      this._elapsedTimer = null;
+    }
+  },
+
+  // --- Scan Detail View ---
+
+  PHASES: [
+    { key: 'discovery', label: 'Discovering' },
+    { key: 'resolution', label: 'DNS' },
+    { key: 'port_scan', label: 'Ports' },
+    { key: 'http_probe', label: 'HTTP' },
+    { key: 'assessment', label: 'Analyzing' },
+    { key: 'completed', label: 'Complete' },
+  ],
+
+  TOOL_ICONS: {
+    subfinder: '\u{1F50D}', dnsx: '\u{1F4CB}', naabu: '\u{1F4E1}',
+    httpx: '\u{1F310}', subjack: '\u{26A0}\uFE0F', nuclei: '\u{1F6E1}\uFE0F',
+  },
+
+  phaseIndex(phase) {
+    if (!phase) return -1;
+    const idx = this.PHASES.findIndex(p => p.key === phase);
+    if (idx >= 0) return idx;
+    // Map alternate names
+    if (phase === 'initializing') return -1;
+    if (phase === 'diffing') return 5;
+    if (phase === 'cancelled') return -1;
+    return -1;
+  },
+
+  renderPhaseIndicator(scan) {
+    const isTerminal = scan.status === 'completed' || scan.status === 'failed' || scan.status === 'cancelled';
+    const currentIdx = isTerminal && scan.status === 'completed' ? 6 : this.phaseIndex(scan.phase);
+
+    return `<div class="phase-indicator">${this.PHASES.map((p, i) => {
+      const num = i + 1;
+      let circleClass = 'phase-circle';
+      let content = num;
+      let stepClass = 'phase-step';
+
+      if (isTerminal && scan.status === 'completed') {
+        circleClass += ' phase-done';
+        content = '\u2713';
+        stepClass += ' done';
+      } else if (i < currentIdx) {
+        circleClass += ' phase-done';
+        content = '\u2713';
+        stepClass += ' done';
+      } else if (i === currentIdx) {
+        if (scan.status === 'failed') {
+          circleClass += ' phase-failed';
+          content = '\u2717';
+        } else if (scan.status === 'cancelled') {
+          circleClass += ' phase-cancelled';
+          content = '\u2013';
+        } else {
+          circleClass += ' phase-active';
+        }
+        stepClass += ' active';
+      }
+
+      const line = i < this.PHASES.length - 1
+        ? `<div class="phase-line${i < currentIdx ? ' phase-line-done' : ''}"></div>`
+        : '';
+
+      return `<div class="${stepClass}"><div class="${circleClass}">${content}</div><span class="phase-label">${p.label}</span></div>${line}`;
+    }).join('')}</div>`;
+  },
+
+  renderProgressBar(scan) {
+    if (scan.status !== 'running') return '';
+    const pct = Math.round(scan.progress || 0);
+    const phase = scan.phase || 'initializing';
+    const fillClass = pct === 0 ? 'progress-bar-fill progress-shimmer' : 'progress-bar-fill';
+
+    return `<div class="progress-bar-container">
+      <div class="progress-bar-header">
+        <span>Phase: ${phase}</span>
+        <span>${pct}%</span>
+      </div>
+      <div class="progress-bar-track">
+        <div class="${fillClass}" style="width:${pct === 0 ? 100 : pct}%"></div>
+      </div>
+    </div>`;
+  },
+
+  renderPipeline(toolRuns) {
+    if (toolRuns.length === 0) return '';
+
+    const sorted = [...toolRuns].sort((a, b) => {
+      if (a.started_at && b.started_at) return new Date(a.started_at) - new Date(b.started_at);
+      return 0;
+    });
+
+    const nodes = sorted.map((tr, i) => {
+      const icon = this.TOOL_ICONS[tr.tool_name] || '\u{1F527}';
+      const isLast = i === sorted.length - 1;
+      const statusClass = 'status-' + (tr.status || 'pending');
+
+      let duration = '';
+      if (tr.status === 'running' && tr.started_at) {
+        const elapsed = Math.round((Date.now() - new Date(tr.started_at).getTime()) / 1000);
+        duration = `<span class="tool-duration mono" data-started="${tr.started_at}">${this.formatElapsed(elapsed)}</span>`;
+      } else if (tr.duration_ms > 0) {
+        duration = `<span class="tool-duration mono">${this.formatDurationMs(tr.duration_ms)}</span>`;
+      }
+
+      const stats = [];
+      if (tr.targets_count > 0) stats.push(`<span class="stat-badge">${tr.targets_count} targets</span>`);
+      if (tr.findings_count > 0) stats.push(`<span class="stat-badge stat-badge-finding">${tr.findings_count} findings</span>`);
+
+      return `<div class="pipeline-node ${statusClass}">
+        <div class="pipeline-connector">
+          <div class="pipeline-dot"></div>
+          ${isLast ? '' : '<div class="pipeline-vline"></div>'}
+        </div>
+        <div class="pipeline-content">
+          <div class="pipeline-header">
+            <span class="tool-icon">${icon}</span>
+            <span class="tool-name">${escapeHtml(tr.tool_name)}</span>
+            ${Components.statusBadge(tr.status)}
+            ${duration}
+          </div>
+          ${stats.length > 0 ? `<div class="pipeline-stats">${stats.join('')}</div>` : ''}
+        </div>
+      </div>`;
+    }).join('');
+
+    return `<div class="card" style="margin-bottom:16px">
+      <div class="card-label">Pipeline</div>
+      <div class="pipeline-view">${nodes}</div>
+    </div>`;
+  },
+
+  formatElapsed(seconds) {
+    if (seconds < 60) return seconds + 's';
+    return Math.floor(seconds / 60) + 'm ' + (seconds % 60) + 's';
+  },
+
+  formatDurationMs(ms) {
+    if (ms < 1000) return ms + 'ms';
+    const s = ms / 1000;
+    if (s < 60) return s.toFixed(1) + 's';
+    return Math.floor(s / 60) + 'm ' + Math.round(s % 60) + 's';
+  },
+
+  renderDetailContent(app, data) {
+    const s = data.scan;
+    const isRunning = s.status === 'running';
+
+    let dur = '-';
+    if (s.started_at && s.finished_at) {
+      dur = Components.formatDuration(Math.floor((new Date(s.finished_at) - new Date(s.started_at)) / 1000));
+    } else if (isRunning && s.started_at) {
+      const elapsed = Math.round((Date.now() - new Date(s.started_at).getTime()) / 1000);
+      dur = this.formatElapsed(elapsed) + ' (running)';
+    }
+
+    const cancelBtn = isRunning
+      ? `<button class="btn btn-danger btn-sm" id="cancel-scan-btn">Cancel Scan</button>`
+      : '';
+
+    const errorCard = s.error
+      ? `<div class="card" style="margin-bottom:16px;border-color:rgba(248,81,73,0.3)">
+          <div style="color:var(--sev-critical);font-size:13px">${escapeHtml(s.error)}</div>
+        </div>`
+      : '';
+
+    const changeRows = data.changes.map(c => `
+      <tr>
+        <td><span class="change-${c.change_type}">${c.change_type}</span></td>
+        <td>${c.asset_type}</td>
+        <td class="mono">${escapeHtml(c.asset_value)}</td>
+        <td>${escapeHtml(c.summary || '-')}</td>
+      </tr>
+    `).join('');
+
+    app.innerHTML = `
+      ${Components.backLink('#/scans', 'Back to scans')}
+      <div class="detail-panel">
+        <div class="detail-header">
+          ${Components.statusBadge(s.status)}
+          <h2>Scan ${Components.truncateID(s.id)}</h2>
+          <span class="text-muted mono" style="font-size:12px">${escapeHtml(data.target)}</span>
+          <span class="text-muted" style="font-size:12px;margin-left:4px">${dur}</span>
+          <div style="margin-left:auto">${cancelBtn}</div>
+        </div>
+
+        ${this.renderPhaseIndicator(s)}
+        ${this.renderProgressBar(s)}
+        ${errorCard}
+      </div>
+
+      ${this.renderPipeline(data.tool_runs)}
+
+      <div class="card" style="margin-bottom:16px">
+        <div class="card-label">Scan Stats</div>
+        <div class="detail-grid" style="margin-top:8px">
+          <span class="detail-label">Subdomains</span><span class="detail-value">${s.stats.subdomains_found || 0}</span>
+          <span class="detail-label">IPs Resolved</span><span class="detail-value">${s.stats.ips_resolved || 0}</span>
+          <span class="detail-label">Ports Scanned</span><span class="detail-value">${s.stats.ports_scanned || 0}</span>
+          <span class="detail-label">Open Ports</span><span class="detail-value">${s.stats.open_ports || 0}</span>
+          <span class="detail-label">HTTP Probed</span><span class="detail-value">${s.stats.http_probed || 0}</span>
+          <span class="detail-label">Findings</span><span class="detail-value">${s.stats.findings_total || 0}</span>
+        </div>
+        ${Components.severityBars({
+          critical: s.stats.findings_critical || 0,
+          high: s.stats.findings_high || 0,
+          medium: s.stats.findings_medium || 0,
+          low: s.stats.findings_low || 0,
+          info: s.stats.findings_info || 0,
+        })}
+      </div>
+
+      ${data.changes.length > 0 ? `
+        <h3 style="margin-bottom:12px">Asset Changes</h3>
+        ${Components.table(['Change', 'Type', 'Value', 'Summary'], [changeRows])}
+      ` : ''}
+    `;
+
+    // Bind cancel button
+    if (isRunning) {
+      const cancelEl = document.getElementById('cancel-scan-btn');
+      if (cancelEl) {
+        cancelEl.addEventListener('click', async () => {
+          if (!confirm('Cancel this scan? Tools already running will be terminated.')) return;
+          cancelEl.disabled = true;
+          cancelEl.textContent = 'Cancelling...';
+          try {
+            await API.cancelScan(s.id);
+            setTimeout(() => this.renderDetail(app, s.id), 1000);
+          } catch (err) {
+            cancelEl.disabled = false;
+            cancelEl.textContent = 'Cancel Scan';
+            alert('Failed to cancel: ' + err.message);
+          }
+        });
+      }
+    }
   },
 
   async renderDetail(app, id) {
@@ -261,95 +503,37 @@ const ScansPage = {
 
     try {
       const data = await API.scan(id);
-      const s = data.scan;
-
-      let dur = '-';
-      if (s.started_at && s.finished_at) {
-        dur = Components.formatDuration(Math.floor((new Date(s.finished_at) - new Date(s.started_at)) / 1000));
-      }
-
-      const toolRows = data.tool_runs.map(tr => `
-        <tr>
-          <td class="mono">${escapeHtml(tr.tool_name)}</td>
-          <td>${tr.phase}</td>
-          <td>${Components.statusBadge(tr.status)}</td>
-          <td class="mono">${tr.duration_ms}ms</td>
-          <td>${tr.findings_count} findings</td>
-          <td>${tr.targets_count} targets</td>
-        </tr>
-      `).join('');
-
-      const changeRows = data.changes.map(c => `
-        <tr>
-          <td><span class="change-${c.change_type}">${c.change_type}</span></td>
-          <td>${c.asset_type}</td>
-          <td class="mono">${escapeHtml(c.asset_value)}</td>
-          <td>${escapeHtml(c.summary || '-')}</td>
-        </tr>
-      `).join('');
-
-      app.innerHTML = `
-        ${Components.backLink('#/scans', 'Back to scans')}
-        <div class="detail-panel">
-          <div class="detail-header">
-            ${Components.statusBadge(s.status)}
-            <h2>Scan ${Components.truncateID(s.id)}</h2>
-          </div>
-          <div class="detail-grid">
-            <span class="detail-label">ID</span>
-            <span class="detail-value mono">${s.id}</span>
-            <span class="detail-label">Target</span>
-            <span class="detail-value mono">${escapeHtml(data.target)}</span>
-            <span class="detail-label">Type</span>
-            <span class="detail-value">${s.type}</span>
-            <span class="detail-label">Status</span>
-            <span class="detail-value">${Components.statusBadge(s.status)}</span>
-            <span class="detail-label">Duration</span>
-            <span class="detail-value">${dur}</span>
-            <span class="detail-label">Started</span>
-            <span class="detail-value">${Components.formatDate(s.started_at)}</span>
-            <span class="detail-label">Finished</span>
-            <span class="detail-value">${Components.formatDate(s.finished_at)}</span>
-            ${s.error ? `<span class="detail-label">Error</span><span class="detail-value" style="color:var(--danger)">${escapeHtml(s.error)}</span>` : ''}
-          </div>
-        </div>
-
-        <div class="card" style="margin-bottom:16px">
-          <div class="card-label">Scan Stats</div>
-          <div class="detail-grid" style="margin-top:8px">
-            <span class="detail-label">Subdomains</span><span class="detail-value">${s.stats.subdomains_found || 0}</span>
-            <span class="detail-label">IPs Resolved</span><span class="detail-value">${s.stats.ips_resolved || 0}</span>
-            <span class="detail-label">Ports Scanned</span><span class="detail-value">${s.stats.ports_scanned || 0}</span>
-            <span class="detail-label">Open Ports</span><span class="detail-value">${s.stats.open_ports || 0}</span>
-            <span class="detail-label">HTTP Probed</span><span class="detail-value">${s.stats.http_probed || 0}</span>
-            <span class="detail-label">Findings</span><span class="detail-value">${s.stats.findings_total || 0}</span>
-          </div>
-          ${Components.severityBars({
-            critical: s.stats.findings_critical || 0,
-            high: s.stats.findings_high || 0,
-            medium: s.stats.findings_medium || 0,
-            low: s.stats.findings_low || 0,
-            info: s.stats.findings_info || 0,
-          })}
-        </div>
-
-        ${data.tool_runs.length > 0 ? `
-          <h3 style="margin-bottom:12px">Tool Runs</h3>
-          ${Components.table(['Tool', 'Phase', 'Status', 'Duration', 'Findings', 'Targets'], [toolRows])}
-        ` : ''}
-
-        ${data.changes.length > 0 ? `
-          <h3 style="margin-bottom:12px">Asset Changes</h3>
-          ${Components.table(['Change', 'Type', 'Value', 'Summary'], [changeRows])}
-        ` : ''}
-      `;
+      this.renderDetailContent(app, data);
 
       // Poll if running
-      if (s.status === 'running') {
-        this.startPolling(app);
+      if (data.scan.status === 'running') {
+        this.startDetailPolling(app, id);
       }
     } catch (err) {
       app.innerHTML = Components.emptyState('Not Found', 'Scan not found.');
     }
+  },
+
+  startDetailPolling(app, id) {
+    this.stopPolling();
+    this._elapsedTimer = setInterval(() => {
+      document.querySelectorAll('.tool-duration[data-started]').forEach(el => {
+        const started = new Date(el.dataset.started).getTime();
+        const elapsed = Math.round((Date.now() - started) / 1000);
+        el.textContent = this.formatElapsed(elapsed);
+      });
+    }, 1000);
+
+    this.pollTimer = setInterval(async () => {
+      try {
+        const data = await API.scan(id);
+        if (data.scan.status !== 'running') {
+          this.stopPolling();
+        }
+        this.renderDetailContent(app, data);
+      } catch {
+        // Ignore polling errors
+      }
+    }, 3000);
   },
 };

--- a/internal/webui/static/js/pages/scans.js
+++ b/internal/webui/static/js/pages/scans.js
@@ -275,20 +275,20 @@ const ScansPage = {
     httpx: '\u{1F310}', subjack: '\u{26A0}\uFE0F', nuclei: '\u{1F6E1}\uFE0F',
   },
 
-  phaseIndex(phase) {
-    if (!phase) return -1;
-    const idx = this.PHASES.findIndex(p => p.key === phase);
-    if (idx >= 0) return idx;
-    // Map alternate names
-    if (phase === 'initializing') return -1;
-    if (phase === 'diffing') return 5;
-    if (phase === 'cancelled') return -1;
-    return -1;
+  // Build a set of phases that actually ran from tool_runs data.
+  ranPhases(toolRuns) {
+    const ran = new Set();
+    for (const tr of toolRuns) {
+      if (tr.phase) ran.add(tr.phase);
+    }
+    return ran;
   },
 
-  renderPhaseIndicator(scan) {
+  renderPhaseIndicator(scan, toolRuns) {
     const isTerminal = scan.status === 'completed' || scan.status === 'failed' || scan.status === 'cancelled';
-    const currentIdx = isTerminal && scan.status === 'completed' ? 6 : this.phaseIndex(scan.phase);
+    const ran = this.ranPhases(toolRuns || []);
+    // For running scans, find the current phase index
+    const currentPhaseIdx = this.PHASES.findIndex(p => p.key === scan.phase);
 
     return `<div class="phase-indicator">${this.PHASES.map((p, i) => {
       const num = i + 1;
@@ -296,29 +296,52 @@ const ScansPage = {
       let content = num;
       let stepClass = 'phase-step';
 
-      if (isTerminal && scan.status === 'completed') {
-        circleClass += ' phase-done';
-        content = '\u2713';
-        stepClass += ' done';
-      } else if (i < currentIdx) {
-        circleClass += ' phase-done';
-        content = '\u2713';
-        stepClass += ' done';
-      } else if (i === currentIdx) {
-        if (scan.status === 'failed') {
-          circleClass += ' phase-failed';
-          content = '\u2717';
+      if (p.key === 'completed') {
+        // Last step: "Complete"
+        if (isTerminal && scan.status === 'completed') {
+          circleClass += ' phase-done'; content = '\u2713'; stepClass += ' done';
+        } else if (scan.status === 'failed') {
+          circleClass += ' phase-failed'; content = '\u2717';
         } else if (scan.status === 'cancelled') {
-          circleClass += ' phase-cancelled';
-          content = '\u2013';
-        } else {
-          circleClass += ' phase-active';
+          circleClass += ' phase-cancelled'; content = '\u2013';
         }
-        stepClass += ' active';
+      } else if (isTerminal && scan.status === 'completed' && ran.has(p.key)) {
+        circleClass += ' phase-done'; content = '\u2713'; stepClass += ' done';
+      } else if (isTerminal && scan.status === 'completed' && !ran.has(p.key)) {
+        circleClass += ' phase-skipped'; content = '\u2013'; stepClass += ' skipped';
+      } else if (isTerminal && (scan.status === 'failed' || scan.status === 'cancelled')) {
+        if (ran.has(p.key)) {
+          // Check if this phase's tools all completed
+          const phaseTools = (toolRuns || []).filter(tr => tr.phase === p.key);
+          const allDone = phaseTools.every(tr => tr.status === 'completed');
+          if (allDone) {
+            circleClass += ' phase-done'; content = '\u2713'; stepClass += ' done';
+          } else {
+            circleClass += scan.status === 'failed' ? ' phase-failed' : ' phase-cancelled';
+            content = scan.status === 'failed' ? '\u2717' : '\u2013';
+          }
+        } else {
+          circleClass += ' phase-skipped'; content = '\u2013'; stepClass += ' skipped';
+        }
+      } else if (!isTerminal) {
+        // Running scan
+        if (ran.has(p.key)) {
+          const phaseTools = (toolRuns || []).filter(tr => tr.phase === p.key);
+          const allDone = phaseTools.every(tr => tr.status === 'completed');
+          if (allDone) {
+            circleClass += ' phase-done'; content = '\u2713'; stepClass += ' done';
+          } else {
+            circleClass += ' phase-active'; stepClass += ' active';
+          }
+        } else if (i === currentPhaseIdx) {
+          circleClass += ' phase-active'; stepClass += ' active';
+        }
       }
 
+      // Connector line
+      const prevDone = circleClass.includes('phase-done');
       const line = i < this.PHASES.length - 1
-        ? `<div class="phase-line${i < currentIdx ? ' phase-line-done' : ''}"></div>`
+        ? `<div class="phase-line${prevDone ? ' phase-line-done' : ''}"></div>`
         : '';
 
       return `<div class="${stepClass}"><div class="${circleClass}">${content}</div><span class="phase-label">${p.label}</span></div>${line}`;
@@ -342,7 +365,7 @@ const ScansPage = {
     </div>`;
   },
 
-  renderPipeline(toolRuns) {
+  renderPipeline(toolRuns, scanId) {
     if (toolRuns.length === 0) return '';
 
     const sorted = [...toolRuns].sort((a, b) => {
@@ -365,7 +388,7 @@ const ScansPage = {
 
       const stats = [];
       if (tr.targets_count > 0) stats.push(`<span class="stat-badge">${tr.targets_count} targets</span>`);
-      if (tr.findings_count > 0) stats.push(`<span class="stat-badge stat-badge-finding">${tr.findings_count} findings</span>`);
+      if (tr.findings_count > 0) stats.push(`<span class="stat-badge stat-badge-finding">${tr.findings_count} results</span>`);
 
       return `<div class="pipeline-node ${statusClass}">
         <div class="pipeline-connector">
@@ -390,6 +413,66 @@ const ScansPage = {
     </div>`;
   },
 
+  renderFindings(findings, scanId) {
+    if (!findings || findings.length === 0) {
+      return `<div class="card" style="margin-bottom:16px">
+        <div class="card-label">Findings</div>
+        <div style="padding:12px 0;color:var(--text-muted);font-size:13px">No findings recorded for this scan.</div>
+      </div>`;
+    }
+
+    const rows = findings.map(f => `
+      <tr class="clickable" onclick="location.hash='#/findings/${f.id}'">
+        <td>${Components.severityBadge ? Components.severityBadge(f.severity) : `<span class="badge badge-${f.severity}">${f.severity}</span>`}</td>
+        <td>${escapeHtml(f.title)}</td>
+        <td class="mono text-muted" style="font-size:11px">${escapeHtml(f.template_id || '-')}</td>
+        <td class="mono text-muted" style="font-size:11px">${escapeHtml(f.source_tool || '-')}</td>
+        <td>${Components.statusBadge(f.status)}</td>
+      </tr>
+    `).join('');
+
+    return `<div class="card" style="margin-bottom:16px">
+      <div class="card-label">Findings <span class="text-muted" style="font-weight:400;text-transform:none">(${findings.length})</span></div>
+      <div class="table-container" style="border:none;margin:8px 0 0">
+        <table>
+          <thead><tr><th>Severity</th><th>Title</th><th>Template</th><th>Tool</th><th>Status</th></tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
+    </div>`;
+  },
+
+  renderScanStats(stats) {
+    // Only show stats that have non-zero values
+    const items = [
+      { label: 'Subdomains', value: stats.subdomains_found },
+      { label: 'IPs Resolved', value: stats.ips_resolved },
+      { label: 'Ports Scanned', value: stats.ports_scanned },
+      { label: 'Open Ports', value: stats.open_ports },
+      { label: 'HTTP Probed', value: stats.http_probed },
+      { label: 'Findings', value: stats.findings_total },
+    ].filter(i => i.value > 0);
+
+    if (items.length === 0) return '';
+
+    const sevs = {
+      critical: stats.findings_critical || 0,
+      high: stats.findings_high || 0,
+      medium: stats.findings_medium || 0,
+      low: stats.findings_low || 0,
+      info: stats.findings_info || 0,
+    };
+    const hasSev = Object.values(sevs).some(v => v > 0);
+
+    return `<div class="card" style="margin-bottom:16px">
+      <div class="card-label">Scan Stats</div>
+      <div class="detail-grid" style="margin-top:8px">
+        ${items.map(i => `<span class="detail-label">${i.label}</span><span class="detail-value">${i.value}</span>`).join('')}
+      </div>
+      ${hasSev ? Components.severityBars(sevs) : ''}
+    </div>`;
+  },
+
   formatElapsed(seconds) {
     if (seconds < 60) return seconds + 's';
     return Math.floor(seconds / 60) + 'm ' + (seconds % 60) + 's';
@@ -402,7 +485,7 @@ const ScansPage = {
     return Math.floor(s / 60) + 'm ' + Math.round(s % 60) + 's';
   },
 
-  renderDetailContent(app, data) {
+  renderDetailContent(app, data, findings) {
     const s = data.scan;
     const isRunning = s.status === 'running';
 
@@ -417,6 +500,12 @@ const ScansPage = {
     const cancelBtn = isRunning
       ? `<button class="btn btn-danger btn-sm" id="cancel-scan-btn">Cancel Scan</button>`
       : '';
+
+    const typeBadge = `<span class="badge badge-info" style="margin-left:8px">${s.type || 'full'}</span>`;
+
+    const timestamps = [];
+    if (s.started_at) timestamps.push(`Started ${Components.formatDate(s.started_at)}`);
+    if (s.finished_at) timestamps.push(`Finished ${Components.formatDate(s.finished_at)}`);
 
     const errorCard = s.error
       ? `<div class="card" style="margin-bottom:16px;border-color:rgba(248,81,73,0.3)">
@@ -439,39 +528,26 @@ const ScansPage = {
         <div class="detail-header">
           ${Components.statusBadge(s.status)}
           <h2>Scan ${Components.truncateID(s.id)}</h2>
-          <span class="text-muted mono" style="font-size:12px">${escapeHtml(data.target)}</span>
+          ${typeBadge}
+          <span class="text-muted mono" style="font-size:12px;margin-left:8px">${escapeHtml(data.target)}</span>
           <span class="text-muted" style="font-size:12px;margin-left:4px">${dur}</span>
           <div style="margin-left:auto">${cancelBtn}</div>
         </div>
+        ${timestamps.length > 0 ? `<div class="text-muted" style="font-size:11px;margin-top:4px">${timestamps.join(' \u00B7 ')}</div>` : ''}
 
-        ${this.renderPhaseIndicator(s)}
+        ${this.renderPhaseIndicator(s, data.tool_runs)}
         ${this.renderProgressBar(s)}
         ${errorCard}
       </div>
 
-      ${this.renderPipeline(data.tool_runs)}
+      ${this.renderPipeline(data.tool_runs, s.id)}
 
-      <div class="card" style="margin-bottom:16px">
-        <div class="card-label">Scan Stats</div>
-        <div class="detail-grid" style="margin-top:8px">
-          <span class="detail-label">Subdomains</span><span class="detail-value">${s.stats.subdomains_found || 0}</span>
-          <span class="detail-label">IPs Resolved</span><span class="detail-value">${s.stats.ips_resolved || 0}</span>
-          <span class="detail-label">Ports Scanned</span><span class="detail-value">${s.stats.ports_scanned || 0}</span>
-          <span class="detail-label">Open Ports</span><span class="detail-value">${s.stats.open_ports || 0}</span>
-          <span class="detail-label">HTTP Probed</span><span class="detail-value">${s.stats.http_probed || 0}</span>
-          <span class="detail-label">Findings</span><span class="detail-value">${s.stats.findings_total || 0}</span>
-        </div>
-        ${Components.severityBars({
-          critical: s.stats.findings_critical || 0,
-          high: s.stats.findings_high || 0,
-          medium: s.stats.findings_medium || 0,
-          low: s.stats.findings_low || 0,
-          info: s.stats.findings_info || 0,
-        })}
-      </div>
+      ${this.renderFindings(findings, s.id)}
+
+      ${this.renderScanStats(s.stats)}
 
       ${data.changes.length > 0 ? `
-        <h3 style="margin-bottom:12px">Asset Changes</h3>
+        <h3 style="margin-bottom:12px">Asset Changes <span class="text-muted" style="font-size:13px;font-weight:400">(${data.changes.length})</span></h3>
         ${Components.table(['Change', 'Type', 'Value', 'Summary'], [changeRows])}
       ` : ''}
     `;
@@ -502,8 +578,11 @@ const ScansPage = {
     app.innerHTML = '<div class="loading">Loading scan...</div>';
 
     try {
-      const data = await API.scan(id);
-      this.renderDetailContent(app, data);
+      const [data, findingsData] = await Promise.all([
+        API.scan(id),
+        API.findings({ scan_id: id, limit: 100 }),
+      ]);
+      this.renderDetailContent(app, data, findingsData.findings || []);
 
       // Poll if running
       if (data.scan.status === 'running') {
@@ -526,11 +605,14 @@ const ScansPage = {
 
     this.pollTimer = setInterval(async () => {
       try {
-        const data = await API.scan(id);
+        const [data, findingsData] = await Promise.all([
+          API.scan(id),
+          API.findings({ scan_id: id, limit: 100 }),
+        ]);
         if (data.scan.status !== 'running') {
           this.stopPolling();
         }
-        this.renderDetailContent(app, data);
+        this.renderDetailContent(app, data, findingsData.findings || []);
       } catch {
         // Ignore polling errors
       }


### PR DESCRIPTION
## Summary

- Replace flat scan detail view (`/#/scans/:id`) with rich pipeline visualization
- Add phase indicator (6-stage progression: Discovering → DNS → Ports → HTTP → Analyzing → Complete) with checkmarks, pulsing active state, and failed/cancelled states
- Add progress bar with shimmer animation for active scans  
- Replace tool runs table with vertical timeline pipeline view showing tool icons, status badges with colors, duration, and stat badges
- Add cancel scan capability via `DELETE /api/v1/scans/:id` endpoint with context cancellation propagation to the pipeline
- Real-time polling updates detail view in-place every 3s during active scans
- Live elapsed timer for running tools updates every second

## Backend changes

- `handlers.go`: Add `cancelFunc` field to handler struct; store `context.CancelFunc` when creating scan; add `handleCancelScan` handler that validates scan state and calls cancel
- `server.go`: Wire DELETE method for `/api/v1/scans/:id` route
- `api.js`: Add `cancelScan(id)` method

## Test plan

- [x] `go test ./internal/webui/...` passes (3 new cancel tests)
- [ ] Navigate to `/#/scans/:id` for a completed scan — phase indicator shows all complete, pipeline view with tool timeline
- [ ] Start a new scan, navigate to detail — live progress bar, pulsing phase, live pipeline, cancel button visible
- [ ] Click cancel on running scan — confirmation dialog, scan cancels, view re-renders
- [ ] Cancel on completed scan — button not shown