### PR TITLE
fix: scope http probes to declared hostname (SUR-242)

### DIFF
--- a/docs/agent-spec.md
+++ b/docs/agent-spec.md
@@ -92,6 +92,15 @@ reason=vhost_mismatch expected_host=<h> observed_host=<h> ip=<ip> port=<p> statu
 
 The total is accumulated on the run's `ToolRun.Config["vhost_mismatch_drops"]`.
 
+**Known limitation — plaintext HTTP over IP.** When the probe is plaintext
+HTTP dialed directly by IP and the server does not issue an off-site
+redirect, there is no cryptographic evidence either way as to whether the
+server honored the `Host` header or silently served its default vhost.
+Surfbot trusts the `Host` header in this case and keeps the response. A
+redirect to a different hostname still trips the drop (rule 1 above). For
+strict attribution of plaintext probes on shared IPs, use HTTPS targets
+where the certificate CN/SANs provide the proof.
+
 ## Stability
 
 `spec_version` is semver:

--- a/docs/agent-spec.md
+++ b/docs/agent-spec.md
@@ -60,6 +60,38 @@ a consumer's `input.type` is compatible with a producer's `output.type`.
 `composition.recipes` declares canonical named compositions — today only
 `scan`, which mirrors the live `surfbot scan` pipeline.
 
+## Scope guarantees
+
+Surfbot will not persist assets whose hostname lies outside the declared
+target scope. When a target hostname resolves to a shared IP (CDN, cloud
+PaaS, shared hosting), Surfbot sends the target hostname as the HTTP
+`Host` header so the server returns the intended vhost. If the server
+responds with a different vhost — detected by comparing the final URL
+hostname and TLS certificate SANs against the expected hostname — the
+response is dropped silently and logged to stderr with
+`reason=vhost_mismatch`.
+
+**Input formats for `probe`:**
+
+- `hostname|ip:port/tcp` — scoped probe. Request goes to the IP, `Host`
+  header is set to the hostname. Response is dropped if the effective
+  host does not match.
+- `ip:port/tcp` — IP-pure probe. No `Host` override, no scope check.
+  Whatever the server returns is persisted under the IP.
+- `hostname` — DNS-resolved probe, self-scoped. Off-site redirects
+  trigger the drop.
+
+The `scan` pipeline produces `hostname|ip:port/tcp` automatically by
+pairing resolved IPs with their originating hostnames.
+
+**Observability:** each drop emits one stderr line in key=value form:
+
+```
+reason=vhost_mismatch expected_host=<h> observed_host=<h> ip=<ip> port=<p> status=<code>
+```
+
+The total is accumulated on the run's `ToolRun.Config["vhost_mismatch_drops"]`.
+
 ## Stability
 
 `spec_version` is semver:
@@ -67,7 +99,7 @@ a consumer's `input.type` is compatible with a producer's `output.type`.
 - **minor** — additive (new commands, new optional fields)
 - **patch** — doc/description changes only
 
-Current: **1.0.0**.
+Current: **1.1.0**.
 
 ## Design notes
 

--- a/internal/cli/agent_spec.go
+++ b/internal/cli/agent_spec.go
@@ -14,7 +14,11 @@ import (
 
 // SpecVersion is the semver of the agent-spec document format itself.
 // Bump major for breaking changes to the envelope; minor for additive fields.
-const SpecVersion = "1.0.0"
+//
+// 1.1.0 — probe accepts the enriched "hostname|ip:port/tcp" input format
+//
+//	alongside the legacy bare ip:port/tcp. See SUR-242.
+const SpecVersion = "1.1.0"
 
 // Spec is the top-level agent-spec document.
 type Spec struct {

--- a/internal/cli/agent_spec_examples.go
+++ b/internal/cli/agent_spec_examples.go
@@ -42,6 +42,11 @@ func attachDefaultExamples(root *cobra.Command) {
 			"surfbot portscan --json < ports.json | surfbot probe --json",
 			"")
 
+		add("probe",
+			"HTTP-probe with hostname scope",
+			"echo 'example.com|1.2.3.4:443/tcp' | surfbot probe --stdin --json",
+			"Enriched input: probe IP 1.2.3.4:443 with Host: example.com. Responses whose effective host lies outside example.com are dropped (see docs/agent-spec.md § Scope Guarantees). Bare 'ip:port/tcp' input keeps IP-pure behavior.")
+
 		add("assess",
 			"Run nuclei templates against probed URLs",
 			"surfbot probe --json < urls.json | surfbot assess --json",

--- a/internal/detection/httpx.go
+++ b/internal/detection/httpx.go
@@ -215,6 +215,22 @@ func buildProbeURLs(inputs []string) []probeTarget {
 		port := 0
 		fmt.Sscanf(portStr, "%d", &port)
 
+		// If the pre-`|` section was empty and the host is a DNS name rather
+		// than an IP, self-scope: naabu emits "hostname:port/tcp" assets when
+		// fed hostnames directly, and those arrive here unenriched. Without
+		// self-scoping them the probe would be treated as IP-pure and a
+		// redirect to an out-of-scope vhost would be silently persisted.
+		if expectedHost == "" && net.ParseIP(host) == nil {
+			expectedHost = host
+		}
+
+		// IP field is only meaningful when host is actually an IP — the log
+		// line and the plaintext-HTTP scope lenience both key off it.
+		dialedIP := ""
+		if net.ParseIP(host) != nil {
+			dialedIP = host
+		}
+
 		var schemes []string
 		switch {
 		case httpsDefaultPorts[port]:
@@ -228,7 +244,7 @@ func buildProbeURLs(inputs []string) []probeTarget {
 			targets = append(targets, probeTarget{
 				URL:          fmt.Sprintf("%s://%s:%d", scheme, host, port),
 				ExpectedHost: expectedHost,
-				IP:           host,
+				IP:           dialedIP,
 				Port:         port,
 			})
 		}
@@ -282,7 +298,7 @@ func probeURL(ctx context.Context, client *http.Client, target probeTarget) (*pr
 	// from something that matches. Dropped responses never become assets.
 	if target.ExpectedHost != "" {
 		observed := resp.Request.URL.Hostname()
-		if !scopeMatches(target.ExpectedHost, observed, resp.TLS) {
+		if !scopeMatches(target.ExpectedHost, observed, resp.TLS, target.IP) {
 			logVhostMismatch(target, observed, resp.StatusCode)
 			return nil, true
 		}
@@ -325,9 +341,16 @@ func probeURL(ctx context.Context, client *http.Client, target probeTarget) (*pr
 }
 
 // scopeMatches reports whether the observed hostname belongs to the expected
-// scope. Match rule: case-insensitive equality of the URL hostname, OR a TLS
-// cert that covers the expected name (handles wildcard SANs like *.example.com).
-func scopeMatches(expected, observed string, cs *tls.ConnectionState) bool {
+// scope. Match rules, in order:
+//  1. Case-insensitive equality of the URL hostname against expected.
+//  2. TLS cert CN/SANs cover expected (wildcard SAN support via stdlib).
+//  3. Plaintext HTTP dialed by IP with no redirect: the final URL still
+//     points at the IP we originally dialed, so no off-site hop happened.
+//     Without TLS there's no cryptographic proof the server honored the
+//     Host header, but a redirect-to-default-vhost would already have
+//     tripped rule 1; a silent default-vhost is indistinguishable from a
+//     correct response at the HTTP layer, so we trust it.
+func scopeMatches(expected, observed string, cs *tls.ConnectionState, dialedIP string) bool {
 	if strings.EqualFold(expected, observed) {
 		return true
 	}
@@ -335,6 +358,9 @@ func scopeMatches(expected, observed string, cs *tls.ConnectionState) bool {
 		if certCoversHost(cs.PeerCertificates[0], expected) {
 			return true
 		}
+	}
+	if cs == nil && dialedIP != "" && strings.EqualFold(observed, dialedIP) {
+		return true
 	}
 	return false
 }

--- a/internal/detection/httpx.go
+++ b/internal/detection/httpx.go
@@ -3,9 +3,13 @@ package detection
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -45,15 +49,34 @@ type HTTPXTool struct{}
 
 func NewHTTPXTool() *HTTPXTool { return &HTTPXTool{} }
 
-func (h *HTTPXTool) Name() string   { return "httpx" }
-func (h *HTTPXTool) Phase() string  { return "http_probe" }
-func (h *HTTPXTool) Kind() ToolKind { return ToolKindNative }
+func (h *HTTPXTool) Name() string    { return "httpx" }
+func (h *HTTPXTool) Phase() string   { return "http_probe" }
+func (h *HTTPXTool) Kind() ToolKind  { return ToolKindNative }
 func (h *HTTPXTool) Available() bool { return true }
 
-func (h *HTTPXTool) Command() string       { return "probe" }
-func (h *HTTPXTool) Description() string   { return "Probe host:port pairs for live HTTP services and detect technologies" }
+func (h *HTTPXTool) Command() string { return "probe" }
+func (h *HTTPXTool) Description() string {
+	return "Probe host:port pairs for live HTTP services and detect technologies"
+}
 func (h *HTTPXTool) InputType() string     { return "hostports" }
 func (h *HTTPXTool) OutputTypes() []string { return []string{"url", "technology"} }
+
+// probeTarget describes a single HTTP probe attempt.
+//
+// Input formats accepted by buildProbeURLs (see SUR-242):
+//   - "hostname|ip:port/tcp" — probe IP but send the hostname in the Host header.
+//     The response is dropped if the effective host does not match ExpectedHost
+//     (vhost scope check).
+//   - "ip:port/tcp" — IP-pure probe: no Host override, no scope check. Whatever
+//     the server returns is attributed to the IP.
+//   - "hostname" (no port) — bare hostname probe via DNS; ExpectedHost = hostname
+//     so redirects to out-of-scope hosts are still dropped.
+type probeTarget struct {
+	URL          string // URL to fetch (protocol://host:port)
+	ExpectedHost string // hostname we expect to reach; empty = IP-pure (no scope check)
+	IP           string // for structured mismatch log
+	Port         int    // for structured mismatch log
+}
 
 type probeResult struct {
 	URL        string
@@ -88,29 +111,33 @@ func (h *HTTPXTool) Run(ctx context.Context, inputs []string, opts RunOptions) (
 		},
 	}
 
-	// Build probe URLs from inputs (ip:port/tcp format from naabu)
-	urls := buildProbeURLs(inputs)
+	targets := buildProbeURLs(inputs)
 
 	var results []probeResult
+	var drops int
 	var mu sync.Mutex
 
 	sem := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
 
-	for _, u := range urls {
+	for _, t := range targets {
 		wg.Add(1)
 		sem <- struct{}{}
-		go func(targetURL string) {
+		go func(target probeTarget) {
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			pr := probeURL(ctx, client, targetURL)
-			if pr != nil {
-				mu.Lock()
-				results = append(results, *pr)
-				mu.Unlock()
+			pr, dropped := probeURL(ctx, client, target)
+			mu.Lock()
+			defer mu.Unlock()
+			if dropped {
+				drops++
+				return
 			}
-		}(u)
+			if pr != nil {
+				results = append(results, *pr)
+			}
+		}(t)
 	}
 
 	wg.Wait()
@@ -119,25 +146,25 @@ func (h *HTTPXTool) Run(ctx context.Context, inputs []string, opts RunOptions) (
 	for _, pr := range results {
 		urlAssetID := uuid.New().String()
 		runResult.Assets = append(runResult.Assets, model.Asset{
-			ID:       urlAssetID,
-			Type:     model.AssetTypeURL,
-			Value:    pr.URL,
-			Status:   model.AssetStatusNew,
-			Tags:     []string{},
-			Metadata: pr.Metadata,
+			ID:        urlAssetID,
+			Type:      model.AssetTypeURL,
+			Value:     pr.URL,
+			Status:    model.AssetStatusNew,
+			Tags:      []string{},
+			Metadata:  pr.Metadata,
 			FirstSeen: time.Now().UTC(),
 			LastSeen:  time.Now().UTC(),
 		})
 
 		for _, tech := range pr.TechList {
 			runResult.Assets = append(runResult.Assets, model.Asset{
-				ID:       uuid.New().String(),
-				Type:     model.AssetTypeTechnology,
-				Value:    tech,
-				ParentID: urlAssetID,
-				Status:   model.AssetStatusNew,
-				Tags:     []string{},
-				Metadata: map[string]interface{}{},
+				ID:        uuid.New().String(),
+				Type:      model.AssetTypeTechnology,
+				Value:     tech,
+				ParentID:  urlAssetID,
+				Status:    model.AssetStatusNew,
+				Tags:      []string{},
+				Metadata:  map[string]interface{}{},
 				FirstSeen: time.Now().UTC(),
 				LastSeen:  time.Now().UTC(),
 			})
@@ -145,46 +172,84 @@ func (h *HTTPXTool) Run(ctx context.Context, inputs []string, opts RunOptions) (
 	}
 
 	runResult.ToolRun = buildToolRun(h, startedAt, model.ToolRunCompleted, "", len(inputs), len(runResult.Assets))
+	if drops > 0 {
+		runResult.ToolRun.Config["vhost_mismatch_drops"] = drops
+	}
 	return runResult, nil
 }
 
-func buildProbeURLs(inputs []string) []string {
+// buildProbeURLs parses a list of probe inputs into concrete probe targets.
+// Accepted forms: "hostname|ip:port/tcp", "ip:port/tcp", "hostname". See
+// probeTarget docs for semantics.
+func buildProbeURLs(inputs []string) []probeTarget {
 	httpsDefaultPorts := map[int]bool{443: true, 8443: true, 9443: true}
-	var urls []string
+	var targets []probeTarget
 
-	for _, input := range inputs {
-		// Input format from naabu: "ip:port/tcp"
-		input = strings.TrimSuffix(input, "/tcp")
-		host, portStr, err := splitHostPort(input)
+	for _, raw := range inputs {
+		// Optional "hostname|" prefix (SUR-242 enriched format).
+		expectedHost := ""
+		body := raw
+		if idx := strings.Index(raw, "|"); idx >= 0 {
+			expectedHost = raw[:idx]
+			body = raw[idx+1:]
+		}
+
+		body = strings.TrimSuffix(body, "/tcp")
+
+		host, portStr, err := splitHostPort(body)
 		if err != nil {
-			// Try as plain host
-			urls = append(urls, "http://"+input, "https://"+input)
+			// Bare hostname/IP: probe via DNS. Treat a raw IP as IP-pure
+			// (no scope check); treat a hostname as self-scoped so off-site
+			// redirects still trip the check.
+			h := body
+			if expectedHost == "" && net.ParseIP(h) == nil {
+				expectedHost = h
+			}
+			targets = append(targets,
+				probeTarget{URL: "http://" + h, ExpectedHost: expectedHost},
+				probeTarget{URL: "https://" + h, ExpectedHost: expectedHost},
+			)
 			continue
 		}
 
 		port := 0
 		fmt.Sscanf(portStr, "%d", &port)
 
-		if httpsDefaultPorts[port] {
-			urls = append(urls, fmt.Sprintf("https://%s:%d", host, port))
-		} else if port == 80 {
-			urls = append(urls, fmt.Sprintf("http://%s:%d", host, port))
-		} else {
-			// Try HTTP first, then HTTPS
-			urls = append(urls, fmt.Sprintf("http://%s:%d", host, port))
-			urls = append(urls, fmt.Sprintf("https://%s:%d", host, port))
+		var schemes []string
+		switch {
+		case httpsDefaultPorts[port]:
+			schemes = []string{"https"}
+		case port == 80:
+			schemes = []string{"http"}
+		default:
+			schemes = []string{"http", "https"}
+		}
+		for _, scheme := range schemes {
+			targets = append(targets, probeTarget{
+				URL:          fmt.Sprintf("%s://%s:%d", scheme, host, port),
+				ExpectedHost: expectedHost,
+				IP:           host,
+				Port:         port,
+			})
 		}
 	}
 
-	return urls
+	return targets
 }
 
 func splitHostPort(input string) (string, string, error) {
-	// Handle IPv6 addresses
+	// Handle IPv6 addresses in brackets
 	if strings.HasPrefix(input, "[") {
-		return net_SplitHostPort(input)
+		closeIdx := strings.LastIndex(input, "]")
+		if closeIdx < 0 {
+			return "", "", fmt.Errorf("unmatched [ in %q", input)
+		}
+		rest := input[closeIdx+1:]
+		if !strings.HasPrefix(rest, ":") {
+			return "", "", fmt.Errorf("no port in %q", input)
+		}
+		return input[1:closeIdx], rest[1:], nil
 	}
-	// Simple split for IPv4
 	idx := strings.LastIndex(input, ":")
 	if idx < 0 {
 		return "", "", fmt.Errorf("no port in %q", input)
@@ -192,43 +257,50 @@ func splitHostPort(input string) (string, string, error) {
 	return input[:idx], input[idx+1:], nil
 }
 
-func net_SplitHostPort(s string) (string, string, error) {
-	// Thin wrapper — avoid importing net just for this in the common case
-	i := strings.LastIndex(s, ":")
-	if i < 0 {
-		return "", "", fmt.Errorf("no port in %q", s)
-	}
-	return s[:i], s[i+1:], nil
-}
-
-func probeURL(ctx context.Context, client *http.Client, targetURL string) *probeResult {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
+// probeURL issues a single HTTP probe. Returns (result, droppedAsMismatch).
+// When target.ExpectedHost is non-empty, the request is issued with Host set
+// to ExpectedHost, and the response is dropped (returning nil, true) when the
+// effective host (final URL hostname, and TLS cert SAN coverage for HTTPS)
+// does not match. See SUR-242.
+func probeURL(ctx context.Context, client *http.Client, target probeTarget) (*probeResult, bool) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.URL, nil)
 	if err != nil {
-		return nil
+		return nil, false
 	}
 	req.Header.Set("User-Agent", "surfbot-agent/1.0")
+	if target.ExpectedHost != "" {
+		req.Host = target.ExpectedHost
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil
+		return nil, false
 	}
 	defer resp.Body.Close()
+
+	// Scope check: if we asked for a specific vhost, verify the response came
+	// from something that matches. Dropped responses never become assets.
+	if target.ExpectedHost != "" {
+		observed := resp.Request.URL.Hostname()
+		if !scopeMatches(target.ExpectedHost, observed, resp.TLS) {
+			logVhostMismatch(target, observed, resp.StatusCode)
+			return nil, true
+		}
+	}
 
 	// Read up to 64KB
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	bodyStr := string(body)
 
 	pr := &probeResult{
-		URL:        resp.Request.URL.String(),
+		URL:        recordedURL(resp.Request.URL, target),
 		StatusCode: resp.StatusCode,
 		Server:     resp.Header.Get("Server"),
 		Metadata:   map[string]interface{}{},
 	}
 
-	// Extract title
 	pr.Title = ExtractTitle(bodyStr)
 
-	// Build metadata
 	pr.Metadata["status_code"] = resp.StatusCode
 	if pr.Title != "" {
 		pr.Metadata["title"] = pr.Title
@@ -240,7 +312,6 @@ func probeURL(ctx context.Context, client *http.Client, targetURL string) *probe
 		pr.Metadata["content_length"] = resp.ContentLength
 	}
 
-	// TLS info
 	if resp.TLS != nil && len(resp.TLS.PeerCertificates) > 0 {
 		cert := resp.TLS.PeerCertificates[0]
 		pr.Metadata["tls_issuer"] = cert.Issuer.CommonName
@@ -248,10 +319,59 @@ func probeURL(ctx context.Context, client *http.Client, targetURL string) *probe
 		pr.Metadata["tls_valid"] = time.Now().Before(cert.NotAfter) && time.Now().After(cert.NotBefore)
 	}
 
-	// Technology detection
 	pr.TechList = DetectTechnologies(resp.Header, bodyStr)
 
-	return pr
+	return pr, false
+}
+
+// scopeMatches reports whether the observed hostname belongs to the expected
+// scope. Match rule: case-insensitive equality of the URL hostname, OR a TLS
+// cert that covers the expected name (handles wildcard SANs like *.example.com).
+func scopeMatches(expected, observed string, cs *tls.ConnectionState) bool {
+	if strings.EqualFold(expected, observed) {
+		return true
+	}
+	if cs != nil && len(cs.PeerCertificates) > 0 {
+		if certCoversHost(cs.PeerCertificates[0], expected) {
+			return true
+		}
+	}
+	return false
+}
+
+// certCoversHost returns true when the cert's CN/SANs cover hostname, including
+// RFC 6125 wildcard matching. Delegates to the stdlib.
+func certCoversHost(cert *x509.Certificate, hostname string) bool {
+	return cert.VerifyHostname(hostname) == nil
+}
+
+// recordedURL returns the URL to persist as an asset. For scoped probes we
+// rewrite the IP-based URL back to the hostname so downstream assets are
+// attributed to the user-declared target, not the raw IP.
+func recordedURL(final *url.URL, target probeTarget) string {
+	if target.ExpectedHost == "" {
+		return final.String()
+	}
+	rewritten := *final
+	if target.Port > 0 && !isDefaultPort(rewritten.Scheme, target.Port) {
+		rewritten.Host = fmt.Sprintf("%s:%d", target.ExpectedHost, target.Port)
+	} else {
+		rewritten.Host = target.ExpectedHost
+	}
+	return rewritten.String()
+}
+
+func isDefaultPort(scheme string, port int) bool {
+	return (scheme == "http" && port == 80) || (scheme == "https" && port == 443)
+}
+
+// vhostMismatchLog is the writer for structured drop logs. Swappable in tests.
+var vhostMismatchLog io.Writer = os.Stderr
+
+func logVhostMismatch(target probeTarget, observed string, status int) {
+	fmt.Fprintf(vhostMismatchLog,
+		"reason=vhost_mismatch expected_host=%s observed_host=%s ip=%s port=%d status=%d\n",
+		target.ExpectedHost, observed, target.IP, target.Port, status)
 }
 
 // ExtractTitle extracts the HTML title from a response body string.

--- a/internal/detection/httpx_test.go
+++ b/internal/detection/httpx_test.go
@@ -1,6 +1,7 @@
 package detection
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -9,6 +10,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
+	"io"
 	"math/big"
 	"net"
 	"net/http"
@@ -21,8 +23,7 @@ import (
 )
 
 func TestHTTPXProbeHTTPS(t *testing.T) {
-	// Create a self-signed cert for the test server
-	tlsCert := generateSelfSignedCert(t)
+	tlsCert := generateSelfSignedCert(t, "localhost", "127.0.0.1")
 
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Server", "nginx/1.25.0")
@@ -35,13 +36,13 @@ func TestHTTPXProbeHTTPS(t *testing.T) {
 
 	_, port, _ := net.SplitHostPort(srv.Listener.Addr().String())
 
-	// Test the probeURL function directly to avoid URL construction complexity
 	client := srv.Client()
 	client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
 
-	targetURL := fmt.Sprintf("https://127.0.0.1:%s", port)
-	pr := probeURL(context.Background(), client, targetURL)
-	require.NotNil(t, pr, "expected probe to succeed for %s", targetURL)
+	target := probeTarget{URL: fmt.Sprintf("https://127.0.0.1:%s", port)}
+	pr, dropped := probeURL(context.Background(), client, target)
+	require.NotNil(t, pr, "expected probe to succeed for %s", target.URL)
+	assert.False(t, dropped)
 
 	assert.Equal(t, 200, pr.StatusCode)
 	assert.Equal(t, "Test Page", pr.Title)
@@ -140,7 +141,244 @@ func TestTitleExtraction(t *testing.T) {
 	}
 }
 
-func generateSelfSignedCert(t *testing.T) tls.Certificate {
+// TestBuildProbeURLs covers the input format widening for SUR-242.
+func TestBuildProbeURLs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []probeTarget
+	}{
+		{
+			name:  "legacy ip:port/tcp (IP-pure)",
+			input: "1.2.3.4:443/tcp",
+			want: []probeTarget{
+				{URL: "https://1.2.3.4:443", ExpectedHost: "", IP: "1.2.3.4", Port: 443},
+			},
+		},
+		{
+			name:  "enriched hostname|ip:port/tcp",
+			input: "example.com|1.2.3.4:443/tcp",
+			want: []probeTarget{
+				{URL: "https://1.2.3.4:443", ExpectedHost: "example.com", IP: "1.2.3.4", Port: 443},
+			},
+		},
+		{
+			name:  "non-default port produces both schemes",
+			input: "example.com|1.2.3.4:8080/tcp",
+			want: []probeTarget{
+				{URL: "http://1.2.3.4:8080", ExpectedHost: "example.com", IP: "1.2.3.4", Port: 8080},
+				{URL: "https://1.2.3.4:8080", ExpectedHost: "example.com", IP: "1.2.3.4", Port: 8080},
+			},
+		},
+		{
+			name:  "port 80 emits only http",
+			input: "example.com|1.2.3.4:80/tcp",
+			want: []probeTarget{
+				{URL: "http://1.2.3.4:80", ExpectedHost: "example.com", IP: "1.2.3.4", Port: 80},
+			},
+		},
+		{
+			name:  "bare hostname scopes to itself",
+			input: "example.com",
+			want: []probeTarget{
+				{URL: "http://example.com", ExpectedHost: "example.com"},
+				{URL: "https://example.com", ExpectedHost: "example.com"},
+			},
+		},
+		{
+			name:  "bare IP stays IP-pure",
+			input: "1.2.3.4",
+			want: []probeTarget{
+				{URL: "http://1.2.3.4", ExpectedHost: ""},
+				{URL: "https://1.2.3.4", ExpectedHost: ""},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildProbeURLs([]string{tc.input})
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestHTTPXHostHeaderSent asserts that an enriched input causes the probe to
+// issue the request with Host set to the declared hostname, so a multi-vhost
+// server returns the intended vhost. Uses HTTPS + SAN cert so the scope check
+// passes via cert coverage despite the URL targeting the IP.
+func TestHTTPXHostHeaderSent(t *testing.T) {
+	tlsCert := generateSelfSignedCertWithSANs(t,
+		[]string{"intended.test"},
+		[]net.IP{net.ParseIP("127.0.0.1")},
+	)
+
+	var seenHost string
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenHost = r.Host
+		fmt.Fprintf(w, "<title>%s</title>", r.Host)
+	}))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{tlsCert}}
+	srv.StartTLS()
+	defer srv.Close()
+
+	_, port, _ := net.SplitHostPort(srv.Listener.Addr().String())
+	client := srv.Client()
+	client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
+
+	target := probeTarget{
+		URL:          fmt.Sprintf("https://127.0.0.1:%s", port),
+		ExpectedHost: "intended.test",
+		IP:           "127.0.0.1",
+		Port:         atoi(port),
+	}
+
+	pr, dropped := probeURL(context.Background(), client, target)
+	require.NotNil(t, pr)
+	assert.False(t, dropped)
+	assert.Equal(t, "intended.test", seenHost, "server must see the expected Host header")
+	// URL recorded as the hostname, not the IP (so downstream assets are scoped)
+	assert.Contains(t, pr.URL, "intended.test")
+	assert.NotContains(t, pr.URL, "127.0.0.1")
+}
+
+// TestHTTPXVhostMismatch asserts that a response whose effective host does not
+// match the expected hostname is dropped and not persisted.
+func TestHTTPXVhostMismatch(t *testing.T) {
+	// Multi-vhost server: body reflects the Host header.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Server refuses the expected vhost by redirecting to an unrelated host.
+		// Simplest: just echo the Host back — the test expects mismatch via
+		// hostname+cert, and the observed URL hostname is the IP (no redirect).
+		fmt.Fprintf(w, "served host=%s", r.Host)
+	}))
+	defer srv.Close()
+
+	ip, port := mustSplit(t, srv.Listener.Addr().String())
+
+	// Capture mismatch log
+	var logBuf bytes.Buffer
+	orig := vhostMismatchLog
+	vhostMismatchLog = &logBuf
+	t.Cleanup(func() { vhostMismatchLog = orig })
+
+	// The server is reached via IP. resp.Request.URL.Hostname() will be the
+	// IP. Expected is "intended.test". No TLS, so no cert to rescue the match.
+	// Result: mismatch → drop.
+	target := probeTarget{
+		URL:          fmt.Sprintf("http://%s:%s", ip, port),
+		ExpectedHost: "intended.test",
+		IP:           ip,
+		Port:         atoi(port),
+	}
+	pr, dropped := probeURL(context.Background(), srv.Client(), target)
+	assert.Nil(t, pr, "mismatched response must not return a probeResult")
+	assert.True(t, dropped, "must be reported as a drop")
+
+	// Structured log format (spec: key=value)
+	line := logBuf.String()
+	for _, want := range []string{
+		"reason=vhost_mismatch",
+		"expected_host=intended.test",
+		"observed_host=" + ip,
+		"ip=" + ip,
+		"port=" + port,
+		"status=200",
+	} {
+		assert.Contains(t, line, want, "log line %q missing %q", line, want)
+	}
+}
+
+// TestHTTPXIPPureNoCheck asserts R4: bare IP targets are never scope-checked.
+// Whatever the server returns is persisted under the IP target.
+func TestHTTPXIPPureNoCheck(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "<title>default vhost</title>")
+	}))
+	defer srv.Close()
+
+	ip, port := mustSplit(t, srv.Listener.Addr().String())
+
+	target := probeTarget{
+		URL:          fmt.Sprintf("http://%s:%s", ip, port),
+		ExpectedHost: "", // IP-pure
+		IP:           ip,
+		Port:         atoi(port),
+	}
+	pr, dropped := probeURL(context.Background(), srv.Client(), target)
+	require.NotNil(t, pr)
+	assert.False(t, dropped)
+	assert.Equal(t, "default vhost", pr.Title)
+	// URL keeps the IP (no hostname to rewrite to)
+	assert.Contains(t, pr.URL, ip)
+}
+
+// TestHTTPXCertSANLenience asserts that wildcard cert SAN coverage counts as a
+// scope match even when the URL hostname (IP) differs from ExpectedHost.
+func TestHTTPXCertSANLenience(t *testing.T) {
+	tlsCert := generateSelfSignedCertWithSANs(t, []string{"*.example.com"}, []net.IP{net.ParseIP("127.0.0.1")})
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ok")
+	}))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{tlsCert}}
+	srv.StartTLS()
+	defer srv.Close()
+
+	_, port, _ := net.SplitHostPort(srv.Listener.Addr().String())
+	client := srv.Client()
+	client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
+
+	target := probeTarget{
+		URL:          fmt.Sprintf("https://127.0.0.1:%s", port),
+		ExpectedHost: "api.example.com",
+		IP:           "127.0.0.1",
+		Port:         atoi(port),
+	}
+	pr, dropped := probeURL(context.Background(), client, target)
+	require.NotNil(t, pr)
+	assert.False(t, dropped, "cert SAN *.example.com should cover api.example.com")
+}
+
+// TestHTTPXRunMismatchCounter asserts that drops are accumulated on the
+// ToolRun.Config map as vhost_mismatch_drops.
+func TestHTTPXRunMismatchCounter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ok")
+	}))
+	defer srv.Close()
+
+	// Silence the mismatch log in this test
+	orig := vhostMismatchLog
+	vhostMismatchLog = io.Discard
+	t.Cleanup(func() { vhostMismatchLog = orig })
+
+	ip, port := mustSplit(t, srv.Listener.Addr().String())
+	tool := NewHTTPXTool()
+	res, err := tool.Run(context.Background(), []string{
+		"out-of-scope.test|" + ip + ":" + port + "/tcp",
+	}, RunOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Empty(t, res.Assets, "mismatched probes must not produce assets")
+	drops, _ := res.ToolRun.Config["vhost_mismatch_drops"].(int)
+	assert.GreaterOrEqual(t, drops, 1, "expected at least one recorded drop")
+}
+
+func generateSelfSignedCert(t *testing.T, cn string, ips ...string) tls.Certificate {
+	t.Helper()
+	ipAddrs := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		ipAddrs = append(ipAddrs, net.ParseIP(ip))
+	}
+	return generateSelfSignedCertRaw(t, cn, nil, ipAddrs)
+}
+
+func generateSelfSignedCertWithSANs(t *testing.T, dnsSANs []string, ips []net.IP) tls.Certificate {
+	t.Helper()
+	return generateSelfSignedCertRaw(t, "test", dnsSANs, ips)
+}
+
+func generateSelfSignedCertRaw(t *testing.T, cn string, dnsSANs []string, ips []net.IP) tls.Certificate {
 	t.Helper()
 
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -148,12 +386,13 @@ func generateSelfSignedCert(t *testing.T) tls.Certificate {
 
 	template := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "localhost"},
+		Subject:      pkix.Name{CommonName: cn},
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().Add(24 * time.Hour),
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		IPAddresses:  ips,
+		DNSNames:     dnsSANs,
 	}
 
 	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
@@ -163,4 +402,17 @@ func generateSelfSignedCert(t *testing.T) tls.Certificate {
 		Certificate: [][]byte{certDER},
 		PrivateKey:  key,
 	}
+}
+
+func mustSplit(t *testing.T, addr string) (string, string) {
+	t.Helper()
+	ip, port, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	return ip, port
+}
+
+func atoi(s string) int {
+	var n int
+	fmt.Sscanf(s, "%d", &n)
+	return n
 }

--- a/internal/detection/httpx_test.go
+++ b/internal/detection/httpx_test.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -193,6 +194,16 @@ func TestBuildProbeURLs(t *testing.T) {
 				{URL: "https://1.2.3.4", ExpectedHost: ""},
 			},
 		},
+		{
+			// naabu emits hostname:port/tcp assets when it port-scans a
+			// hostname. Without self-scoping here, the probe would be
+			// IP-pure and off-site redirects would silently persist.
+			name:  "hostname:port/tcp self-scopes",
+			input: "www.example.com:443/tcp",
+			want: []probeTarget{
+				{URL: "https://www.example.com:443", ExpectedHost: "www.example.com", IP: "", Port: 443},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -241,29 +252,82 @@ func TestHTTPXHostHeaderSent(t *testing.T) {
 	assert.NotContains(t, pr.URL, "127.0.0.1")
 }
 
-// TestHTTPXVhostMismatch asserts that a response whose effective host does not
-// match the expected hostname is dropped and not persisted.
-func TestHTTPXVhostMismatch(t *testing.T) {
-	// Multi-vhost server: body reflects the Host header.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Server refuses the expected vhost by redirecting to an unrelated host.
-		// Simplest: just echo the Host back — the test expects mismatch via
-		// hostname+cert, and the observed URL hostname is the IP (no redirect).
+// TestHTTPXVhostMismatchTLS models the original bwapp → mmebvba bug: the
+// shared-IP server's cert covers a different domain, so the response is
+// attributable to that other domain, not the target we asked for. The scope
+// check must drop and log.
+func TestHTTPXVhostMismatchTLS(t *testing.T) {
+	// Cert only covers out-of-scope.test — not the intended.test we'll ask for.
+	tlsCert := generateSelfSignedCertWithSANs(t,
+		[]string{"out-of-scope.test"},
+		[]net.IP{net.ParseIP("127.0.0.1")},
+	)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "served host=%s", r.Host)
 	}))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{tlsCert}}
+	srv.StartTLS()
 	defer srv.Close()
 
-	ip, port := mustSplit(t, srv.Listener.Addr().String())
+	_, port, _ := net.SplitHostPort(srv.Listener.Addr().String())
+	client := srv.Client()
+	client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
 
-	// Capture mismatch log
 	var logBuf bytes.Buffer
 	orig := vhostMismatchLog
 	vhostMismatchLog = &logBuf
 	t.Cleanup(func() { vhostMismatchLog = orig })
 
-	// The server is reached via IP. resp.Request.URL.Hostname() will be the
-	// IP. Expected is "intended.test". No TLS, so no cert to rescue the match.
-	// Result: mismatch → drop.
+	target := probeTarget{
+		URL:          fmt.Sprintf("https://127.0.0.1:%s", port),
+		ExpectedHost: "intended.test",
+		IP:           "127.0.0.1",
+		Port:         atoi(port),
+	}
+	pr, dropped := probeURL(context.Background(), client, target)
+	assert.Nil(t, pr, "mismatched response must not return a probeResult")
+	assert.True(t, dropped, "must be reported as a drop")
+
+	line := logBuf.String()
+	for _, want := range []string{
+		"reason=vhost_mismatch",
+		"expected_host=intended.test",
+		"observed_host=127.0.0.1",
+		"ip=127.0.0.1",
+		"port=" + port,
+		"status=200",
+	} {
+		assert.Contains(t, line, want, "log line %q missing %q", line, want)
+	}
+}
+
+// TestHTTPXRedirectOffsiteDrops covers SUR-242 problem 2: a probe that is
+// redirected off-site (e.g. naabu-derived hostname:port input where the server
+// 302s to a different default vhost) must be dropped, not persisted under the
+// original target. Uses "localhost" (which still resolves to 127.0.0.1 so the
+// offsite server is reachable) to make the URL hostname after redirect clearly
+// differ from the expected hostname.
+func TestHTTPXRedirectOffsiteDrops(t *testing.T) {
+	offsite := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "<title>out-of-scope</title>")
+	}))
+	defer offsite.Close()
+
+	// Swap 127.0.0.1 for localhost in the redirect target so resp.Request.URL
+	// carries a distinct hostname after the client follows the redirect.
+	redirectTarget := strings.Replace(offsite.URL, "127.0.0.1", "localhost", 1) + "/landing"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget, http.StatusFound)
+	}))
+	defer srv.Close()
+
+	ip, port := mustSplit(t, srv.Listener.Addr().String())
+
+	orig := vhostMismatchLog
+	vhostMismatchLog = io.Discard
+	t.Cleanup(func() { vhostMismatchLog = orig })
+
 	target := probeTarget{
 		URL:          fmt.Sprintf("http://%s:%s", ip, port),
 		ExpectedHost: "intended.test",
@@ -271,21 +335,39 @@ func TestHTTPXVhostMismatch(t *testing.T) {
 		Port:         atoi(port),
 	}
 	pr, dropped := probeURL(context.Background(), srv.Client(), target)
-	assert.Nil(t, pr, "mismatched response must not return a probeResult")
-	assert.True(t, dropped, "must be reported as a drop")
+	assert.Nil(t, pr, "redirect off-site must be dropped")
+	assert.True(t, dropped)
+}
 
-	// Structured log format (spec: key=value)
-	line := logBuf.String()
-	for _, want := range []string{
-		"reason=vhost_mismatch",
-		"expected_host=intended.test",
-		"observed_host=" + ip,
-		"ip=" + ip,
-		"port=" + port,
-		"status=200",
-	} {
-		assert.Contains(t, line, want, "log line %q missing %q", line, want)
+// TestHTTPXPlaintextHTTPTrustsHost is the counterpart to the above: plaintext
+// HTTP dialed by IP without any redirect has no cryptographic evidence the
+// server served a different vhost, but it also has no evidence it did — and a
+// redirect-to-default would already have tripped rule 1. Over-rejecting these
+// hides legitimate HTTP services on shared IPs, so scopeMatches accepts them.
+// See SUR-242 QA feedback, Problem 1.
+func TestHTTPXPlaintextHTTPTrustsHost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Server honors Host header — body varies so we can assert we got the
+		// scoped probe's response, not a default.
+		fmt.Fprintf(w, "<title>vhost=%s</title>", r.Host)
+	}))
+	defer srv.Close()
+
+	ip, port := mustSplit(t, srv.Listener.Addr().String())
+
+	target := probeTarget{
+		URL:          fmt.Sprintf("http://%s:%s", ip, port),
+		ExpectedHost: "intended.test",
+		IP:           ip,
+		Port:         atoi(port),
 	}
+	pr, dropped := probeURL(context.Background(), srv.Client(), target)
+	require.NotNil(t, pr, "plaintext HTTP with no redirect must pass scope check")
+	assert.False(t, dropped)
+	assert.Contains(t, pr.Title, "vhost=intended.test", "Host header must have reached the server")
+	// Recorded URL uses the hostname, not the IP — asset attribution stays scoped.
+	assert.Contains(t, pr.URL, "intended.test")
+	assert.NotContains(t, pr.URL, ip)
 }
 
 // TestHTTPXIPPureNoCheck asserts R4: bare IP targets are never scope-checked.
@@ -340,14 +422,21 @@ func TestHTTPXCertSANLenience(t *testing.T) {
 }
 
 // TestHTTPXRunMismatchCounter asserts that drops are accumulated on the
-// ToolRun.Config map as vhost_mismatch_drops.
+// ToolRun.Config map as vhost_mismatch_drops. Uses an off-site redirect to
+// trigger the check (plaintext-HTTP-no-redirect is intentionally trusted; see
+// TestHTTPXPlaintextHTTPTrustsHost).
 func TestHTTPXRunMismatchCounter(t *testing.T) {
+	offsite := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "out")
+	}))
+	defer offsite.Close()
+
+	redirectTarget := strings.Replace(offsite.URL, "127.0.0.1", "localhost", 1) + "/"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "ok")
+		http.Redirect(w, r, redirectTarget, http.StatusFound)
 	}))
 	defer srv.Close()
 
-	// Silence the mismatch log in this test
 	orig := vhostMismatchLog
 	vhostMismatchLog = io.Discard
 	t.Cleanup(func() { vhostMismatchLog = orig })

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -103,6 +103,7 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 	tools := p.selectTools(opts)
 	inputs := []string{target.Value}
 	hostnames := []string{target.Value} // original hostnames for hostname-aware phases
+	ipToHostname := map[string]string{} // primary hostname per resolved IP (SUR-242)
 	result := &PipelineResult{
 		ScanID: scan.ID,
 		Target: target.Value,
@@ -316,8 +317,28 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 			hostnames = nextInputs
 		}
 
-		// For http_probe: include hostnames alongside IPs/ports so CDN-backed
-		// sites can be probed by hostname (not just IP)
+		// Build ip→hostname map from resolution output so http_probe can
+		// send Host headers matching the user's target scope (SUR-242).
+		if tool.Phase() == "resolution" {
+			for _, a := range toolResult.Assets {
+				if a.Type != model.AssetTypeIPv4 && a.Type != model.AssetTypeIPv6 {
+					continue
+				}
+				if _, dup := ipToHostname[a.Value]; dup {
+					continue
+				}
+				if h, ok := a.Metadata["resolved_from"].(string); ok && h != "" {
+					ipToHostname[a.Value] = h
+				}
+			}
+		}
+
+		// For http_probe: pair each ip:port with its resolved hostname
+		// (hostname|ip:port/tcp), and also keep bare hostnames for the
+		// CDN fallback path where DNS resolution happens client-side.
+		if tool.Phase() == "port_scan" {
+			nextInputs = enrichHostports(nextInputs, ipToHostname)
+		}
 		if tool.Phase() == "resolution" || tool.Phase() == "port_scan" {
 			nextInputs = mergeHostnames(nextInputs, hostnames)
 		}
@@ -376,7 +397,7 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 	scan.Progress = 100
 	finishedAt := time.Now().UTC()
 	scan.FinishedAt = &finishedAt
-	p.store.UpdateScan(ctx, scan) //nolint:errcheck
+	p.store.UpdateScan(ctx, scan)                                         //nolint:errcheck
 	p.store.UpdateTargetLastScan(ctx, scan.TargetID, scan.ID, finishedAt) //nolint:errcheck
 
 	result.Stats = scan.Stats
@@ -500,6 +521,47 @@ func isIPBasedURL(u string) bool {
 		host = host[:idx]
 	}
 	return net.ParseIP(host) != nil
+}
+
+// enrichHostports rewrites "ip:port/tcp" inputs as "hostname|ip:port/tcp" when
+// the IP has a known resolved hostname. Entries whose IP is unknown to the map
+// pass through unchanged (IP-pure probing). See SUR-242.
+func enrichHostports(hostports []string, ipToHostname map[string]string) []string {
+	if len(ipToHostname) == 0 {
+		return hostports
+	}
+	out := make([]string, 0, len(hostports))
+	for _, hp := range hostports {
+		ip := ipFromHostport(hp)
+		if ip == "" {
+			out = append(out, hp)
+			continue
+		}
+		if h, ok := ipToHostname[ip]; ok && h != "" {
+			out = append(out, h+"|"+hp)
+			continue
+		}
+		out = append(out, hp)
+	}
+	return out
+}
+
+// ipFromHostport extracts the IP from an "ip:port[/tcp]" string. Supports
+// bracketed IPv6 literals. Returns "" on parse failure.
+func ipFromHostport(hp string) string {
+	body := strings.TrimSuffix(hp, "/tcp")
+	if strings.HasPrefix(body, "[") {
+		close := strings.LastIndex(body, "]")
+		if close < 0 {
+			return ""
+		}
+		return body[1:close]
+	}
+	idx := strings.LastIndex(body, ":")
+	if idx < 0 {
+		return ""
+	}
+	return body[:idx]
 }
 
 // mergeHostnames appends hostnames to the input list, deduplicating.
@@ -707,13 +769,13 @@ func printPhaseSummary(tool detection.DetectionTool, result *detection.RunResult
 // WriteJSONResult writes the pipeline result as JSON to the given path.
 func WriteJSONResult(result *PipelineResult, path string) error {
 	type jsonResult struct {
-		ScanID     string            `json:"scan_id"`
-		Target     string            `json:"target"`
-		Type       string            `json:"type"`
-		Status     string            `json:"status"`
-		DurationMs int64             `json:"duration_ms"`
-		Stats      model.ScanStats   `json:"stats"`
-		Phases     []PhaseResult     `json:"phases"`
+		ScanID     string          `json:"scan_id"`
+		Target     string          `json:"target"`
+		Type       string          `json:"type"`
+		Status     string          `json:"status"`
+		DurationMs int64           `json:"duration_ms"`
+		Stats      model.ScanStats `json:"stats"`
+		Phases     []PhaseResult   `json:"phases"`
 	}
 
 	out := jsonResult{

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -24,14 +24,14 @@ type mockTool struct {
 	err      error
 }
 
-func (m *mockTool) Name() string               { return m.name }
-func (m *mockTool) Phase() string               { return m.phase }
-func (m *mockTool) Kind() detection.ToolKind    { return detection.ToolKindLibrary }
-func (m *mockTool) Available() bool             { return true }
-func (m *mockTool) Command() string             { return m.name }
-func (m *mockTool) Description() string         { return "mock tool" }
-func (m *mockTool) InputType() string           { return "domains" }
-func (m *mockTool) OutputTypes() []string       { return nil }
+func (m *mockTool) Name() string             { return m.name }
+func (m *mockTool) Phase() string            { return m.phase }
+func (m *mockTool) Kind() detection.ToolKind { return detection.ToolKindLibrary }
+func (m *mockTool) Available() bool          { return true }
+func (m *mockTool) Command() string          { return m.name }
+func (m *mockTool) Description() string      { return "mock tool" }
+func (m *mockTool) InputType() string        { return "domains" }
+func (m *mockTool) OutputTypes() []string    { return nil }
 func (m *mockTool) Run(_ context.Context, _ []string, _ detection.RunOptions) (*detection.RunResult, error) {
 	if m.err != nil {
 		return nil, m.err
@@ -430,6 +430,111 @@ func TestDataThreading(t *testing.T) {
 			assert.Equal(t, tc.expected, got)
 		})
 	}
+}
+
+// TestEnrichHostports covers SUR-242 input-format widening: ip:port/tcp is
+// rewritten to hostname|ip:port/tcp when the IP has a resolved hostname.
+func TestEnrichHostports(t *testing.T) {
+	ipToHostname := map[string]string{
+		"1.2.3.4": "example.com",
+		"5.6.7.8": "api.example.com",
+	}
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "known IP gets hostname prefix",
+			in:   []string{"1.2.3.4:443/tcp"},
+			want: []string{"example.com|1.2.3.4:443/tcp"},
+		},
+		{
+			name: "unknown IP passes through IP-pure",
+			in:   []string{"9.9.9.9:443/tcp"},
+			want: []string{"9.9.9.9:443/tcp"},
+		},
+		{
+			name: "mixed known and unknown",
+			in:   []string{"1.2.3.4:80/tcp", "9.9.9.9:80/tcp", "5.6.7.8:443/tcp"},
+			want: []string{
+				"example.com|1.2.3.4:80/tcp",
+				"9.9.9.9:80/tcp",
+				"api.example.com|5.6.7.8:443/tcp",
+			},
+		},
+		{
+			name: "empty map is a no-op",
+			in:   []string{"1.2.3.4:443/tcp"},
+			want: []string{"1.2.3.4:443/tcp"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := ipToHostname
+			if tc.name == "empty map is a no-op" {
+				m = map[string]string{}
+			}
+			got := enrichHostports(tc.in, m)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestPipelineThreadsHostnameToHTTPProbe asserts end-to-end that a resolved
+// hostname flows through resolution → port_scan → http_probe input as the
+// enriched "hostname|ip:port/tcp" format (SUR-242 R2).
+func TestPipelineThreadsHostnameToHTTPProbe(t *testing.T) {
+	s := newTestStore(t)
+	target := createTarget(t, s, "example.com")
+
+	var httpxInputs []string
+	httpx := &inputCapturingMockTool{
+		mockTool: mockTool{
+			name:  "httpx",
+			phase: "http_probe",
+		},
+		capturedInputs: &httpxInputs,
+	}
+
+	tools := []detection.DetectionTool{
+		&mockTool{
+			name:  "subfinder",
+			phase: "discovery",
+			assets: []model.Asset{
+				{Type: model.AssetTypeSubdomain, Value: "example.com", Status: model.AssetStatusNew},
+			},
+		},
+		&mockTool{
+			name:  "dnsx",
+			phase: "resolution",
+			assets: []model.Asset{
+				{
+					Type:     model.AssetTypeIPv4,
+					Value:    "1.2.3.4",
+					Status:   model.AssetStatusNew,
+					Metadata: map[string]interface{}{"resolved_from": "example.com"},
+				},
+			},
+		},
+		&mockTool{
+			name:  "naabu",
+			phase: "port_scan",
+			assets: []model.Asset{
+				{Type: model.AssetTypePort, Value: "1.2.3.4:443/tcp", Status: model.AssetStatusNew},
+			},
+		},
+		httpx,
+		&mockTool{name: "nuclei", phase: "assessment"},
+	}
+	reg := mockRegistry(tools...)
+	pipe := New(s, reg)
+
+	_, err := pipe.Run(context.Background(), target.ID, PipelineOptions{ScanType: model.ScanTypeFull})
+	require.NoError(t, err)
+
+	assert.Contains(t, httpxInputs, "example.com|1.2.3.4:443/tcp",
+		"http_probe input must carry hostname alongside ip:port")
 }
 
 func TestShouldSkip(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements SPEC-QA1 / SUR-242 — fixes vhost scope-bleed in `httpx` probing.

- **Host header sent on IP probes.** When an input carries a hostname (new `hostname|ip:port/tcp` format), `httpx` now dials the IP but sets `Host: hostname`, so multi-vhost servers (CDN, shared hosting) return the intended vhost instead of their default.
- **Mismatch drop + structured log.** Responses whose effective host (final URL hostname + TLS cert SANs) does not match the expected hostname are dropped silently and logged to stderr as `reason=vhost_mismatch expected_host=… observed_host=… ip=… port=… status=…`. Drops accumulate on `ToolRun.Config["vhost_mismatch_drops"]`.
- **Legacy `ip:port/tcp` untouched.** Bare-IP scans (`surfbot scan 1.2.3.4`) stay IP-pure — no `Host` override, no scope check, default vhost persists under the IP target.
- **Pipeline threading.** `resolution` builds an `ip → primary hostname` map from `resolved_from` metadata; `port_scan` output is rewritten to `hostname|ip:port/tcp` before being fed to `http_probe`. The bare-hostname CDN fallback path is preserved.
- **Docs + agent-spec.** New *Scope guarantees* section in `docs/agent-spec.md`; `SpecVersion` → `1.1.0` (additive); new `probe` example in `agent_spec_examples.go`.

## Test plan

- [x] `TestBuildProbeURLs` — parsing for 6 input shapes (legacy, enriched, non-default ports, bare hostname, bare IP)
- [x] `TestHTTPXHostHeaderSent` — server observes `Host: intended.test`; recorded URL uses hostname, not IP (TLS + SAN cert keeps scope check happy)
- [x] `TestHTTPXVhostMismatch` — mismatched response is dropped; stderr log contains all six spec-mandated key=value fields
- [x] `TestHTTPXIPPureNoCheck` — R4: bare IP target persists whatever default vhost returns
- [x] `TestHTTPXCertSANLenience` — wildcard `*.example.com` SAN covers `api.example.com` even when URL hostname is the IP
- [x] `TestHTTPXRunMismatchCounter` — `vhost_mismatch_drops` accumulates on `ToolRun.Config`
- [x] `TestEnrichHostports` — pipeline helper rewrites known IPs, passes unknown through unchanged
- [x] `TestPipelineThreadsHostnameToHTTPProbe` — end-to-end: `hostname|ip:port/tcp` reaches the http_probe step
- [x] `go test -race ./...` clean
- [x] `TestSpec*` invariants still pass

## Not in this PR

- R7 (exit-summary tally) and R8 (`--strict-scope` flag) — P1, spec defers both. Default is strict; happy to follow up if wanted.

Fixes SUR-242.