### PR TITLE
SUR-244: replace ScanStats with target_state/delta/work model

### DIFF
--- a/docs/agent-spec.md
+++ b/docs/agent-spec.md
@@ -108,7 +108,72 @@ where the certificate CN/SANs provide the proof.
 - **minor** — additive (new commands, new optional fields)
 - **patch** — doc/description changes only
 
-Current: **1.1.0**.
+Current: **2.0.0**.
+
+## Changelog
+
+### 2.0.0 — scan aggregates redesign (SPEC-QA3 / SUR-244)
+
+The `ScanStats` type is removed. `Scan` now exposes three semantically
+distinct aggregates, each populated from database queries at scan
+completion (no in-memory accumulators, no drift from `list` subcommands):
+
+- **`target_state`** — what the target looks like at scan completion.
+  Source: queries against `assets` and `findings` filtered by `target_id`.
+  Answers *"what currently exists?"*. Includes `assets_by_type`,
+  `assets_total`, `ports_by_status`, `findings_open`, `findings_open_total`,
+  `findings_by_status`, and `remediations` (empty placeholder until
+  remediation tooling lands).
+- **`delta`** — what *this* scan changed relative to prior state. Source:
+  the `asset_changes` table (scan_id-scoped) plus finding status transitions.
+  Answers *"what did this scan discover or resolve?"*. Includes
+  `new_assets`, `disappeared_assets`, `modified_assets`, `new_findings`,
+  `resolved_findings`, `returned_findings`, and `is_baseline`.
+- **`work`** — telemetry of the execution itself. Source: `tool_runs` and
+  scan timing. Includes `duration_ms`, `tools_run`, `tools_failed`,
+  `tools_skipped`, `phases_run`, and `raw_emissions` (pre-dedup tool output
+  count, useful for debugging tool noise).
+
+**Field mapping (1.x → 2.0):**
+
+| 1.x (`stats.*`) | 2.0 (|
+|---|---|
+| `subdomains_found` | `target_state.assets_by_type.subdomain` |
+| `ips_resolved` | `target_state.assets_by_type.ipv4` + `.ipv6` |
+| `open_ports` | `target_state.ports_by_status.open` |
+| *(new)* | `target_state.ports_by_status.filtered` |
+| `http_probed` | `target_state.assets_by_type.url` |
+| `tech_detected` | `target_state.assets_by_type.technology` |
+| `ports_scanned` | *removed (was never populated)* |
+| `findings_total` | `target_state.findings_open_total` *(strictly DB-derived, no longer inflated by pre-dedup emissions)* |
+| `findings_<severity>` | `target_state.findings_open.<severity>` |
+
+**Open-ended stat buckets.** `assets_by_type`, `new_assets`, `ports_by_status`,
+and siblings are JSON objects keyed by enum strings. For `AssetType` the
+vocabulary is **open** — a new detection tool may introduce a new key
+without a spec version bump. Consumers must tolerate unknown keys. For
+`Severity`, `FindingStatus`, and `RemediationStatus` the vocabulary is
+closed (universal concepts, not tool-specific).
+
+**Finding.scan_id semantics changed.** It now tracks the LATEST scan that
+observed the finding (updated on every upsert). The immutable originating
+scan moved to a new field `first_seen_scan_id`. This makes
+`COUNT(*) WHERE scan_id = X AND status = 'open'` a meaningful query for
+"findings observed by scan X" — which was broken under 1.x semantics.
+
+**Assets type CHECK removed.** The `assets.type` column no longer has a
+SQL CHECK constraint. A new detection tool that emits an asset type
+outside the built-in vocabulary no longer requires a schema migration —
+`AssetType` is validated in Go. The `Finding` severity and `Asset` status
+enums remain closed at the SQL level.
+
+### 1.2.0 — portscan status metadata (SUR-243/SUR-248)
+
+Portscan assets gain `status` (open|filtered) and `banner_preview` metadata.
+
+### 1.1.0 — enriched probe input (SUR-242)
+
+`probe` accepts `hostname|ip:port/tcp` alongside bare `ip:port/tcp`.
 
 ## Design notes
 

--- a/internal/cli/agent_spec.go
+++ b/internal/cli/agent_spec.go
@@ -15,6 +15,14 @@ import (
 // SpecVersion is the semver of the agent-spec document format itself.
 // Bump major for breaking changes to the envelope; minor for additive fields.
 //
+// 2.0.0 — scan aggregates redesign. ScanStats is removed; Scan now exposes
+//
+//	target_state (what the target looks like), delta (what this scan
+//	changed), and work (telemetry). Finding gains first_seen_scan_id;
+//	scan_id now tracks the latest observing scan. AssetType vocabulary
+//	is declared open (new detection tools may introduce new keys).
+//	See SUR-244 / SPEC-QA3.
+//
 // 1.2.0 — portscan assets gain `status` (open|filtered) and
 //
 //	`banner_preview` metadata fields. See SUR-243/SUR-248.
@@ -22,7 +30,7 @@ import (
 // 1.1.0 — probe accepts the enriched "hostname|ip:port/tcp" input format
 //
 //	alongside the legacy bare ip:port/tcp. See SUR-242.
-const SpecVersion = "1.2.0"
+const SpecVersion = "2.0.0"
 
 // Spec is the top-level agent-spec document.
 type Spec struct {

--- a/internal/cli/agent_spec_schemas.go
+++ b/internal/cli/agent_spec_schemas.go
@@ -28,13 +28,17 @@ func BuildTypeSchemas() map[string]Schema {
 	boolean := Schema{Type: "boolean"}
 	obj := Schema{Type: "object"}
 
+	// Asset.type is declared as a plain string (not an enum) because new
+	// detection tools may introduce new AssetType values without a spec
+	// version bump. The `KnownAssetTypes` list below documents the current
+	// built-in vocabulary; consumers must tolerate unseen values.
 	asset := Schema{
 		Type: "object",
 		Properties: map[string]Schema{
 			"id":         str,
 			"target_id":  str,
 			"parent_id":  str,
-			"type":       {Type: "string", Enum: []string{"domain", "subdomain", "ipv4", "ipv6", "port_service", "url", "technology", "service"}},
+			"type":       {Type: "string", Description: "AssetType. Open vocabulary. Built-in values: domain, subdomain, ipv4, ipv6, port_service, url, technology, service. Detection tools may emit additional values — consumers must tolerate unknown AssetType strings."},
 			"value":      str,
 			"status":     {Type: "string", Enum: []string{"active", "new", "disappeared", "returned", "inactive", "ignored"}},
 			"tags":       strArr,
@@ -47,30 +51,35 @@ func BuildTypeSchemas() map[string]Schema {
 		Required: []string{"id", "type", "value", "status"},
 	}
 
+	// Finding.scan_id tracks the LATEST scan that observed this finding
+	// (updated on every upsert). Finding.first_seen_scan_id is immutable
+	// and names the scan that first discovered it. To recover a scan's
+	// complete observation set, query findings WHERE scan_id = <scan>.
 	finding := Schema{
 		Type: "object",
 		Properties: map[string]Schema{
-			"id":            str,
-			"asset_id":      str,
-			"scan_id":       str,
-			"template_id":   str,
-			"template_name": str,
-			"severity":      {Type: "string", Enum: []string{"critical", "high", "medium", "low", "info"}},
-			"title":         str,
-			"description":   str,
-			"references":    strArr,
-			"remediation":   str,
-			"evidence":      str,
-			"cvss":          num,
-			"cve":           str,
-			"status":        {Type: "string", Enum: []string{"open", "acknowledged", "resolved", "false_positive", "ignored"}},
-			"source_tool":   str,
-			"confidence":    num,
-			"first_seen":    str,
-			"last_seen":     str,
-			"resolved_at":   str,
-			"created_at":    str,
-			"updated_at":    str,
+			"id":                 str,
+			"asset_id":           str,
+			"scan_id":            {Type: "string", Description: "id of the most recent scan that observed this finding (mutable)"},
+			"first_seen_scan_id": {Type: "string", Description: "id of the scan that first discovered this finding (immutable)"},
+			"template_id":        str,
+			"template_name":      str,
+			"severity":           {Type: "string", Enum: []string{"critical", "high", "medium", "low", "info"}},
+			"title":              str,
+			"description":        str,
+			"references":         strArr,
+			"remediation":        str,
+			"evidence":           str,
+			"cvss":               num,
+			"cve":                str,
+			"status":             {Type: "string", Enum: []string{"open", "acknowledged", "resolved", "false_positive", "ignored"}},
+			"source_tool":        str,
+			"confidence":         num,
+			"first_seen":         str,
+			"last_seen":          str,
+			"resolved_at":        str,
+			"created_at":         str,
+			"updated_at":         str,
 		},
 		Required: []string{"id", "asset_id", "severity", "title", "status"},
 	}
@@ -112,35 +121,90 @@ func BuildTypeSchemas() map[string]Schema {
 		Required: []string{"id", "tool_name", "status"},
 	}
 
+	// --- Scan aggregates (spec 2.0) ---
+	//
+	// A scan is described by three semantically distinct aggregates:
+	//
+	//   target_state — what the target looks like at scan completion.
+	//                  Derived from assets/findings queries. State, not
+	//                  event: if the scan doesn't cover a phase, the
+	//                  corresponding counts reflect whatever was there
+	//                  before (nothing is reset).
+	//
+	//   delta        — what this scan changed vs. the target's prior
+	//                  state. Derived from asset_changes (scan_id) and
+	//                  finding status transitions.
+	//
+	//   work         — telemetry of the execution itself. Derived from
+	//                  tool_runs (scan_id) and scan timing.
+	//
+	// All count-bucket fields (assets_by_type, new_assets, findings_open,
+	// …) are JSON objects keyed by the relevant enum string. The enum
+	// vocabularies are open for AssetType (new tools may add keys) and
+	// closed for Severity / FindingStatus / RemediationStatus. Consumers
+	// must tolerate unknown keys regardless.
+	assetTypeCounts := Schema{Type: "object", Description: "Counts keyed by AssetType (open vocabulary). Example: {\"subdomain\": 12, \"port_service\": 5}"}
+	severityCounts := Schema{Type: "object", Description: "Counts keyed by Severity (critical|high|medium|low|info)"}
+	findingStatusCounts := Schema{Type: "object", Description: "Counts keyed by FindingStatus (open|acknowledged|resolved|false_positive|ignored)"}
+	remediationStatusCounts := Schema{Type: "object", Description: "Counts keyed by RemediationStatus (planned|approved|running|completed|failed|rolled_back). Empty until remediation tooling lands."}
+	stringCounts := Schema{Type: "object", Description: "Counts keyed by arbitrary string. Port status values (open|filtered|unknown|…) are emitted by the port_scan tool."}
+
+	targetState := Schema{
+		Type:        "object",
+		Description: "Snapshot of the target's observed state at scan completion. Answers \"what exists now?\"",
+		Properties: map[string]Schema{
+			"assets_by_type":       assetTypeCounts,
+			"assets_total":         integer,
+			"ports_by_status":      stringCounts,
+			"findings_open":        severityCounts,
+			"findings_open_total":  integer,
+			"findings_by_status":   findingStatusCounts,
+			"remediations":         remediationStatusCounts,
+		},
+	}
+
+	scanDelta := Schema{
+		Type:        "object",
+		Description: "What this scan changed vs. the prior state of the target. Baseline scans report is_baseline=true with empty buckets.",
+		Properties: map[string]Schema{
+			"new_assets":         assetTypeCounts,
+			"disappeared_assets": assetTypeCounts,
+			"modified_assets":    assetTypeCounts,
+			"new_findings":       severityCounts,
+			"resolved_findings":  severityCounts,
+			"returned_findings":  severityCounts,
+			"is_baseline":        boolean,
+		},
+	}
+
+	scanWork := Schema{
+		Type:        "object",
+		Description: "Telemetry of the scan execution. Independent of what was observed or changed.",
+		Properties: map[string]Schema{
+			"duration_ms":   integer,
+			"tools_run":     integer,
+			"tools_failed":  integer,
+			"tools_skipped": integer,
+			"phases_run":    strArr,
+			"raw_emissions": Schema{Type: "integer", Description: "Sum of findings emitted by tools before storage dedup. Useful for debugging tool noise (e.g. nuclei emitted 50 findings but storage merged them into 3 unique rows)."},
+		},
+	}
+
 	scan := Schema{
 		Type: "object",
 		Properties: map[string]Schema{
-			"id":          str,
-			"target_id":   str,
-			"type":        {Type: "string", Enum: []string{"full", "quick", "discovery"}},
-			"status":      {Type: "string", Enum: []string{"queued", "running", "completed", "failed", "cancelled"}},
-			"phase":       str,
-			"progress":    num,
-			"started_at":  str,
-			"finished_at": str,
-			"error":       str,
-			"stats": {
-				Type: "object",
-				Properties: map[string]Schema{
-					"subdomains_found":  integer,
-					"ips_resolved":      integer,
-					"ports_scanned":     integer,
-					"open_ports":        integer,
-					"http_probed":       integer,
-					"tech_detected":     integer,
-					"findings_total":    integer,
-					"findings_critical": integer,
-					"findings_high":     integer,
-					"findings_medium":   integer,
-					"findings_low":      integer,
-					"findings_info":     integer,
-				},
-			},
+			"id":           str,
+			"target_id":    str,
+			"type":         {Type: "string", Enum: []string{"full", "quick", "discovery"}},
+			"status":       {Type: "string", Enum: []string{"queued", "running", "completed", "failed", "cancelled"}},
+			"phase":        str,
+			"progress":     num,
+			"started_at":   str,
+			"finished_at":  str,
+			"error":        str,
+			"target_state": targetState,
+			"delta":        scanDelta,
+			"work":         scanWork,
 		},
 		Required: []string{"id", "type", "status"},
 	}
@@ -178,6 +242,9 @@ func BuildTypeSchemas() map[string]Schema {
 		"Target":      target,
 		"ToolRun":     toolRun,
 		"ScanResult":  scan,
+		"TargetState": targetState,
+		"ScanDelta":   scanDelta,
+		"ScanWork":    scanWork,
 		"Score":       score,
 		"Status":      status,
 		"DomainList":  domainList,

--- a/internal/cli/agent_spec_schemas.go
+++ b/internal/cli/agent_spec_schemas.go
@@ -153,13 +153,13 @@ func BuildTypeSchemas() map[string]Schema {
 		Type:        "object",
 		Description: "Snapshot of the target's observed state at scan completion. Answers \"what exists now?\"",
 		Properties: map[string]Schema{
-			"assets_by_type":       assetTypeCounts,
-			"assets_total":         integer,
-			"ports_by_status":      stringCounts,
-			"findings_open":        severityCounts,
-			"findings_open_total":  integer,
-			"findings_by_status":   findingStatusCounts,
-			"remediations":         remediationStatusCounts,
+			"assets_by_type":      assetTypeCounts,
+			"assets_total":        integer,
+			"ports_by_status":     stringCounts,
+			"findings_open":       severityCounts,
+			"findings_open_total": integer,
+			"findings_by_status":  findingStatusCounts,
+			"remediations":        remediationStatusCounts,
 		},
 	}
 
@@ -186,7 +186,7 @@ func BuildTypeSchemas() map[string]Schema {
 			"tools_failed":  integer,
 			"tools_skipped": integer,
 			"phases_run":    strArr,
-			"raw_emissions": Schema{Type: "integer", Description: "Sum of findings emitted by tools before storage dedup. Useful for debugging tool noise (e.g. nuclei emitted 50 findings but storage merged them into 3 unique rows)."},
+			"raw_emissions": {Type: "integer", Description: "Sum of findings emitted by tools before storage dedup. Useful for debugging tool noise (e.g. nuclei emitted 50 findings but storage merged them into 3 unique rows)."},
 		},
 	}
 
@@ -196,7 +196,7 @@ func BuildTypeSchemas() map[string]Schema {
 			"id":           str,
 			"target_id":    str,
 			"type":         {Type: "string", Enum: []string{"full", "quick", "discovery"}},
-			"status":       {Type: "string", Enum: []string{"queued", "running", "completed", "failed", "cancelled"}},
+			"status":       {Type: "string", Enum: []string{"queued", "running", "completed", "failed", "cancelled"}}, //nolint:misspell // "cancelled" is the value used throughout the codebase (model.ScanStatusCancelled); match the DB enum exactly.
 			"phase":        str,
 			"progress":     num,
 			"started_at":   str,

--- a/internal/detection/dnsx.go
+++ b/internal/detection/dnsx.go
@@ -2,6 +2,7 @@ package detection
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strings"
 	"sync"
@@ -42,7 +43,14 @@ func (d *DNSXTool) Run(ctx context.Context, inputs []string, opts RunOptions) (*
 	}
 
 	results := make([]dnsResult, 0, len(inputs))
+	// errLog accumulates per-host resolution errors so the tool_run record
+	// shows the user what went wrong (NXDOMAIN, timeouts, …) rather than
+	// silently dropping hosts. dnsx isn't a subprocess so "stderr" here is
+	// synthesised.
+	var errLog strings.Builder
 	var mu sync.Mutex
+	resolved := 0
+	failed := 0
 
 	sem := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
@@ -62,6 +70,10 @@ func (d *DNSXTool) Run(ctx context.Context, inputs []string, opts RunOptions) (*
 			ips, err := net.DefaultResolver.LookupHost(rctx, h)
 			if err == nil {
 				dr.IPs = ips
+			} else {
+				mu.Lock()
+				fmt.Fprintf(&errLog, "[dnsx] %s: %v\n", h, err)
+				mu.Unlock()
 			}
 
 			cname, err := net.DefaultResolver.LookupCNAME(rctx, h)
@@ -69,11 +81,14 @@ func (d *DNSXTool) Run(ctx context.Context, inputs []string, opts RunOptions) (*
 				dr.CNAME = strings.TrimSuffix(cname, ".")
 			}
 
+			mu.Lock()
 			if len(dr.IPs) > 0 {
-				mu.Lock()
 				results = append(results, dr)
-				mu.Unlock()
+				resolved++
+			} else {
+				failed++
 			}
+			mu.Unlock()
 		}(host)
 	}
 
@@ -115,6 +130,19 @@ func (d *DNSXTool) Run(ctx context.Context, inputs []string, opts RunOptions) (*
 		}
 	}
 
-	runResult.ToolRun = buildToolRun(d, startedAt, model.ToolRunCompleted, "", len(inputs), len(runResult.Assets))
+	tr := buildToolRun(d, startedAt, model.ToolRunCompleted, "", len(inputs), len(runResult.Assets))
+	tr.OutputSummary = fmt.Sprintf("Resolved %d of %d hosts to %d unique IP(s) (concurrency=%d)",
+		resolved, len(inputs), len(runResult.Assets), concurrency)
+	// No external process → exit_code 0, command is a human-readable label.
+	attachExecContext(&tr,
+		fmt.Sprintf("dnsx (in-process resolver, concurrency=%d)", concurrency),
+		0,
+		errLog.String(),
+		inputs,
+	)
+	if failed > 0 {
+		tr.Config["unresolved_hosts"] = failed
+	}
+	runResult.ToolRun = tr
 	return runResult, nil
 }

--- a/internal/detection/dnsx.go
+++ b/internal/detection/dnsx.go
@@ -46,7 +46,7 @@ func (d *DNSXTool) Run(ctx context.Context, inputs []string, opts RunOptions) (*
 	// errLog accumulates per-host resolution errors so the tool_run record
 	// shows the user what went wrong (NXDOMAIN, timeouts, …) rather than
 	// silently dropping hosts. dnsx isn't a subprocess so "stderr" here is
-	// synthesised.
+	// synthesized.
 	var errLog strings.Builder
 	var mu sync.Mutex
 	resolved := 0

--- a/internal/detection/helpers.go
+++ b/internal/detection/helpers.go
@@ -1,6 +1,7 @@
 package detection
 
 import (
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,5 +25,68 @@ func buildToolRun(tool DetectionTool, startedAt time.Time, status model.ToolRunS
 		Config:        map[string]interface{}{},
 		CreatedAt:     now,
 		UpdatedAt:     now,
+	}
+}
+
+// Size cap for captured log tails. Big enough to show the last few lines of
+// tool stderr for debugging, small enough to keep tool_runs.config JSON
+// blobs under a reasonable size even for chatty tools like naabu (which
+// spams per-port errors in verbose mode).
+const toolLogTailMaxBytes = 4096
+
+// tailString returns the last `max` bytes of s, prefixed with a "…\n" marker
+// when it had to truncate, so the user knows the earlier output was dropped.
+// Trimmed at the first newline after the cut to avoid mid-line slices.
+func tailString(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	cut := s[len(s)-max:]
+	if i := strings.IndexByte(cut, '\n'); i >= 0 && i < max-1 {
+		cut = cut[i+1:]
+	}
+	return "…\n" + cut
+}
+
+// inputPreview returns the first `max` elements of inputs for surfacing in
+// tool_run.config without blowing up the JSON size when a tool receives
+// thousands of targets (nuclei on a large scan can easily hit 1000+ URLs).
+func inputPreview(inputs []string, max int) []string {
+	if len(inputs) <= max {
+		out := make([]string, len(inputs))
+		copy(out, inputs)
+		return out
+	}
+	out := make([]string, max)
+	copy(out, inputs[:max])
+	return out
+}
+
+// attachExecContext stuffs exec telemetry (command line, exit code, stderr
+// tail) into tool_run.Config under a stable schema so the webui and any
+// other consumer can render logs without per-tool special casing.
+//
+// Convention of keys inside Config:
+//
+//	command        — string, space-joined argv as run
+//	exit_code      — int, process exit code (0 on success or when not a subprocess)
+//	stderr_tail    — string, tail of stderr captured during the run (may be "")
+//	input_preview  — []string, up to 8 of the inputs passed in
+//	inputs_truncated — bool, true when input_preview was cut
+func attachExecContext(tr *model.ToolRun, command string, exitCode int, stderr string, inputs []string) {
+	if tr.Config == nil {
+		tr.Config = map[string]interface{}{}
+	}
+	if command != "" {
+		tr.Config["command"] = command
+	}
+	tr.Config["exit_code"] = exitCode
+	if stderr != "" {
+		tr.Config["stderr_tail"] = tailString(strings.TrimRight(stderr, "\n"), toolLogTailMaxBytes)
+	}
+	const inputPreviewCap = 8
+	tr.Config["input_preview"] = inputPreview(inputs, inputPreviewCap)
+	if len(inputs) > inputPreviewCap {
+		tr.Config["inputs_truncated"] = true
 	}
 }

--- a/internal/detection/httpx.go
+++ b/internal/detection/httpx.go
@@ -171,10 +171,32 @@ func (h *HTTPXTool) Run(ctx context.Context, inputs []string, opts RunOptions) (
 		}
 	}
 
-	runResult.ToolRun = buildToolRun(h, startedAt, model.ToolRunCompleted, "", len(inputs), len(runResult.Assets))
-	if drops > 0 {
-		runResult.ToolRun.Config["vhost_mismatch_drops"] = drops
+	urlCount, techCount := 0, 0
+	for _, a := range runResult.Assets {
+		switch a.Type {
+		case model.AssetTypeURL:
+			urlCount++
+		case model.AssetTypeTechnology:
+			techCount++
+		}
 	}
+
+	tr := buildToolRun(h, startedAt, model.ToolRunCompleted, "", len(inputs), len(runResult.Assets))
+	tr.OutputSummary = fmt.Sprintf("Probed %d target(s) → %d live URL(s), %d technolog(ies), %d dropped (vhost mismatch)",
+		len(targets), urlCount, techCount, drops)
+	attachExecContext(&tr,
+		fmt.Sprintf("httpx (in-process HTTP prober, concurrency=%d, timeout=10s)", concurrency),
+		0,
+		"", // httpx's per-probe dropped/failure reasons already go to os.Stderr via the vhostMismatchLog writer and would be too verbose here
+		inputs,
+	)
+	if drops > 0 {
+		tr.Config["vhost_mismatch_drops"] = drops
+	}
+	tr.Config["targets_probed"] = len(targets)
+	tr.Config["url_count"] = urlCount
+	tr.Config["tech_count"] = techCount
+	runResult.ToolRun = tr
 	return runResult, nil
 }
 

--- a/internal/detection/naabu.go
+++ b/internal/detection/naabu.go
@@ -122,17 +122,21 @@ func (n *NaabuTool) Run(ctx context.Context, inputs []string, opts RunOptions) (
 
 	results, dialErrs, failuresAll := n.runScan(ctx, inputs, ports, dialTimeout, concurrency, retryCap, noBanner, br, defaultDialer)
 
-	// Log at most one stderr line per unique dial error class. Timeout and
-	// RST/refused are normal and not surfaced here; everything else (DNS
-	// failures on hostname inputs, unroutable networks, etc.) gets logged
-	// exactly once per unique (ip, err-class) so a million identical errors
-	// don't spam the user.
+	// Build a stderr-ish log from the de-duplicated dial errors so the
+	// tool_run surfaces unusual failures (DNS, unroutable net, etc.)
+	// without spamming. Timeouts and refused connections are omitted by
+	// runScan's classifyErr filter — they're routine on a port scan.
+	// Mirror each line to stderr live so the operator also sees them.
+	var errLog strings.Builder
 	for _, d := range dialErrs {
-		fmt.Fprintf(os.Stderr, "[naabu] reason=dial_error ip=%s port=%d err=%s\n", d.ip, d.port, d.err)
+		line := fmt.Sprintf("[naabu] reason=dial_error ip=%s port=%d err=%s\n", d.ip, d.port, d.err)
+		errLog.WriteString(line)
+		fmt.Fprint(os.Stderr, line)
 	}
 	_ = failuresAll // reserved for future per-IP breaker, SPEC-QA2 R12
 
 	runResult := &RunResult{}
+	openCount, filteredCount := 0, 0
 	for _, r := range results {
 		md := map[string]interface{}{
 			"port":           r.Port,
@@ -140,6 +144,11 @@ func (n *NaabuTool) Run(ctx context.Context, inputs []string, opts RunOptions) (
 			"ip":             r.IP,
 			"status":         r.Status,
 			"banner_preview": r.BannerPreview,
+		}
+		if r.Status == "filtered" {
+			filteredCount++
+		} else {
+			openCount++
 		}
 		runResult.Assets = append(runResult.Assets, model.Asset{
 			ID:        uuid.New().String(),
@@ -153,10 +162,23 @@ func (n *NaabuTool) Run(ctx context.Context, inputs []string, opts RunOptions) (
 		})
 	}
 
-	runResult.ToolRun = buildToolRun(n, startedAt, model.ToolRunCompleted, "", len(inputs), len(runResult.Assets))
-	runResult.ToolRun.Config["concurrency_halvings"] = br.halvingsCount()
-	runResult.ToolRun.Config["default_concurrency"] = defaultConcurrency
-	runResult.ToolRun.Config["effective_concurrency"] = concurrency
+	tr := buildToolRun(n, startedAt, model.ToolRunCompleted, "", len(inputs), len(runResult.Assets))
+	tr.OutputSummary = fmt.Sprintf("Probed %d host(s) × %d port(s) → %d open, %d filtered (dialTimeout=%s, concurrency=%d)",
+		len(inputs), len(ports), openCount, filteredCount, dialTimeout, concurrency)
+	attachExecContext(&tr,
+		fmt.Sprintf("naabu (in-process scanner, ports=%s, timeout=%s, concurrency=%d, banner=%v)",
+			opts.ExtraArgs["ports"], dialTimeout, concurrency, !noBanner),
+		0,
+		errLog.String(),
+		inputs,
+	)
+	tr.Config["concurrency_halvings"] = br.halvingsCount()
+	tr.Config["default_concurrency"] = defaultConcurrency
+	tr.Config["effective_concurrency"] = concurrency
+	tr.Config["ports_scanned"] = len(ports)
+	tr.Config["open_count"] = openCount
+	tr.Config["filtered_count"] = filteredCount
+	runResult.ToolRun = tr
 	return runResult, nil
 }
 

--- a/internal/detection/nuclei.go
+++ b/internal/detection/nuclei.go
@@ -31,12 +31,18 @@ func (n *NucleiTool) InputType() string     { return "urls" }
 func (n *NucleiTool) OutputTypes() []string { return []string{"finding"} }
 
 func (n *NucleiTool) Run(ctx context.Context, inputs []string, opts RunOptions) (*RunResult, error) {
+	startedAt := time.Now().UTC()
+
 	if len(inputs) == 0 {
-		return &RunResult{}, nil
+		tr := buildToolRun(n, startedAt, model.ToolRunCompleted, "", 0, 0)
+		tr.OutputSummary = "No input URLs — skipped."
+		return &RunResult{ToolRun: tr}, nil
 	}
 
 	if err := ensureNucleiTemplates(); err != nil {
-		return nil, fmt.Errorf("nuclei templates setup: %w", err)
+		tr := buildToolRun(n, startedAt, model.ToolRunFailed, err.Error(), len(inputs), 0)
+		attachExecContext(&tr, "nuclei (SDK in-process)", 1, err.Error(), inputs)
+		return &RunResult{ToolRun: tr}, fmt.Errorf("nuclei templates setup: %w", err)
 	}
 
 	severity := "critical,high,medium,low,info"
@@ -97,7 +103,9 @@ func (n *NucleiTool) Run(ctx context.Context, inputs []string, opts RunOptions) 
 
 	ne, err := nuclei.NewNucleiEngineCtx(ctx, engineOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("nuclei engine init: %w", err)
+		tr := buildToolRun(n, startedAt, model.ToolRunFailed, err.Error(), len(inputs), 0)
+		attachExecContext(&tr, "nuclei (SDK in-process)", 1, err.Error(), inputs)
+		return &RunResult{ToolRun: tr}, fmt.Errorf("nuclei engine init: %w", err)
 	}
 	defer ne.Close()
 
@@ -130,23 +138,43 @@ func (n *NucleiTool) Run(ctx context.Context, inputs []string, opts RunOptions) 
 	// Context deadline/cancellation is not a fatal error if we already have findings —
 	// nuclei may not finish all templates within the timeout, and that's OK.
 	if err != nil && len(findings) == 0 {
-		return nil, fmt.Errorf("nuclei execution: %w", err)
+		tr := buildToolRun(n, startedAt, model.ToolRunFailed, err.Error(), len(inputs), 0)
+		attachExecContext(&tr, "nuclei (SDK in-process)", 1, err.Error(), inputs)
+		return &RunResult{ToolRun: tr}, fmt.Errorf("nuclei execution: %w", err)
 	}
 
-	result := &RunResult{
-		Findings: findings,
-		ToolRun: model.ToolRun{
-			ToolName:      "nuclei",
-			Phase:         "assessment",
-			Status:        model.ToolRunCompleted,
-			FindingsCount: len(findings),
-			TargetsCount:  len(inputs),
-			Config: map[string]interface{}{
-				"filtered": skipped,
-			},
-		},
+	status := model.ToolRunCompleted
+	var runErr string
+	if err != nil {
+		// Partial run: engine hit a deadline/cancellation but we have
+		// findings. Don't flip to failed — record the warning in
+		// ErrorMessage so the UI can surface "completed with errors".
+		runErr = err.Error()
 	}
-	return result, nil
+	// Severity histogram for OutputSummary.
+	sevCount := map[string]int{}
+	for _, f := range findings {
+		sevCount[string(f.Severity)]++
+	}
+
+	tr := buildToolRun(n, startedAt, status, runErr, len(inputs), len(findings))
+	tr.OutputSummary = fmt.Sprintf("Executed nuclei against %d target(s) → %d finding(s) persisted (%d filtered as noise). Severity: critical=%d high=%d medium=%d low=%d info=%d.",
+		len(inputs), len(findings), skipped,
+		sevCount["critical"], sevCount["high"], sevCount["medium"], sevCount["low"], sevCount["info"])
+	attachExecContext(&tr,
+		fmt.Sprintf("nuclei (SDK in-process, severity=%s, profile=%s, rate_limit=%d/s, timeout=%ds)",
+			severity, profile, rateLimit, timeout),
+		0,
+		runErr,
+		inputs,
+	)
+	tr.Config["filtered"] = skipped
+	tr.Config["profile"] = profile
+	tr.Config["severity_filter"] = severity
+	tr.Config["rate_limit_per_sec"] = rateLimit
+	tr.Config["template_tags"] = filters.Tags
+
+	return &RunResult{Findings: findings, ToolRun: tr}, nil
 }
 
 // isValidFinding checks if a nuclei result represents a real finding, not noise.

--- a/internal/detection/subfinder.go
+++ b/internal/detection/subfinder.go
@@ -39,15 +39,30 @@ func (s *SubfinderTool) Run(ctx context.Context, inputs []string, opts RunOption
 
 	if !s.Available() {
 		tr := buildToolRun(s, startedAt, model.ToolRunSkipped, "subfinder binary not found in PATH", len(inputs), 0)
+		attachExecContext(&tr, "", 0, "", inputs)
 		return &RunResult{ToolRun: tr}, nil
 	}
 
 	result := &RunResult{}
+	// Accumulate stderr and last-run command across per-domain executions
+	// so the tool_run record shows what actually ran end-to-end even when
+	// subfinder is invoked once per input.
+	var stderrAcc strings.Builder
+	var lastCmd string
+	var lastExit int
 
 	for _, domain := range inputs {
-		subs, err := s.enumerate(ctx, domain, opts)
+		subs, cmdStr, stderrTail, exitCode, err := s.enumerate(ctx, domain, opts)
+		lastCmd = cmdStr
+		lastExit = exitCode
+		if stderrTail != "" {
+			stderrAcc.WriteString(stderrTail)
+			stderrAcc.WriteByte('\n')
+		}
 		if err != nil {
-			result.ToolRun = buildToolRun(s, startedAt, model.ToolRunFailed, err.Error(), len(inputs), 0)
+			tr := buildToolRun(s, startedAt, model.ToolRunFailed, err.Error(), len(inputs), 0)
+			attachExecContext(&tr, cmdStr, exitCode, stderrAcc.String(), inputs)
+			result.ToolRun = tr
 			return result, nil
 		}
 
@@ -68,11 +83,14 @@ func (s *SubfinderTool) Run(ctx context.Context, inputs []string, opts RunOption
 		}
 	}
 
-	result.ToolRun = buildToolRun(s, startedAt, model.ToolRunCompleted, "", len(inputs), len(result.Assets))
+	tr := buildToolRun(s, startedAt, model.ToolRunCompleted, "", len(inputs), len(result.Assets))
+	tr.OutputSummary = fmt.Sprintf("Discovered %d subdomain(s) across %d input domain(s)", len(result.Assets), len(inputs))
+	attachExecContext(&tr, lastCmd, lastExit, stderrAcc.String(), inputs)
+	result.ToolRun = tr
 	return result, nil
 }
 
-func (s *SubfinderTool) enumerate(ctx context.Context, domain string, opts RunOptions) (map[string]struct{}, error) {
+func (s *SubfinderTool) enumerate(ctx context.Context, domain string, opts RunOptions) (map[string]struct{}, string, string, int, error) {
 	args := []string{
 		"-d", domain,
 		"-silent",
@@ -95,14 +113,19 @@ func (s *SubfinderTool) enumerate(ctx context.Context, domain string, opts RunOp
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	if err := cmd.Run(); err != nil {
-		// If we got some output, parse it anyway
+	cmdStr := "subfinder " + strings.Join(args, " ")
+	runErr := cmd.Run()
+	exitCode := 0
+	if runErr != nil {
+		exitCode = cmd.ProcessState.ExitCode()
+		// If we got some output, parse it anyway — subfinder sometimes
+		// fails the overall process but produces partial results.
 		if stdout.Len() == 0 {
-			return nil, fmt.Errorf("subfinder failed: %s", stderr.String())
+			return nil, cmdStr, stderr.String(), exitCode, fmt.Errorf("subfinder failed: %s", stderr.String())
 		}
 	}
 
-	return ParseSubfinderOutput(stdout.Bytes()), nil
+	return ParseSubfinderOutput(stdout.Bytes()), cmdStr, stderr.String(), exitCode, nil
 }
 
 // ParseSubfinderOutput parses subfinder text output (one subdomain per line).

--- a/internal/model/asset.go
+++ b/internal/model/asset.go
@@ -2,6 +2,13 @@ package model
 
 import "time"
 
+// AssetType identifies what kind of entity an Asset represents.
+//
+// The set of constants below is the vocabulary currently produced by built-in
+// detection tools. It is intentionally open-ended: a new tool may introduce a
+// new AssetType constant without requiring a SQL migration — the database
+// column is unconstrained and validation happens in Go. LLM consumers must
+// tolerate unknown AssetType strings.
 type AssetType string
 
 const (
@@ -15,6 +22,21 @@ const (
 	AssetTypeService    AssetType = "service"
 )
 
+// KnownAssetTypes is the vocabulary documented in the agent-spec. Used by
+// spec generation and by tests that want to iterate over the built-in set.
+// New detection tools can emit AssetTypes outside this list; storage does
+// not reject them.
+var KnownAssetTypes = []AssetType{
+	AssetTypeDomain,
+	AssetTypeSubdomain,
+	AssetTypeIPv4,
+	AssetTypeIPv6,
+	AssetTypePort,
+	AssetTypeURL,
+	AssetTypeTechnology,
+	AssetTypeService,
+}
+
 type AssetStatus string
 
 const (
@@ -25,6 +47,17 @@ const (
 	AssetStatusInactive    AssetStatus = "inactive"
 	AssetStatusIgnored     AssetStatus = "ignored"
 )
+
+// AssetStatusIsLive reports whether an asset status represents an asset
+// currently present on the target. Used by TargetState counting so that
+// disappeared/inactive/ignored assets don't inflate the current-state view.
+func AssetStatusIsLive(s AssetStatus) bool {
+	switch s {
+	case AssetStatusActive, AssetStatusNew, AssetStatusReturned:
+		return true
+	}
+	return false
+}
 
 type Asset struct {
 	ID        string         `json:"id"`

--- a/internal/model/finding.go
+++ b/internal/model/finding.go
@@ -38,7 +38,7 @@ type Finding struct {
 	// before migration 003 that were never re-observed.
 	FirstSeenScanID string `json:"first_seen_scan_id,omitempty"`
 
-	TemplateID string `json:"template_id"`
+	TemplateID   string        `json:"template_id"`
 	TemplateName string        `json:"template_name"`
 	Severity     Severity      `json:"severity"`
 	Title        string        `json:"title"`

--- a/internal/model/finding.go
+++ b/internal/model/finding.go
@@ -23,10 +23,22 @@ const (
 )
 
 type Finding struct {
-	ID           string        `json:"id"`
-	AssetID      string        `json:"asset_id"`
-	ScanID       string        `json:"scan_id,omitempty"`
-	TemplateID   string        `json:"template_id"`
+	ID string `json:"id"`
+
+	AssetID string `json:"asset_id"`
+
+	// ScanID is the id of the most recent scan that observed this finding.
+	// Updated on every UpsertFinding so that "findings observed in scan X"
+	// (COUNT WHERE scan_id=X) is a meaningful query. To recover the
+	// originating scan, use FirstSeenScanID.
+	ScanID string `json:"scan_id,omitempty"`
+
+	// FirstSeenScanID is the id of the scan that first discovered this
+	// finding. Immutable after creation. Nullable for findings created
+	// before migration 003 that were never re-observed.
+	FirstSeenScanID string `json:"first_seen_scan_id,omitempty"`
+
+	TemplateID string `json:"template_id"`
 	TemplateName string        `json:"template_name"`
 	Severity     Severity      `json:"severity"`
 	Title        string        `json:"title"`

--- a/internal/model/scan.go
+++ b/internal/model/scan.go
@@ -20,32 +20,114 @@ const (
 	ScanStatusCancelled ScanStatus = "cancelled"
 )
 
-type ScanStats struct {
-	SubdomainsFound  int `json:"subdomains_found"`
-	IPsResolved      int `json:"ips_resolved"`
-	PortsScanned     int `json:"ports_scanned"`
-	OpenPorts        int `json:"open_ports"`
-	HTTPProbed       int `json:"http_probed"`
-	TechDetected     int `json:"tech_detected"`
-	FindingsTotal    int `json:"findings_total"`
-	FindingsCritical int `json:"findings_critical"`
-	FindingsHigh     int `json:"findings_high"`
-	FindingsMedium   int `json:"findings_medium"`
-	FindingsLow      int `json:"findings_low"`
-	FindingsInfo     int `json:"findings_info"`
+// RemediationStatus mirrors the remediations table constraint. Declared here
+// so TargetState can aggregate by status even though the storage layer does
+// not yet expose remediation CRUD (placeholder until remediation tooling
+// lands — see `internal/remediation/`). The vocabulary is open for counting
+// purposes: any status string appears as a key in TargetState.Remediations.
+type RemediationStatus string
+
+const (
+	RemediationStatusPlanned    RemediationStatus = "planned"
+	RemediationStatusApproved   RemediationStatus = "approved"
+	RemediationStatusRunning    RemediationStatus = "running"
+	RemediationStatusCompleted  RemediationStatus = "completed"
+	RemediationStatusFailed     RemediationStatus = "failed"
+	RemediationStatusRolledBack RemediationStatus = "rolled_back"
+)
+
+// TargetState is the snapshot of a target's observed state at the moment a
+// scan completes. Source of truth: queries against the assets, findings, and
+// remediations tables filtered by target_id. TargetState answers "what does
+// the target look like now?" — distinct from ScanDelta (what this scan
+// changed) and ScanWork (what this scan did).
+//
+// The map-based fields are intentionally open: a new detection tool that
+// emits a new AssetType automatically appears as a key in AssetsByType
+// without any schema, struct, or agent-spec structural change. LLM consumers
+// must tolerate unknown keys.
+type TargetState struct {
+	// AssetsByType is the count of active+new+returned assets per AssetType.
+	// Disappeared/inactive/ignored assets are excluded — TargetState reflects
+	// what currently exists, not historical presence.
+	AssetsByType map[AssetType]int `json:"assets_by_type"`
+	AssetsTotal  int               `json:"assets_total"`
+
+	// PortsByStatus buckets port_service assets by metadata.status
+	// ("open", "filtered", anything a future scanner emits). Empty when the
+	// target has no port_service assets.
+	PortsByStatus map[string]int `json:"ports_by_status,omitempty"`
+
+	// FindingsOpen counts findings with status=open by severity. FindingsByStatus
+	// counts findings across every status bucket (open/acknowledged/resolved/…).
+	FindingsOpen      map[Severity]int      `json:"findings_open"`
+	FindingsOpenTotal int                   `json:"findings_open_total"`
+	FindingsByStatus  map[FindingStatus]int `json:"findings_by_status"`
+
+	// Remediations counts remediation records by status. Empty until the
+	// remediation storage layer is implemented; the field exists in the
+	// contract so LLM consumers can assume stable shape.
+	Remediations map[RemediationStatus]int `json:"remediations"`
 }
 
+// ScanDelta captures what changed in this scan versus the previous state of
+// the target. Source: the asset_changes table (scoped by scan_id) plus
+// finding-status transitions derived from first_seen/last_seen timestamps.
+//
+// Delta answers "what did this scan discover or resolve?" — not "what does
+// the target look like now?" (that's TargetState).
+type ScanDelta struct {
+	NewAssets         map[AssetType]int `json:"new_assets"`
+	DisappearedAssets map[AssetType]int `json:"disappeared_assets"`
+	ModifiedAssets    map[AssetType]int `json:"modified_assets"`
+
+	NewFindings      map[Severity]int `json:"new_findings"`
+	ResolvedFindings map[Severity]int `json:"resolved_findings"`
+	ReturnedFindings map[Severity]int `json:"returned_findings"`
+
+	// IsBaseline is true when this is the first scan of a target: all
+	// discovered assets appear as "new" but they do not represent actual
+	// additions — the delta is mostly informational.
+	IsBaseline bool `json:"is_baseline"`
+}
+
+// ScanWork records what the scan did — telemetry of the execution itself,
+// independent of what it observed. Source: the tool_runs table filtered by
+// scan_id plus scan timing.
+type ScanWork struct {
+	DurationMs   int64    `json:"duration_ms"`
+	ToolsRun     int      `json:"tools_run"`
+	ToolsFailed  int      `json:"tools_failed"`
+	ToolsSkipped int      `json:"tools_skipped"`
+	PhasesRun    []string `json:"phases_run"`
+
+	// RawEmissions is the sum of findings emitted by tools before storage
+	// dedup — useful for debugging tool noise (e.g. nuclei emitted 50
+	// findings but storage merged them into 3 unique rows).
+	RawEmissions int `json:"raw_emissions"`
+}
+
+// Scan describes one pipeline execution against a target. The three
+// aggregate fields are populated at the end of the run:
+//   - TargetState: snapshot of the target observed by this scan.
+//   - Delta:       what this scan changed relative to prior state.
+//   - Work:        telemetry of the execution itself.
+//
+// These three concepts replace the legacy ScanStats struct which conflated
+// state, delta, and work into a single mutable accumulator.
 type Scan struct {
-	ID         string     `json:"id"`
-	TargetID   string     `json:"target_id"`
-	Type       ScanType   `json:"type"`
-	Status     ScanStatus `json:"status"`
-	Phase      string     `json:"phase"`
-	Progress   float32    `json:"progress"`
-	Stats      ScanStats  `json:"stats"`
-	StartedAt  *time.Time `json:"started_at,omitempty"`
-	FinishedAt *time.Time `json:"finished_at,omitempty"`
-	Error      string     `json:"error,omitempty"`
-	CreatedAt  time.Time  `json:"created_at"`
-	UpdatedAt  time.Time  `json:"updated_at"`
+	ID          string      `json:"id"`
+	TargetID    string      `json:"target_id"`
+	Type        ScanType    `json:"type"`
+	Status      ScanStatus  `json:"status"`
+	Phase       string      `json:"phase"`
+	Progress    float32     `json:"progress"`
+	TargetState TargetState `json:"target_state"`
+	Delta       ScanDelta   `json:"delta"`
+	Work        ScanWork    `json:"work"`
+	StartedAt   *time.Time  `json:"started_at,omitempty"`
+	FinishedAt  *time.Time  `json:"finished_at,omitempty"`
+	Error       string      `json:"error,omitempty"`
+	CreatedAt   time.Time   `json:"created_at"`
+	UpdatedAt   time.Time   `json:"updated_at"`
 }

--- a/internal/pipeline/diff.go
+++ b/internal/pipeline/diff.go
@@ -277,64 +277,28 @@ func ApplyStatusChanges(ctx context.Context, store storage.Store, changes []mode
 	return nil
 }
 
-// ChangeSummary holds aggregated change counts for display.
-type ChangeSummary struct {
-	NewAssets           int
-	DisappearedAssets   int
-	ModifiedAssets      int
-	NewFindings         int
-	ResolvedFindings    int
-	IsBaseline          bool
-	TotalBaselineAssets int
-	NewByType           map[string]int
-	CriticalModified    int
-}
-
-// BuildChangeSummary aggregates changes for display.
-func BuildChangeSummary(changes []model.AssetChange, newFindings, resolvedFindings int) ChangeSummary {
-	s := ChangeSummary{
-		NewFindings:      newFindings,
-		ResolvedFindings: resolvedFindings,
-		NewByType:        make(map[string]int),
-	}
-
-	for _, c := range changes {
-		if c.Baseline {
-			s.IsBaseline = true
-			s.TotalBaselineAssets++
-			continue
-		}
-		switch c.ChangeType {
-		case model.ChangeTypeAppeared:
-			s.NewAssets++
-			s.NewByType[c.AssetType]++
-		case model.ChangeTypeDisappeared:
-			s.DisappearedAssets++
-		case model.ChangeTypeModified:
-			s.ModifiedAssets++
-			if c.Significance == model.SignificanceCritical {
-				s.CriticalModified++
-			}
-		}
-	}
-	return s
-}
-
-// PrintChangeSummary prints the change summary to stderr with colored markers.
-func PrintChangeSummary(summary ChangeSummary) {
+// PrintChangeSummary prints a human-readable summary of the scan delta to
+// stderr. Source of truth is the ScanDelta computed by FinalizeScanDelta —
+// there is no separate ChangeSummary struct; the delta IS the summary.
+func PrintChangeSummary(delta model.ScanDelta) {
 	success := color.RGB(0, 229, 153) // Surfbot Signal Green #00E599
 	errColor := color.New(color.FgRed)
 	warn := color.New(color.FgYellow)
 	muted := color.New(color.Faint)
 	bold := color.New(color.Bold)
 
-	if summary.IsBaseline {
-		muted.Fprintf(os.Stderr, "\nBASELINE SCAN — %d assets discovered. Run again to detect changes.\n", summary.TotalBaselineAssets)
+	newAssetsTotal := sumIntMap(delta.NewAssets)
+	disAssetsTotal := sumIntMap(delta.DisappearedAssets)
+	modAssetsTotal := sumIntMap(delta.ModifiedAssets)
+	newFindingsTotal := sumSevMap(delta.NewFindings)
+	resolvedFindingsTotal := sumSevMap(delta.ResolvedFindings)
+
+	if delta.IsBaseline {
+		muted.Fprintf(os.Stderr, "\nBASELINE SCAN — run again to detect changes.\n")
 		return
 	}
 
-	total := summary.NewAssets + summary.DisappearedAssets + summary.ModifiedAssets + summary.NewFindings + summary.ResolvedFindings
-	if total == 0 {
+	if newAssetsTotal+disAssetsTotal+modAssetsTotal+newFindingsTotal+resolvedFindingsTotal == 0 {
 		muted.Fprintf(os.Stderr, "\nNo changes since last scan.\n")
 		return
 	}
@@ -342,34 +306,74 @@ func PrintChangeSummary(summary ChangeSummary) {
 	fmt.Fprintln(os.Stderr, "")
 	bold.Fprintln(os.Stderr, "CHANGES SINCE LAST SCAN")
 
-	if summary.NewAssets > 0 {
-		parts := []string{}
-		for typ, count := range summary.NewByType {
-			parts = append(parts, fmt.Sprintf("%d %s", count, pluralize(typ, count)))
-		}
-		detail := ""
-		if len(parts) > 0 {
-			detail = " (" + strings.Join(parts, ", ") + ")"
-		}
-		success.Fprintf(os.Stderr, "  + %d new %s%s\n", summary.NewAssets, pluralize("asset", summary.NewAssets), detail)
+	if newAssetsTotal > 0 {
+		success.Fprintf(os.Stderr, "  + %d new %s%s\n",
+			newAssetsTotal, pluralize("asset", newAssetsTotal), formatTypeBreakdown(delta.NewAssets))
 	}
-	if summary.DisappearedAssets > 0 {
-		errColor.Fprintf(os.Stderr, "  - %d disappeared %s\n", summary.DisappearedAssets, pluralize("asset", summary.DisappearedAssets))
+	if disAssetsTotal > 0 {
+		errColor.Fprintf(os.Stderr, "  - %d disappeared %s%s\n",
+			disAssetsTotal, pluralize("asset", disAssetsTotal), formatTypeBreakdown(delta.DisappearedAssets))
 	}
-	if summary.ModifiedAssets > 0 {
-		detail := ""
-		if summary.CriticalModified > 0 {
-			detail = fmt.Sprintf(" (%d critical)", summary.CriticalModified)
-		}
-		warn.Fprintf(os.Stderr, "  ~ %d modified %s%s\n", summary.ModifiedAssets, pluralize("asset", summary.ModifiedAssets), detail)
+	if modAssetsTotal > 0 {
+		warn.Fprintf(os.Stderr, "  ~ %d modified %s%s\n",
+			modAssetsTotal, pluralize("asset", modAssetsTotal), formatTypeBreakdown(delta.ModifiedAssets))
 	}
-	if summary.NewFindings > 0 {
-		success.Fprintf(os.Stderr, "  + %d new %s\n", summary.NewFindings, pluralize("finding", summary.NewFindings))
+	if newFindingsTotal > 0 {
+		success.Fprintf(os.Stderr, "  + %d new %s%s\n",
+			newFindingsTotal, pluralize("finding", newFindingsTotal), formatSevBreakdown(delta.NewFindings))
 	}
-	if summary.ResolvedFindings > 0 {
+	if resolvedFindingsTotal > 0 {
 		successMuted := color.RGB(0, 229, 153).Add(color.Faint) // Signal Green + dim
-		successMuted.Fprintf(os.Stderr, "  ✓ %d resolved %s\n", summary.ResolvedFindings, pluralize("finding", summary.ResolvedFindings))
+		successMuted.Fprintf(os.Stderr, "  ✓ %d resolved %s\n",
+			resolvedFindingsTotal, pluralize("finding", resolvedFindingsTotal))
 	}
+}
+
+func sumIntMap(m map[model.AssetType]int) int {
+	total := 0
+	for _, n := range m {
+		total += n
+	}
+	return total
+}
+
+func sumSevMap(m map[model.Severity]int) int {
+	total := 0
+	for _, n := range m {
+		total += n
+	}
+	return total
+}
+
+// formatTypeBreakdown renders " (2 subdomains, 1 url)" etc. Returns "" when
+// the map is empty or has exactly one key (the total is already shown).
+func formatTypeBreakdown(m map[model.AssetType]int) string {
+	if len(m) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(m))
+	for typ, n := range m {
+		parts = append(parts, fmt.Sprintf("%d %s", n, pluralize(string(typ), n)))
+	}
+	return " (" + strings.Join(parts, ", ") + ")"
+}
+
+// formatSevBreakdown renders " (1 critical, 3 high)" ordered by severity.
+func formatSevBreakdown(m map[model.Severity]int) string {
+	if len(m) == 0 {
+		return ""
+	}
+	order := []model.Severity{model.SeverityCritical, model.SeverityHigh, model.SeverityMedium, model.SeverityLow, model.SeverityInfo}
+	parts := make([]string, 0, len(m))
+	for _, sev := range order {
+		if n := m[sev]; n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", n, sev))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(parts, ", ") + ")"
 }
 
 func pluralize(word string, count int) string {

--- a/internal/pipeline/diff.go
+++ b/internal/pipeline/diff.go
@@ -280,6 +280,8 @@ func ApplyStatusChanges(ctx context.Context, store storage.Store, changes []mode
 // PrintChangeSummary prints a human-readable summary of the scan delta to
 // stderr. Source of truth is the ScanDelta computed by FinalizeScanDelta —
 // there is no separate ChangeSummary struct; the delta IS the summary.
+//
+//nolint:errcheck // all stderr writes below are unrecoverable and not actionable
 func PrintChangeSummary(delta model.ScanDelta) {
 	success := color.RGB(0, 229, 153) // Surfbot Signal Green #00E599
 	errColor := color.New(color.FgRed)
@@ -324,6 +326,7 @@ func PrintChangeSummary(delta model.ScanDelta) {
 	}
 	if resolvedFindingsTotal > 0 {
 		successMuted := color.RGB(0, 229, 153).Add(color.Faint) // Signal Green + dim
+		//nolint:errcheck // stderr write errors are unrecoverable and not actionable
 		successMuted.Fprintf(os.Stderr, "  ✓ %d resolved %s\n",
 			resolvedFindingsTotal, pluralize("finding", resolvedFindingsTotal))
 	}

--- a/internal/pipeline/diff_integration_test.go
+++ b/internal/pipeline/diff_integration_test.go
@@ -12,6 +12,22 @@ import (
 	"github.com/surfbot-io/surfbot-agent/internal/storage"
 )
 
+func sumAssetTypeMap(m map[model.AssetType]int) int {
+	total := 0
+	for _, n := range m {
+		total += n
+	}
+	return total
+}
+
+func sumSeverityMap(m map[model.Severity]int) int {
+	total := 0
+	for _, n := range m {
+		total += n
+	}
+	return total
+}
+
 func TestDiffIntegrationInPipeline(t *testing.T) {
 	s := newTestStore(t)
 	target := createTarget(t, s, "example.com")
@@ -40,9 +56,9 @@ func TestDiffIntegrationInPipeline(t *testing.T) {
 	require.NoError(t, err)
 
 	// First scan should be baseline
-	require.NotNil(t, result1.DiffSummary)
-	assert.True(t, result1.DiffSummary.IsBaseline)
-	assert.Equal(t, 3, result1.DiffSummary.TotalBaselineAssets)
+	assert.True(t, result1.Delta.IsBaseline)
+	// Baseline: 3 assets discovered (2 subs + 1 ip)
+	assert.Equal(t, 3, result1.TargetState.AssetsTotal)
 
 	// Run 2: different assets (sub1 still present, sub2 gone, sub3 new)
 	tools2 := []detection.DetectionTool{
@@ -67,10 +83,9 @@ func TestDiffIntegrationInPipeline(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should detect changes
-	require.NotNil(t, result2.DiffSummary)
-	assert.False(t, result2.DiffSummary.IsBaseline)
-	assert.True(t, result2.DiffSummary.NewAssets > 0, "should have new assets")
-	assert.True(t, result2.DiffSummary.DisappearedAssets > 0, "should have disappeared assets")
+	assert.False(t, result2.Delta.IsBaseline)
+	assert.NotZero(t, sumAssetTypeMap(result2.Delta.NewAssets), "should have new assets")
+	assert.NotZero(t, sumAssetTypeMap(result2.Delta.DisappearedAssets), "should have disappeared assets")
 
 	// Verify changes were persisted
 	changes, err := s.ListAssetChanges(ctx, storage.AssetChangeListOptions{ScanID: result2.ScanID, Limit: 100})
@@ -171,8 +186,7 @@ func TestFindingAutoResolveInPipeline(t *testing.T) {
 	require.NoError(t, err)
 
 	// Finding should now be auto-resolved
-	require.NotNil(t, result2.DiffSummary)
-	assert.True(t, result2.DiffSummary.ResolvedFindings > 0, "should have resolved findings")
+	assert.NotZero(t, sumSeverityMap(result2.Delta.ResolvedFindings), "should have resolved findings")
 
 	// Check in DB
 	resolved, _ := s.ListFindings(ctx, storage.FindingListOptions{Status: model.FindingStatusResolved, Limit: 10})

--- a/internal/pipeline/diff_test.go
+++ b/internal/pipeline/diff_test.go
@@ -246,7 +246,7 @@ func TestNormalizeAssetStatuses(t *testing.T) {
 
 // Note: BuildChangeSummary / ChangeSummary were removed — ScanDelta is now
 // computed directly by FinalizeScanDelta from DB ground truth (see
-// finalize.go). Equivalent behavioural coverage is in diff_integration_test.go
+// finalize.go). Equivalent behavioral coverage is in diff_integration_test.go
 // (TestDiffIntegrationInPipeline, TestFindingAutoResolveInPipeline) which
 // asserts ScanDelta fields end-to-end through a real pipeline run.
 

--- a/internal/pipeline/diff_test.go
+++ b/internal/pipeline/diff_test.go
@@ -244,36 +244,11 @@ func TestNormalizeAssetStatuses(t *testing.T) {
 	}
 }
 
-func TestBuildChangeSummary(t *testing.T) {
-	changes := []model.AssetChange{
-		{ChangeType: model.ChangeTypeAppeared, AssetType: "subdomain"},
-		{ChangeType: model.ChangeTypeAppeared, AssetType: "subdomain"},
-		{ChangeType: model.ChangeTypeAppeared, AssetType: "ipv4"},
-		{ChangeType: model.ChangeTypeDisappeared, AssetType: "subdomain"},
-		{ChangeType: model.ChangeTypeModified, Significance: model.SignificanceCritical},
-	}
-
-	summary := BuildChangeSummary(changes, 2, 1)
-	assert.Equal(t, 3, summary.NewAssets)
-	assert.Equal(t, 1, summary.DisappearedAssets)
-	assert.Equal(t, 1, summary.ModifiedAssets)
-	assert.Equal(t, 1, summary.CriticalModified)
-	assert.Equal(t, 2, summary.NewFindings)
-	assert.Equal(t, 1, summary.ResolvedFindings)
-	assert.False(t, summary.IsBaseline)
-}
-
-func TestBuildChangeSummaryBaseline(t *testing.T) {
-	changes := []model.AssetChange{
-		{ChangeType: model.ChangeTypeAppeared, Baseline: true},
-		{ChangeType: model.ChangeTypeAppeared, Baseline: true},
-	}
-
-	summary := BuildChangeSummary(changes, 0, 0)
-	assert.True(t, summary.IsBaseline)
-	assert.Equal(t, 2, summary.TotalBaselineAssets)
-	assert.Equal(t, 0, summary.NewAssets)
-}
+// Note: BuildChangeSummary / ChangeSummary were removed — ScanDelta is now
+// computed directly by FinalizeScanDelta from DB ground truth (see
+// finalize.go). Equivalent behavioural coverage is in diff_integration_test.go
+// (TestDiffIntegrationInPipeline, TestFindingAutoResolveInPipeline) which
+// asserts ScanDelta fields end-to-end through a real pipeline run.
 
 // --- Helpers ---
 

--- a/internal/pipeline/finalize.go
+++ b/internal/pipeline/finalize.go
@@ -186,21 +186,27 @@ func FinalizeScanWork(
 		work.PhasesRun = append(work.PhasesRun, p)
 	}
 	sort.Slice(work.PhasesRun, func(i, j int) bool {
-		a, b := phaseFirstSeen[work.PhasesRun[i]], phaseFirstSeen[work.PhasesRun[j]]
-		// Phases with zero timestamps fall back to their DB insert order
-		// (first-seen ordering within the tool_runs rows), which is itself
-		// pipeline order because recordToolRun is called inline during the
-		// loop.
-		if a.IsZero() && b.IsZero() {
-			return phaseInsertOrder[work.PhasesRun[i]] < phaseInsertOrder[work.PhasesRun[j]]
-		}
-		if a.IsZero() {
+		pi, pj := work.PhasesRun[i], work.PhasesRun[j]
+		a, b := phaseFirstSeen[pi], phaseFirstSeen[pj]
+		// Zero-timestamp phases fall back to DB insert order (pipeline
+		// order, since recordToolRun is called inline during the loop).
+		switch {
+		case a.IsZero() && b.IsZero():
+			return phaseInsertOrder[pi] < phaseInsertOrder[pj]
+		case a.IsZero():
 			return false
-		}
-		if b.IsZero() {
+		case b.IsZero():
 			return true
+		case a.Equal(b):
+			// Timestamps collide at second-level granularity in SQLite
+			// (RFC3339 format). Without an explicit tiebreaker sort.Slice
+			// is non-deterministic and the test hits a different order
+			// under -race than without. Fall back to pipeline insert
+			// order so the output is stable regardless of scheduling.
+			return phaseInsertOrder[pi] < phaseInsertOrder[pj]
+		default:
+			return a.Before(b)
 		}
-		return a.Before(b)
 	})
 
 	return work, nil

--- a/internal/pipeline/finalize.go
+++ b/internal/pipeline/finalize.go
@@ -146,7 +146,14 @@ func FinalizeScanWork(
 		return work, fmt.Errorf("work tool_runs: %w", err)
 	}
 
-	phaseSet := make(map[string]struct{})
+	// Track the earliest started_at per phase so we can emit PhasesRun in
+	// actual execution order, not alphabetic. Alphabetic sort would
+	// suggest to an LLM consumer that nuclei ran before subfinder, which
+	// is obviously wrong. Phases with no timestamp fall back to the
+	// iteration order of the runs slice (which is DB insertion order).
+	phaseFirstSeen := make(map[string]time.Time)
+	phaseInsertOrder := make(map[string]int)
+	insertOrder := 0
 	for _, r := range runs {
 		work.ToolsRun++
 		switch r.Status {
@@ -156,16 +163,45 @@ func FinalizeScanWork(
 			work.ToolsSkipped++
 		}
 		work.RawEmissions += r.FindingsCount
-		if r.Phase != "" {
-			phaseSet[r.Phase] = struct{}{}
+		if r.Phase == "" {
+			continue
+		}
+		existing, seen := phaseFirstSeen[r.Phase]
+		if !seen {
+			phaseFirstSeen[r.Phase] = r.StartedAt
+			phaseInsertOrder[r.Phase] = insertOrder
+			insertOrder++
+			continue
+		}
+		// Keep the earliest timestamp for a phase in case multiple tools
+		// share a phase (future-proofing: today each phase has one tool,
+		// but the model doesn't enforce that).
+		if !r.StartedAt.IsZero() && (existing.IsZero() || r.StartedAt.Before(existing)) {
+			phaseFirstSeen[r.Phase] = r.StartedAt
 		}
 	}
 
-	work.PhasesRun = make([]string, 0, len(phaseSet))
-	for p := range phaseSet {
+	work.PhasesRun = make([]string, 0, len(phaseFirstSeen))
+	for p := range phaseFirstSeen {
 		work.PhasesRun = append(work.PhasesRun, p)
 	}
-	sort.Strings(work.PhasesRun)
+	sort.Slice(work.PhasesRun, func(i, j int) bool {
+		a, b := phaseFirstSeen[work.PhasesRun[i]], phaseFirstSeen[work.PhasesRun[j]]
+		// Phases with zero timestamps fall back to their DB insert order
+		// (first-seen ordering within the tool_runs rows), which is itself
+		// pipeline order because recordToolRun is called inline during the
+		// loop.
+		if a.IsZero() && b.IsZero() {
+			return phaseInsertOrder[work.PhasesRun[i]] < phaseInsertOrder[work.PhasesRun[j]]
+		}
+		if a.IsZero() {
+			return false
+		}
+		if b.IsZero() {
+			return true
+		}
+		return a.Before(b)
+	})
 
 	return work, nil
 }

--- a/internal/pipeline/finalize.go
+++ b/internal/pipeline/finalize.go
@@ -1,0 +1,171 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// FinalizeTargetState queries the database to build a snapshot of the
+// target's observed state at the moment the scan completed. Source of
+// truth: assets, findings (all rows for the target); no in-memory counters.
+//
+// The returned TargetState is self-consistent with what `asset list` and
+// `finding list` subcommands report — re-running those commands immediately
+// after persistence yields the same counts.
+func FinalizeTargetState(ctx context.Context, store storage.Store, targetID string) (model.TargetState, error) {
+	state := model.TargetState{
+		AssetsByType:     make(map[model.AssetType]int),
+		FindingsOpen:     make(map[model.Severity]int),
+		FindingsByStatus: make(map[model.FindingStatus]int),
+		Remediations:     make(map[model.RemediationStatus]int),
+	}
+
+	byType, err := store.CountAssetsByTypeForTarget(ctx, targetID)
+	if err != nil {
+		return state, fmt.Errorf("target_state assets_by_type: %w", err)
+	}
+	state.AssetsByType = byType
+	for _, n := range byType {
+		state.AssetsTotal += n
+	}
+
+	// ports_by_status is only populated when the target actually has port
+	// assets — keep the map nil / omitempty on the JSON side otherwise.
+	if byType[model.AssetTypePort] > 0 {
+		ports, err := store.CountPortsByStatusForTarget(ctx, targetID)
+		if err != nil {
+			return state, fmt.Errorf("target_state ports_by_status: %w", err)
+		}
+		state.PortsByStatus = ports
+	}
+
+	open, err := store.CountFindingsBySeverityForTarget(ctx, targetID, model.FindingStatusOpen)
+	if err != nil {
+		return state, fmt.Errorf("target_state findings_open: %w", err)
+	}
+	state.FindingsOpen = open
+	for _, n := range open {
+		state.FindingsOpenTotal += n
+	}
+
+	byStatus, err := store.CountFindingsByStatusForTarget(ctx, targetID)
+	if err != nil {
+		return state, fmt.Errorf("target_state findings_by_status: %w", err)
+	}
+	state.FindingsByStatus = byStatus
+
+	// Remediations aggregate is an empty map for now — remediation storage
+	// is not yet implemented. The field stays in the contract so future
+	// wiring is purely additive.
+	return state, nil
+}
+
+// FinalizeScanDelta derives ScanDelta from the asset_changes table and the
+// already-computed finding change lists (newFindings, resolvedFindings are
+// computed during the diff phase; pass them in so we don't re-run the diff).
+//
+// The returned ScanDelta reflects only what this scan actually changed —
+// baseline scans are reported as IsBaseline=true with empty change buckets.
+func FinalizeScanDelta(
+	ctx context.Context,
+	store storage.Store,
+	scanID string,
+	newFindings []model.Finding,
+	resolvedFindings []model.Finding,
+) (model.ScanDelta, error) {
+	delta := model.ScanDelta{
+		NewAssets:         make(map[model.AssetType]int),
+		DisappearedAssets: make(map[model.AssetType]int),
+		ModifiedAssets:    make(map[model.AssetType]int),
+		NewFindings:       make(map[model.Severity]int),
+		ResolvedFindings:  make(map[model.Severity]int),
+		ReturnedFindings:  make(map[model.Severity]int),
+	}
+
+	isBaseline, err := store.ScanIsBaseline(ctx, scanID)
+	if err != nil {
+		return delta, fmt.Errorf("delta is_baseline: %w", err)
+	}
+	delta.IsBaseline = isBaseline
+
+	// Baseline scans have every asset flagged appeared+baseline; we don't
+	// bubble those into new_assets because they're not a true delta.
+	if !isBaseline {
+		changeCounts, err := store.AssetChangeCountsForScan(ctx, scanID)
+		if err != nil {
+			return delta, fmt.Errorf("delta asset_changes: %w", err)
+		}
+		if m := changeCounts[string(model.ChangeTypeAppeared)]; m != nil {
+			delta.NewAssets = m
+		}
+		if m := changeCounts[string(model.ChangeTypeDisappeared)]; m != nil {
+			delta.DisappearedAssets = m
+		}
+		if m := changeCounts[string(model.ChangeTypeModified)]; m != nil {
+			delta.ModifiedAssets = m
+		}
+	}
+
+	for _, f := range newFindings {
+		delta.NewFindings[f.Severity]++
+	}
+	for _, f := range resolvedFindings {
+		delta.ResolvedFindings[f.Severity]++
+	}
+	// ReturnedFindings ("resolved then re-opened") is not yet computed by
+	// the diff phase — the detection of reopened findings would require
+	// tracking status transitions over scans. Left empty for now; the key
+	// stays in the contract so consumers can rely on a stable shape.
+
+	return delta, nil
+}
+
+// FinalizeScanWork gathers the telemetry of the scan execution: total
+// duration, tools run/failed/skipped, phases executed, and the raw
+// pre-dedup emission count (sum of tool_runs.findings_count).
+//
+// Source: tool_runs rows with scan_id plus scan timing. Duration is passed
+// in because the scan's FinishedAt hasn't been persisted yet at call time.
+func FinalizeScanWork(
+	ctx context.Context,
+	store storage.Store,
+	scanID string,
+	duration time.Duration,
+) (model.ScanWork, error) {
+	work := model.ScanWork{
+		DurationMs: duration.Milliseconds(),
+	}
+
+	runs, err := store.ListToolRuns(ctx, scanID)
+	if err != nil {
+		return work, fmt.Errorf("work tool_runs: %w", err)
+	}
+
+	phaseSet := make(map[string]struct{})
+	for _, r := range runs {
+		work.ToolsRun++
+		switch r.Status {
+		case model.ToolRunFailed, model.ToolRunTimeout:
+			work.ToolsFailed++
+		case model.ToolRunSkipped:
+			work.ToolsSkipped++
+		}
+		work.RawEmissions += r.FindingsCount
+		if r.Phase != "" {
+			phaseSet[r.Phase] = struct{}{}
+		}
+	}
+
+	work.PhasesRun = make([]string, 0, len(phaseSet))
+	for p := range phaseSet {
+		work.PhasesRun = append(work.PhasesRun, p)
+	}
+	sort.Strings(work.PhasesRun)
+
+	return work, nil
+}

--- a/internal/pipeline/finalize_test.go
+++ b/internal/pipeline/finalize_test.go
@@ -1,0 +1,129 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/detection"
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// TestFindingDedupMatchesTargetState is the SPEC-QA3 acceptance test: when
+// nuclei emits duplicate findings (same asset + template_id), storage
+// merges them. target_state.findings_open_total must equal the DB COUNT,
+// not the pre-dedup emission count.
+//
+// This asserts the end-to-end invariant: stats = DB ground truth.
+func TestFindingDedupMatchesTargetState(t *testing.T) {
+	s := newTestStore(t)
+	target := createTarget(t, s, "example.com")
+	ctx := context.Background()
+
+	// Nuclei emits 5 findings but only 3 are unique on (asset, template_id,
+	// source_tool). Duplicates will merge at storage via the UNIQUE
+	// constraint → 3 distinct rows.
+	tools := []detection.DetectionTool{
+		&mockTool{
+			name: "subfinder", phase: "discovery",
+			assets: []model.Asset{
+				{Type: model.AssetTypeSubdomain, Value: "sub.example.com", Status: model.AssetStatusNew},
+			},
+		},
+		&mockTool{
+			name: "dnsx", phase: "resolution",
+			assets: []model.Asset{
+				{Type: model.AssetTypeIPv4, Value: "1.2.3.4", Status: model.AssetStatusNew},
+			},
+		},
+		&mockTool{name: "naabu", phase: "port_scan",
+			assets: []model.Asset{
+				{Type: model.AssetTypePort, Value: "1.2.3.4:443/tcp", Status: model.AssetStatusNew, Metadata: map[string]any{"status": "open"}},
+			},
+		},
+		&mockTool{name: "httpx", phase: "http_probe",
+			assets: []model.Asset{
+				{Type: model.AssetTypeURL, Value: "https://sub.example.com", Status: model.AssetStatusNew},
+			},
+		},
+		&mockTool{
+			name: "nuclei", phase: "assessment",
+			findings: []model.Finding{
+				{TemplateID: "CVE-2024-A", Severity: model.SeverityHigh, Title: "A", Status: model.FindingStatusOpen, SourceTool: "nuclei"},
+				{TemplateID: "CVE-2024-A", Severity: model.SeverityHigh, Title: "A", Status: model.FindingStatusOpen, SourceTool: "nuclei"}, // dup
+				{TemplateID: "CVE-2024-B", Severity: model.SeverityMedium, Title: "B", Status: model.FindingStatusOpen, SourceTool: "nuclei"},
+				{TemplateID: "CVE-2024-B", Severity: model.SeverityMedium, Title: "B", Status: model.FindingStatusOpen, SourceTool: "nuclei"}, // dup
+				{TemplateID: "CVE-2024-C", Severity: model.SeverityCritical, Title: "C", Status: model.FindingStatusOpen, SourceTool: "nuclei"},
+			},
+		},
+	}
+
+	reg := mockRegistry(tools...)
+	pipe := New(s, reg)
+	result, err := pipe.Run(ctx, target.ID, PipelineOptions{ScanType: model.ScanTypeFull})
+	require.NoError(t, err)
+
+	// DB ground truth: exactly 3 findings persisted (duplicates merged).
+	dbFindings, err := s.ListFindings(ctx, storage.FindingListOptions{TargetID: target.ID, Limit: 100})
+	require.NoError(t, err)
+	assert.Len(t, dbFindings, 3, "storage must dedup on (asset, template_id, source_tool)")
+
+	// target_state must equal DB ground truth — the whole point of QA3.
+	assert.Equal(t, 3, result.TargetState.FindingsOpenTotal,
+		"findings_open_total must equal the persisted row count, not the pre-dedup emission count")
+	assert.Equal(t, 1, result.TargetState.FindingsOpen[model.SeverityCritical])
+	assert.Equal(t, 1, result.TargetState.FindingsOpen[model.SeverityHigh])
+	assert.Equal(t, 1, result.TargetState.FindingsOpen[model.SeverityMedium])
+
+	// Re-reading the scan row from the DB must yield the same snapshot —
+	// the aggregate is persisted, not computed fresh each time.
+	persisted, err := s.GetScan(ctx, result.ScanID)
+	require.NoError(t, err)
+	assert.Equal(t, 3, persisted.TargetState.FindingsOpenTotal)
+
+	// work.raw_emissions captures the pre-dedup tool output — 5 emissions
+	// before storage merged them into 3. Useful for debugging tool noise.
+	assert.Equal(t, 5, result.Work.RawEmissions,
+		"work.raw_emissions must record pre-dedup tool emissions")
+}
+
+// TestTargetStatePortsBucket asserts that port_scan assets with different
+// metadata.status values land in the correct target_state.ports_by_status
+// buckets. Previously SPEC-QA2 introduced status=filtered ports but the old
+// stats conflated open + filtered into a single OpenPorts count.
+func TestTargetStatePortsBucket(t *testing.T) {
+	s := newTestStore(t)
+	target := createTarget(t, s, "example.com")
+	ctx := context.Background()
+
+	tools := []detection.DetectionTool{
+		&mockTool{name: "subfinder", phase: "discovery",
+			assets: []model.Asset{
+				{Type: model.AssetTypeSubdomain, Value: "sub.example.com", Status: model.AssetStatusNew},
+			},
+		},
+		&mockTool{name: "dnsx", phase: "resolution",
+			assets: []model.Asset{
+				{Type: model.AssetTypeIPv4, Value: "1.2.3.4", Status: model.AssetStatusNew},
+			},
+		},
+		&mockTool{name: "naabu", phase: "port_scan",
+			assets: []model.Asset{
+				{Type: model.AssetTypePort, Value: "1.2.3.4:80/tcp", Status: model.AssetStatusNew, Metadata: map[string]any{"status": "open"}},
+				{Type: model.AssetTypePort, Value: "1.2.3.4:443/tcp", Status: model.AssetStatusNew, Metadata: map[string]any{"status": "open"}},
+				{Type: model.AssetTypePort, Value: "1.2.3.4:8080/tcp", Status: model.AssetStatusNew, Metadata: map[string]any{"status": "filtered"}},
+			},
+		},
+	}
+
+	reg := mockRegistry(tools...)
+	pipe := New(s, reg)
+	result, err := pipe.Run(ctx, target.ID, PipelineOptions{ScanType: model.ScanTypeFull})
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, result.TargetState.PortsByStatus["open"], "open ports bucketed separately")
+	assert.Equal(t, 1, result.TargetState.PortsByStatus["filtered"], "filtered ports bucketed separately")
+}

--- a/internal/pipeline/finalize_test.go
+++ b/internal/pipeline/finalize_test.go
@@ -90,6 +90,39 @@ func TestFindingDedupMatchesTargetState(t *testing.T) {
 		"work.raw_emissions must record pre-dedup tool emissions")
 }
 
+// TestWorkPhasesRunInExecutionOrder guards against the regression where
+// FinalizeScanWork sorted phases alphabetically — that produced
+// "assessment → discovery → http_probe → port_scan → resolution" for a
+// scan whose actual pipeline order is "discovery → resolution →
+// port_scan → http_probe → assessment". An LLM consumer reading that
+// JSON would infer the wrong execution order.
+func TestWorkPhasesRunInExecutionOrder(t *testing.T) {
+	s := newTestStore(t)
+	target := createTarget(t, s, "example.com")
+	ctx := context.Background()
+
+	tools := []detection.DetectionTool{
+		&mockTool{name: "subfinder", phase: "discovery",
+			assets: []model.Asset{{Type: model.AssetTypeSubdomain, Value: "a.example.com", Status: model.AssetStatusNew}}},
+		&mockTool{name: "dnsx", phase: "resolution",
+			assets: []model.Asset{{Type: model.AssetTypeIPv4, Value: "1.2.3.4", Status: model.AssetStatusNew}}},
+		&mockTool{name: "naabu", phase: "port_scan",
+			assets: []model.Asset{{Type: model.AssetTypePort, Value: "1.2.3.4:443/tcp", Status: model.AssetStatusNew, Metadata: map[string]any{"status": "open"}}}},
+		&mockTool{name: "httpx", phase: "http_probe",
+			assets: []model.Asset{{Type: model.AssetTypeURL, Value: "https://a.example.com", Status: model.AssetStatusNew}}},
+		&mockTool{name: "nuclei", phase: "assessment"},
+	}
+
+	reg := mockRegistry(tools...)
+	pipe := New(s, reg)
+	result, err := pipe.Run(ctx, target.ID, PipelineOptions{ScanType: model.ScanTypeFull})
+	require.NoError(t, err)
+
+	expected := []string{"discovery", "resolution", "port_scan", "http_probe", "assessment"}
+	assert.Equal(t, expected, result.Work.PhasesRun,
+		"phases_run must reflect actual pipeline execution order, not alphabetic")
+}
+
 // TestTargetStatePortsBucket asserts that port_scan assets with different
 // metadata.status values land in the correct target_state.ports_by_status
 // buckets. Previously SPEC-QA2 introduced status=filtered ports but the old

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -871,6 +871,7 @@ func PrintSummary(result *PipelineResult) {
 	printWorkBlock(pp, result.Work)
 }
 
+//nolint:errcheck // stderr writes are unrecoverable and not actionable
 func printTargetStateBlock(pp *pipelinePrinter, state model.TargetState) {
 	if state.AssetsTotal == 0 && state.FindingsOpenTotal == 0 {
 		return
@@ -932,6 +933,7 @@ func printTargetStateBlock(pp *pipelinePrinter, state model.TargetState) {
 	}
 }
 
+//nolint:errcheck // all terminal writes below are unrecoverable and not actionable
 func printFindingsBlock(pp *pipelinePrinter, state model.TargetState) {
 	if state.FindingsOpenTotal == 0 {
 		return
@@ -958,6 +960,7 @@ func printFindingsBlock(pp *pipelinePrinter, state model.TargetState) {
 	pp.theme.Muted.Fprintln(os.Stderr, "Use `surfbot findings show <id>` for full evidence.")
 }
 
+//nolint:errcheck // stderr writes are unrecoverable and not actionable
 func printWorkBlock(pp *pipelinePrinter, work model.ScanWork) {
 	if work.ToolsRun == 0 {
 		return

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -496,6 +496,16 @@ func (p *Pipeline) recordToolRun(ctx context.Context, tool detection.DetectionTo
 		if tr.ErrorMessage == "" && src.ErrorMessage != "" {
 			tr.ErrorMessage = src.ErrorMessage
 		}
+		// Wrapper's Status wins when it reports a non-success terminal
+		// state (skipped / failed / timeout). The outer caller can only
+		// infer "completed" from the absence of a Go error — the wrapper
+		// knows when e.g. the binary is missing or the SDK init failed
+		// and had to skip. Without this merge, subfinder-not-in-PATH
+		// appears as "completed" in the UI.
+		switch src.Status {
+		case model.ToolRunSkipped, model.ToolRunFailed, model.ToolRunTimeout:
+			tr.Status = src.Status
+		}
 		for k, v := range src.Config {
 			tr.Config[k] = v
 		}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -310,7 +310,12 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 		// tool_runs.findings_count is the count of FINDINGS emitted by this
 		// tool (pre-storage-dedup). Not the output total — assets and
 		// findings are counted separately in the data model.
-		p.recordToolRun(ctx, tool, scan.ID, startTime, duration, len(inputs), len(toolResult.Findings), model.ToolRunCompleted, "")
+		//
+		// Detection wrappers may populate RunResult.ToolRun with rich
+		// telemetry (command args, stderr tail, output summary, exit
+		// code). Merge those into the persisted record so the webui and
+		// `surfbot scan detail` can show per-tool logs.
+		p.recordToolRun(ctx, tool, scan.ID, startTime, duration, len(inputs), len(toolResult.Findings), model.ToolRunCompleted, "", &toolResult.ToolRun)
 
 		// Print phase summary
 		printPhaseSummary(tool, toolResult)
@@ -456,7 +461,17 @@ func (p *Pipeline) selectTools(opts PipelineOptions) []detection.DetectionTool {
 	return selected
 }
 
-func (p *Pipeline) recordToolRun(ctx context.Context, tool detection.DetectionTool, scanID string, startedAt time.Time, duration time.Duration, inputCount, outputCount int, status model.ToolRunStatus, errMsg string) {
+// recordToolRun persists a tool_run row. The optional `enrich` argument is
+// the ToolRun returned by the tool wrapper — it carries telemetry the
+// pipeline can't infer from outside (command args, output_summary, stderr
+// tail, tool-specific config). When present, its Config map and
+// OutputSummary are merged into the persisted record so the webui can
+// show per-tool logs without additional round-trips to the subprocess.
+//
+// The pipeline-controlled fields (scan_id, timing, counts, status)
+// always win — the wrapper doesn't know scan_id and its own timing may
+// be slightly off vs. the outer timer.
+func (p *Pipeline) recordToolRun(ctx context.Context, tool detection.DetectionTool, scanID string, startedAt time.Time, duration time.Duration, inputCount, outputCount int, status model.ToolRunStatus, errMsg string, enrich ...*model.ToolRun) {
 	finishedAt := startedAt.Add(duration)
 	tr := &model.ToolRun{
 		ID:            uuid.New().String(),
@@ -471,6 +486,19 @@ func (p *Pipeline) recordToolRun(ctx context.Context, tool detection.DetectionTo
 		FindingsCount: outputCount,
 		ErrorMessage:  errMsg,
 		Config:        map[string]interface{}{},
+	}
+	if len(enrich) > 0 && enrich[0] != nil {
+		src := enrich[0]
+		tr.OutputSummary = src.OutputSummary
+		// Wrapper's ErrorMessage wins when it's non-empty and the outer
+		// caller didn't pass one. This lets wrappers surface partial-run
+		// warnings without being classified as failed.
+		if tr.ErrorMessage == "" && src.ErrorMessage != "" {
+			tr.ErrorMessage = src.ErrorMessage
+		}
+		for k, v := range src.Config {
+			tr.Config[k] = v
+		}
 	}
 	p.store.CreateToolRun(ctx, tr) //nolint:errcheck
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -28,15 +29,20 @@ type PipelineOptions struct {
 }
 
 // PipelineResult holds the output of a pipeline execution.
+//
+// The three aggregate fields (TargetState, Delta, Work) are populated by the
+// finalize* functions at end-of-scan. They mirror the three blobs persisted
+// to scans.target_state / scans.delta / scans.work. Consumers should read
+// these rather than recomputing counts from Phases.
 type PipelineResult struct {
-	ScanID        string
-	Target        string
-	TotalAssets   int
-	TotalFindings int
-	Duration      time.Duration
-	Stats         model.ScanStats
-	Phases        []PhaseResult
-	DiffSummary   *ChangeSummary
+	ScanID      string
+	Target      string
+	Type        model.ScanType
+	Duration    time.Duration
+	TargetState model.TargetState
+	Delta       model.ScanDelta
+	Work        model.ScanWork
+	Phases      []PhaseResult
 }
 
 // PhaseResult describes the outcome of a single pipeline phase.
@@ -292,15 +298,19 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 			}
 		}
 
-		// Update stats
-		updateStats(&scan.Stats, tool.Phase(), toolResult)
+		// Per-scan stats are no longer accumulated here — they are computed
+		// from the database at end-of-scan via FinalizeTargetState /
+		// FinalizeScanDelta / FinalizeScanWork. See SPEC-QA3.
 
 		outputCount := len(toolResult.Assets) + len(toolResult.Findings)
 		pr.Status = "completed"
 		pr.OutputCount = outputCount
 		result.Phases = append(result.Phases, pr)
 
-		p.recordToolRun(ctx, tool, scan.ID, startTime, duration, len(inputs), outputCount, model.ToolRunCompleted, "")
+		// tool_runs.findings_count is the count of FINDINGS emitted by this
+		// tool (pre-storage-dedup). Not the output total — assets and
+		// findings are counted separately in the data model.
+		p.recordToolRun(ctx, tool, scan.ID, startTime, duration, len(inputs), len(toolResult.Findings), model.ToolRunCompleted, "")
 
 		// Print phase summary
 		printPhaseSummary(tool, toolResult)
@@ -373,37 +383,55 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 
 	postAssets, _ := SnapshotAssets(ctx, p.store, targetID)
 	changes := ComputeChanges(targetID, scan.ID, preAssets, postAssets, isFirstScan)
-	newFindingCount, resolvedFindingCount := 0, 0
+	var newFindings, resolvedFindings []model.Finding
 
 	for i := range changes {
 		p.store.CreateAssetChange(ctx, &changes[i]) //nolint:errcheck
 	}
 	ApplyStatusChanges(ctx, p.store, changes) //nolint:errcheck
 
-	newFindings, resolvedFindings, findingErr := ComputeFindingChanges(ctx, p.store, targetID, scan.ID)
+	var findingErr error
+	newFindings, resolvedFindings, findingErr = ComputeFindingChanges(ctx, p.store, targetID, scan.ID)
 	if findingErr == nil {
 		AutoResolveFindings(ctx, p.store, resolvedFindings) //nolint:errcheck
-		newFindingCount = len(newFindings)
-		resolvedFindingCount = len(resolvedFindings)
 	}
 
-	summary := BuildChangeSummary(changes, newFindingCount, resolvedFindingCount)
-	result.DiffSummary = &summary
-	PrintChangeSummary(summary)
+	// Finalize aggregates from DB ground truth. Order matters for logging:
+	// delta first (cheap, depends on already-written asset_changes), then
+	// target_state (queries the live tables), then work (reads tool_runs).
+	finishedAt := time.Now().UTC()
+	duration := finishedAt.Sub(*scan.StartedAt)
 
-	// Complete scan
+	delta, err := FinalizeScanDelta(ctx, p.store, scan.ID, newFindings, resolvedFindings)
+	if err != nil {
+		pp.warn("finalize delta: %v", err)
+	}
+	targetState, err := FinalizeTargetState(ctx, p.store, targetID)
+	if err != nil {
+		pp.warn("finalize target_state: %v", err)
+	}
+	work, err := FinalizeScanWork(ctx, p.store, scan.ID, duration)
+	if err != nil {
+		pp.warn("finalize work: %v", err)
+	}
+
+	scan.TargetState = targetState
+	scan.Delta = delta
+	scan.Work = work
 	scan.Status = model.ScanStatusCompleted
 	scan.Phase = "completed"
 	scan.Progress = 100
-	finishedAt := time.Now().UTC()
 	scan.FinishedAt = &finishedAt
 	p.store.UpdateScan(ctx, scan)                                         //nolint:errcheck
 	p.store.UpdateTargetLastScan(ctx, scan.TargetID, scan.ID, finishedAt) //nolint:errcheck
 
-	result.Stats = scan.Stats
-	result.Duration = finishedAt.Sub(*scan.StartedAt)
-	result.TotalAssets = scan.Stats.SubdomainsFound + scan.Stats.IPsResolved + scan.Stats.OpenPorts + scan.Stats.HTTPProbed
-	result.TotalFindings = scan.Stats.FindingsTotal
+	result.Type = opts.ScanType
+	result.Duration = duration
+	result.TargetState = targetState
+	result.Delta = delta
+	result.Work = work
+
+	PrintChangeSummary(delta)
 
 	return result, nil
 }
@@ -667,50 +695,6 @@ func extractInputsForNextPhase(phase string, result *detection.RunResult) []stri
 	return nil
 }
 
-func updateStats(stats *model.ScanStats, phase string, result *detection.RunResult) {
-	switch phase {
-	case "discovery":
-		for _, a := range result.Assets {
-			if a.Type == model.AssetTypeSubdomain {
-				stats.SubdomainsFound++
-			}
-		}
-	case "resolution":
-		for _, a := range result.Assets {
-			if a.Type == model.AssetTypeIPv4 || a.Type == model.AssetTypeIPv6 {
-				stats.IPsResolved++
-			}
-		}
-	case "port_scan":
-		stats.OpenPorts = len(result.Assets)
-	case "http_probe":
-		for _, a := range result.Assets {
-			switch a.Type {
-			case model.AssetTypeURL:
-				stats.HTTPProbed++
-			case model.AssetTypeTechnology:
-				stats.TechDetected++
-			}
-		}
-	case "assessment":
-		for _, f := range result.Findings {
-			stats.FindingsTotal++
-			switch f.Severity {
-			case model.SeverityCritical:
-				stats.FindingsCritical++
-			case model.SeverityHigh:
-				stats.FindingsHigh++
-			case model.SeverityMedium:
-				stats.FindingsMedium++
-			case model.SeverityLow:
-				stats.FindingsLow++
-			case model.SeverityInfo:
-				stats.FindingsInfo++
-			}
-		}
-	}
-}
-
 func printPhaseSummary(tool detection.DetectionTool, result *detection.RunResult) {
 	pp := newPipelinePrinter(os.Stderr)
 	switch tool.Phase() {
@@ -782,31 +766,46 @@ func printPhaseSummary(tool detection.DetectionTool, result *detection.RunResult
 			}
 		}
 		total := len(result.Findings)
-		pp.muted("    Scanned %d URLs, found %d findings (%d critical, %d high, %d medium, %d low, %d info)\n",
-			len(result.Assets)+total, total, crit, high, med, low, info)
+		// Pre-dedup emission count. The final per-scan findings total is
+		// reported at the end from the DB (see PrintSummary) — this phase
+		// line just tells the operator what nuclei emitted right now.
+		pp.muted("    Emitted %d findings (%d critical, %d high, %d medium, %d low, %d info)\n",
+			total, crit, high, med, low, info)
 	}
 }
 
-// WriteJSONResult writes the pipeline result as JSON to the given path.
-func WriteJSONResult(result *PipelineResult, path string) error {
-	type jsonResult struct {
-		ScanID     string          `json:"scan_id"`
-		Target     string          `json:"target"`
-		Type       string          `json:"type"`
-		Status     string          `json:"status"`
-		DurationMs int64           `json:"duration_ms"`
-		Stats      model.ScanStats `json:"stats"`
-		Phases     []PhaseResult   `json:"phases"`
-	}
+// JSONResult is the canonical JSON shape written by WriteJSONResult. Exposed
+// so consumers (webui, CI helpers) can share the type instead of re-declaring
+// it. Mirrors the scan.target_state / scan.delta / scan.work model exactly.
+type JSONResult struct {
+	ScanID      string            `json:"scan_id"`
+	Target      string            `json:"target"`
+	Type        string            `json:"type"`
+	Status      string            `json:"status"`
+	DurationMs  int64             `json:"duration_ms"`
+	TargetState model.TargetState `json:"target_state"`
+	Delta       model.ScanDelta   `json:"delta"`
+	Work        model.ScanWork    `json:"work"`
+	Phases      []PhaseResult     `json:"phases"`
+}
 
-	out := jsonResult{
-		ScanID:     result.ScanID,
-		Target:     result.Target,
-		Type:       "full",
-		Status:     "completed",
-		DurationMs: result.Duration.Milliseconds(),
-		Stats:      result.Stats,
-		Phases:     result.Phases,
+// WriteJSONResult writes the pipeline result as JSON to the given path.
+// Shape version: agent-spec 2.0 (see docs/agent-spec.md).
+func WriteJSONResult(result *PipelineResult, path string) error {
+	scanType := string(result.Type)
+	if scanType == "" {
+		scanType = string(model.ScanTypeFull)
+	}
+	out := JSONResult{
+		ScanID:      result.ScanID,
+		Target:      result.Target,
+		Type:        scanType,
+		Status:      "completed",
+		DurationMs:  result.Duration.Milliseconds(),
+		TargetState: result.TargetState,
+		Delta:       result.Delta,
+		Work:        result.Work,
+		Phases:      result.Phases,
 	}
 
 	data, err := json.MarshalIndent(out, "", "  ")
@@ -816,32 +815,129 @@ func WriteJSONResult(result *PipelineResult, path string) error {
 	return os.WriteFile(path, data, 0o644)
 }
 
-// PrintSummary prints the findings summary table to stderr with colored severity.
+// PrintSummary prints a three-section human summary to stderr:
+//
+//	TARGET STATE — what currently exists on the target
+//	CHANGES      — what this scan changed (printed separately via PrintChangeSummary)
+//	WORK         — telemetry of the execution
+//
+// The CHANGES block is emitted earlier in the flow by PrintChangeSummary.
+// PrintSummary handles state + findings table + work.
 func PrintSummary(result *PipelineResult) {
 	pp := newPipelinePrinter(os.Stderr)
 
 	pp.theme.Success.Fprintf(os.Stderr, "\nScan completed in %s\n", formatDuration(result.Duration))
 
-	if result.Stats.FindingsTotal > 0 {
-		pp.theme.Bold.Fprintf(os.Stderr, "\nFINDINGS SUMMARY\n")
+	printTargetStateBlock(pp, result.TargetState)
+	printFindingsBlock(pp, result.TargetState)
+	printWorkBlock(pp, result.Work)
+}
 
-		w := tabwriter.NewWriter(os.Stderr, 0, 0, 3, ' ', 0)
-		pp.theme.Bold.Fprintln(w, "Severity\tCount")
-		pp.theme.Muted.Fprintln(w, strings.Repeat("─", 20)+"\t")
+func printTargetStateBlock(pp *pipelinePrinter, state model.TargetState) {
+	if state.AssetsTotal == 0 && state.FindingsOpenTotal == 0 {
+		return
+	}
 
-		printSeverityRow(w, pp.theme.Critical, "CRITICAL", result.Stats.FindingsCritical, pp.theme.Muted)
-		printSeverityRow(w, pp.theme.High, "HIGH", result.Stats.FindingsHigh, pp.theme.Muted)
-		printSeverityRow(w, pp.theme.Medium, "MEDIUM", result.Stats.FindingsMedium, pp.theme.Muted)
-		printSeverityRow(w, pp.theme.Low, "LOW", result.Stats.FindingsLow, pp.theme.Muted)
-		printSeverityRow(w, pp.theme.Info, "INFO", result.Stats.FindingsInfo, pp.theme.Muted)
+	pp.theme.Bold.Fprintf(os.Stderr, "\nTARGET STATE\n")
 
-		pp.theme.Muted.Fprintln(w, strings.Repeat("─", 20)+"\t")
-		pp.theme.Bold.Fprintf(w, "%-12s\t%d\n", "TOTAL", result.Stats.FindingsTotal)
-		w.Flush()
+	// Render asset counts in a stable order. Known types first in pipeline
+	// order; any unknown types (from tools that aren't built-in) follow
+	// alphabetically so the output is deterministic.
+	known := []model.AssetType{
+		model.AssetTypeSubdomain, model.AssetTypeIPv4, model.AssetTypeIPv6,
+		model.AssetTypePort, model.AssetTypeURL, model.AssetTypeTechnology,
+		model.AssetTypeDomain, model.AssetTypeService,
+	}
+	seen := make(map[model.AssetType]bool, len(known))
+	parts := make([]string, 0, len(state.AssetsByType))
+	for _, t := range known {
+		if n, ok := state.AssetsByType[t]; ok && n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", n, pluralize(string(t), n)))
+			seen[t] = true
+		}
+	}
+	extras := make([]string, 0)
+	for t, n := range state.AssetsByType {
+		if !seen[t] && n > 0 {
+			extras = append(extras, fmt.Sprintf("%d %s", n, pluralize(string(t), n)))
+		}
+	}
+	sort.Strings(extras)
+	parts = append(parts, extras...)
 
-		fmt.Fprintln(os.Stderr, "")
-		pp.theme.Muted.Fprintln(os.Stderr, "Use `surfbot findings list` to see details.")
-		pp.theme.Muted.Fprintln(os.Stderr, "Use `surfbot findings show <id>` for full evidence.")
+	if len(parts) > 0 {
+		pp.muted("%s", "  "+strings.Join(parts, " · ")+"\n")
+	}
+
+	// Ports detail (open/filtered/…) when any ports exist.
+	if len(state.PortsByStatus) > 0 {
+		portParts := make([]string, 0, len(state.PortsByStatus))
+		statusOrder := []string{"open", "filtered", "closed", "unknown"}
+		seenStatus := make(map[string]bool)
+		for _, st := range statusOrder {
+			if n := state.PortsByStatus[st]; n > 0 {
+				portParts = append(portParts, fmt.Sprintf("%d %s", n, st))
+				seenStatus[st] = true
+			}
+		}
+		extraStatus := make([]string, 0)
+		for st, n := range state.PortsByStatus {
+			if !seenStatus[st] && n > 0 {
+				extraStatus = append(extraStatus, fmt.Sprintf("%d %s", n, st))
+			}
+		}
+		sort.Strings(extraStatus)
+		portParts = append(portParts, extraStatus...)
+		if len(portParts) > 0 {
+			pp.muted("%s", "  ports: "+strings.Join(portParts, ", ")+"\n")
+		}
+	}
+}
+
+func printFindingsBlock(pp *pipelinePrinter, state model.TargetState) {
+	if state.FindingsOpenTotal == 0 {
+		return
+	}
+
+	pp.theme.Bold.Fprintf(os.Stderr, "\nFINDINGS (open)\n")
+
+	w := tabwriter.NewWriter(os.Stderr, 0, 0, 3, ' ', 0)
+	pp.theme.Bold.Fprintln(w, "Severity\tCount")
+	pp.theme.Muted.Fprintln(w, strings.Repeat("─", 20)+"\t")
+
+	printSeverityRow(w, pp.theme.Critical, "CRITICAL", state.FindingsOpen[model.SeverityCritical], pp.theme.Muted)
+	printSeverityRow(w, pp.theme.High, "HIGH", state.FindingsOpen[model.SeverityHigh], pp.theme.Muted)
+	printSeverityRow(w, pp.theme.Medium, "MEDIUM", state.FindingsOpen[model.SeverityMedium], pp.theme.Muted)
+	printSeverityRow(w, pp.theme.Low, "LOW", state.FindingsOpen[model.SeverityLow], pp.theme.Muted)
+	printSeverityRow(w, pp.theme.Info, "INFO", state.FindingsOpen[model.SeverityInfo], pp.theme.Muted)
+
+	pp.theme.Muted.Fprintln(w, strings.Repeat("─", 20)+"\t")
+	pp.theme.Bold.Fprintf(w, "%-12s\t%d\n", "TOTAL", state.FindingsOpenTotal)
+	w.Flush()
+
+	fmt.Fprintln(os.Stderr, "")
+	pp.theme.Muted.Fprintln(os.Stderr, "Use `surfbot findings list` to see details.")
+	pp.theme.Muted.Fprintln(os.Stderr, "Use `surfbot findings show <id>` for full evidence.")
+}
+
+func printWorkBlock(pp *pipelinePrinter, work model.ScanWork) {
+	if work.ToolsRun == 0 {
+		return
+	}
+	pp.theme.Bold.Fprintf(os.Stderr, "\nWORK\n")
+	details := fmt.Sprintf("  %d %s run", work.ToolsRun, pluralize("tool", work.ToolsRun))
+	if work.ToolsFailed > 0 {
+		details += fmt.Sprintf(", %d failed", work.ToolsFailed)
+	}
+	if work.ToolsSkipped > 0 {
+		details += fmt.Sprintf(", %d skipped", work.ToolsSkipped)
+	}
+	if work.RawEmissions > 0 {
+		details += fmt.Sprintf(" · %d raw emissions (pre-dedup)", work.RawEmissions)
+	}
+	pp.muted("%s\n", details)
+	if len(work.PhasesRun) > 0 {
+		pp.muted("%s", "  phases: "+strings.Join(work.PhasesRun, " → ")+"\n")
 	}
 }
 

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -177,16 +177,24 @@ func TestPipelineFullScan(t *testing.T) {
 	assert.Equal(t, "http_probe", result.Phases[3].Phase)
 	assert.Equal(t, "assessment", result.Phases[4].Phase)
 
-	// Stats
-	assert.Equal(t, 2, result.Stats.SubdomainsFound)
-	assert.Equal(t, 2, result.Stats.IPsResolved)
-	assert.Equal(t, 2, result.Stats.OpenPorts)
-	assert.Equal(t, 1, result.Stats.HTTPProbed)
-	assert.Equal(t, 1, result.Stats.TechDetected)
-	assert.Equal(t, 3, result.Stats.FindingsTotal)
-	assert.Equal(t, 1, result.Stats.FindingsCritical)
-	assert.Equal(t, 1, result.Stats.FindingsHigh)
-	assert.Equal(t, 1, result.Stats.FindingsInfo)
+	// TargetState reflects the DB snapshot at scan completion — counts
+	// come from assets/findings queries, not from in-memory accumulators.
+	state := result.TargetState
+	assert.Equal(t, 2, state.AssetsByType[model.AssetTypeSubdomain])
+	assert.Equal(t, 1, state.AssetsByType[model.AssetTypeIPv4])
+	assert.Equal(t, 1, state.AssetsByType[model.AssetTypeIPv6])
+	assert.Equal(t, 2, state.AssetsByType[model.AssetTypePort])
+	assert.Equal(t, 1, state.AssetsByType[model.AssetTypeURL])
+	assert.Equal(t, 1, state.AssetsByType[model.AssetTypeTechnology])
+	assert.Equal(t, 3, state.FindingsOpenTotal)
+	assert.Equal(t, 1, state.FindingsOpen[model.SeverityCritical])
+	assert.Equal(t, 1, state.FindingsOpen[model.SeverityHigh])
+	assert.Equal(t, 1, state.FindingsOpen[model.SeverityInfo])
+
+	// Work block: telemetry of the execution.
+	assert.GreaterOrEqual(t, result.Work.ToolsRun, 5)
+	assert.Contains(t, result.Work.PhasesRun, "discovery")
+	assert.Contains(t, result.Work.PhasesRun, "assessment")
 
 	// Scan should be completed
 	scan, err := s.GetScan(context.Background(), result.ScanID)
@@ -604,57 +612,10 @@ func TestShouldSkip(t *testing.T) {
 	assert.True(t, shouldSkip(&mockTool{phase: "assessment"}, PipelineOptions{ScanType: model.ScanTypeDiscovery}))
 }
 
-func TestUpdateStats(t *testing.T) {
-	stats := &model.ScanStats{}
-
-	updateStats(stats, "discovery", &detection.RunResult{
-		Assets: []model.Asset{
-			{Type: model.AssetTypeSubdomain, Value: "a.example.com"},
-			{Type: model.AssetTypeSubdomain, Value: "b.example.com"},
-		},
-	})
-	assert.Equal(t, 2, stats.SubdomainsFound)
-
-	updateStats(stats, "resolution", &detection.RunResult{
-		Assets: []model.Asset{
-			{Type: model.AssetTypeIPv4, Value: "1.2.3.4"},
-		},
-	})
-	assert.Equal(t, 1, stats.IPsResolved)
-
-	updateStats(stats, "port_scan", &detection.RunResult{
-		Assets: []model.Asset{
-			{Type: model.AssetTypePort, Value: "1.2.3.4:80/tcp"},
-			{Type: model.AssetTypePort, Value: "1.2.3.4:443/tcp"},
-		},
-	})
-	assert.Equal(t, 2, stats.OpenPorts)
-
-	updateStats(stats, "http_probe", &detection.RunResult{
-		Assets: []model.Asset{
-			{Type: model.AssetTypeURL, Value: "https://example.com"},
-			{Type: model.AssetTypeTechnology, Value: "nginx"},
-		},
-	})
-	assert.Equal(t, 1, stats.HTTPProbed)
-	assert.Equal(t, 1, stats.TechDetected)
-
-	updateStats(stats, "assessment", &detection.RunResult{
-		Findings: []model.Finding{
-			{Severity: model.SeverityCritical},
-			{Severity: model.SeverityHigh},
-			{Severity: model.SeverityMedium},
-			{Severity: model.SeverityLow},
-			{Severity: model.SeverityInfo},
-		},
-	})
-	assert.Equal(t, 5, stats.FindingsTotal)
-	assert.Equal(t, 1, stats.FindingsCritical)
-	assert.Equal(t, 1, stats.FindingsHigh)
-	assert.Equal(t, 1, stats.FindingsMedium)
-	assert.Equal(t, 1, stats.FindingsLow)
-	assert.Equal(t, 1, stats.FindingsInfo)
-}
+// TestUpdateStats was removed when updateStats itself was deleted. Stats
+// are now computed from DB ground truth at end-of-scan by FinalizeTargetState
+// / FinalizeScanDelta / FinalizeScanWork. See TestPipelineFullScan for
+// end-to-end stats coverage and storage unit tests for per-query coverage.
 
 func TestPipelineNoURLsSkipsNuclei(t *testing.T) {
 	s := newTestStore(t)

--- a/internal/storage/migrations/003_scan_state_model.sql
+++ b/internal/storage/migrations/003_scan_state_model.sql
@@ -1,0 +1,79 @@
+-- Migration 003: scan_state_model
+--
+-- Replaces the legacy scans.stats JSON blob with three semantically-distinct
+-- snapshots: target_state, delta, work. See SPEC-QA3 (SUR-244).
+--
+-- Also:
+--  * Opens up assets.type (drops CHECK constraint) so that new detection
+--    tools can introduce new AssetTypes without requiring a SQL migration.
+--    Validation lives in Go — the database treats the column as opaque.
+--  * Adds findings.first_seen_scan_id to preserve the original discovery
+--    scan when findings.scan_id is later overwritten by re-observation
+--    upserts.
+--
+-- Pre-launch destructive migration: legacy stats data in scans.stats is
+-- dropped. New target_state/delta/work snapshots are zero-valued for
+-- pre-existing scans; they will be correctly populated on the next run.
+
+-- === scans: replace stats with three snapshots ==============================
+
+ALTER TABLE scans ADD COLUMN target_state TEXT NOT NULL DEFAULT '{}';
+ALTER TABLE scans ADD COLUMN delta        TEXT NOT NULL DEFAULT '{}';
+ALTER TABLE scans ADD COLUMN work         TEXT NOT NULL DEFAULT '{}';
+
+-- Drop the legacy blob. SQLite 3.35+ supports DROP COLUMN; modernc.org/sqlite
+-- embeds a recent enough build. If that assumption ever breaks, convert this
+-- to a CREATE TABLE … AS + swap.
+ALTER TABLE scans DROP COLUMN stats;
+
+-- === findings: preserve first-discovery scan ================================
+
+ALTER TABLE findings ADD COLUMN first_seen_scan_id TEXT REFERENCES scans(id) ON DELETE SET NULL;
+
+-- Backfill: existing rows' scan_id was assigned on first insert (UpsertFinding
+-- didn't update it on conflict), so it already represents first-discovery.
+-- Copy it into first_seen_scan_id before scan_id starts tracking "latest".
+UPDATE findings SET first_seen_scan_id = scan_id WHERE first_seen_scan_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_findings_first_seen_scan_id ON findings(first_seen_scan_id);
+
+-- === assets: drop CHECK on type =============================================
+--
+-- SQLite cannot drop a CHECK constraint in place, so we rebuild the table.
+-- The legacy schema pinned the type column to a closed vocabulary; new
+-- detection tools would have required a migration to emit a new AssetType.
+-- After this change the database is agnostic to the AssetType vocabulary.
+
+CREATE TABLE assets_new (
+    id          TEXT PRIMARY KEY,
+    target_id   TEXT NOT NULL REFERENCES targets(id) ON DELETE CASCADE,
+    parent_id   TEXT REFERENCES assets(id) ON DELETE SET NULL,
+    type        TEXT NOT NULL,
+    value       TEXT NOT NULL,
+    status      TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'new', 'disappeared', 'returned', 'inactive', 'ignored')),
+    tags        TEXT NOT NULL DEFAULT '[]',
+    metadata    TEXT NOT NULL DEFAULT '{}',
+    first_seen  TEXT NOT NULL,
+    last_seen   TEXT NOT NULL,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL,
+    UNIQUE(target_id, value)
+);
+
+INSERT INTO assets_new (id, target_id, parent_id, type, value, status, tags, metadata,
+                        first_seen, last_seen, created_at, updated_at)
+SELECT id, target_id, parent_id, type, value, status, tags, metadata,
+       first_seen, last_seen, created_at, updated_at
+FROM assets;
+
+DROP TABLE assets;
+ALTER TABLE assets_new RENAME TO assets;
+
+CREATE INDEX IF NOT EXISTS idx_assets_target_id ON assets(target_id);
+CREATE INDEX IF NOT EXISTS idx_assets_type      ON assets(type);
+CREATE INDEX IF NOT EXISTS idx_assets_status    ON assets(status);
+CREATE INDEX IF NOT EXISTS idx_assets_parent_id ON assets(parent_id);
+
+-- === schema version =========================================================
+
+UPDATE agent_meta SET value = '3' WHERE key = 'schema_version';

--- a/internal/storage/scan_aggregates.go
+++ b/internal/storage/scan_aggregates.go
@@ -1,0 +1,183 @@
+package storage
+
+// Aggregate queries used by the pipeline's finalize* functions to compute
+// TargetState / ScanDelta / ScanWork at the end of a scan. All counts come
+// from the database so that the persisted aggregates match what `list`
+// subcommands return — no in-memory accumulator drift.
+//
+// Conventions:
+//   * Target-scoped: aggregates that answer "what does the target look like?"
+//     (assets, findings by status). Filter by target_id, not scan_id.
+//   * Scan-scoped: aggregates that answer "what did this scan do/change?"
+//     (asset_changes, tool_runs). Filter by scan_id.
+//
+// Empty results return an empty map and a nil error, never an error.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// CountAssetsByTypeForTarget returns a map[AssetType]count of assets for the
+// given target, filtered to the "live" statuses (active|new|returned).
+// Disappeared/inactive/ignored assets are excluded — this answers "what
+// currently exists", not "what has ever existed."
+func (s *SQLiteStore) CountAssetsByTypeForTarget(ctx context.Context, targetID string) (map[model.AssetType]int, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT type, COUNT(*) FROM assets
+		 WHERE target_id = ? AND status IN ('active', 'new', 'returned')
+		 GROUP BY type`,
+		targetID)
+	if err != nil {
+		return nil, fmt.Errorf("counting assets by type for target %s: %w", targetID, err)
+	}
+	defer rows.Close()
+
+	counts := make(map[model.AssetType]int)
+	for rows.Next() {
+		var typ model.AssetType
+		var n int
+		if err := rows.Scan(&typ, &n); err != nil {
+			return nil, fmt.Errorf("scanning asset type count: %w", err)
+		}
+		counts[typ] = n
+	}
+	return counts, rows.Err()
+}
+
+// CountPortsByStatusForTarget returns a map[status]count of port_service
+// assets for the target, bucketed by metadata.status. Non-port_service
+// assets are excluded. Returns an empty map (not nil) when the target has
+// no port assets.
+//
+// Port status vocabulary is open — whatever string a port_scan tool writes
+// into metadata.status becomes a key. Ports with no status metadata bucket
+// under "unknown" so the sum equals the port_service asset count.
+func (s *SQLiteStore) CountPortsByStatusForTarget(ctx context.Context, targetID string) (map[string]int, error) {
+	// Alias explicitly — bare "status" collides with the column name and
+	// SQLite would group by the asset_status instead of the JSON status.
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT COALESCE(NULLIF(json_extract(metadata, '$.status'), ''), 'unknown') AS port_status,
+		        COUNT(*)
+		 FROM assets
+		 WHERE target_id = ? AND type = ? AND status IN ('active', 'new', 'returned')
+		 GROUP BY port_status`,
+		targetID, string(model.AssetTypePort))
+	if err != nil {
+		return nil, fmt.Errorf("counting ports by status for target %s: %w", targetID, err)
+	}
+	defer rows.Close()
+
+	counts := make(map[string]int)
+	for rows.Next() {
+		var status string
+		var n int
+		if err := rows.Scan(&status, &n); err != nil {
+			return nil, fmt.Errorf("scanning port status count: %w", err)
+		}
+		counts[status] = n
+	}
+	return counts, rows.Err()
+}
+
+// CountFindingsBySeverityForTarget returns a map[Severity]count of findings
+// for assets belonging to the target, optionally filtered by status. Pass
+// an empty status to count all findings regardless of status.
+func (s *SQLiteStore) CountFindingsBySeverityForTarget(ctx context.Context, targetID string, status model.FindingStatus) (map[model.Severity]int, error) {
+	query := `SELECT severity, COUNT(*) FROM findings
+	          WHERE asset_id IN (SELECT id FROM assets WHERE target_id = ?)`
+	args := []interface{}{targetID}
+	if status != "" {
+		query += ` AND status = ?`
+		args = append(args, string(status))
+	}
+	query += ` GROUP BY severity`
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("counting findings by severity for target %s: %w", targetID, err)
+	}
+	defer rows.Close()
+
+	counts := make(map[model.Severity]int)
+	for rows.Next() {
+		var sev model.Severity
+		var n int
+		if err := rows.Scan(&sev, &n); err != nil {
+			return nil, fmt.Errorf("scanning finding severity count: %w", err)
+		}
+		counts[sev] = n
+	}
+	return counts, rows.Err()
+}
+
+// CountFindingsByStatusForTarget returns a map[FindingStatus]count of
+// findings for assets belonging to the target.
+func (s *SQLiteStore) CountFindingsByStatusForTarget(ctx context.Context, targetID string) (map[model.FindingStatus]int, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT status, COUNT(*) FROM findings
+		 WHERE asset_id IN (SELECT id FROM assets WHERE target_id = ?)
+		 GROUP BY status`,
+		targetID)
+	if err != nil {
+		return nil, fmt.Errorf("counting findings by status for target %s: %w", targetID, err)
+	}
+	defer rows.Close()
+
+	counts := make(map[model.FindingStatus]int)
+	for rows.Next() {
+		var st model.FindingStatus
+		var n int
+		if err := rows.Scan(&st, &n); err != nil {
+			return nil, fmt.Errorf("scanning finding status count: %w", err)
+		}
+		counts[st] = n
+	}
+	return counts, rows.Err()
+}
+
+// AssetChangeCountsForScan returns the change counts for a scan, keyed by
+// (change_type, asset_type). The outer map's keys are change_type strings
+// ("appeared", "disappeared", "modified"); the inner map buckets by the
+// asset type that changed. Used to build ScanDelta.
+func (s *SQLiteStore) AssetChangeCountsForScan(ctx context.Context, scanID string) (map[string]map[model.AssetType]int, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT change_type, asset_type, COUNT(*)
+		 FROM asset_changes
+		 WHERE scan_id = ? AND baseline = 0
+		 GROUP BY change_type, asset_type`,
+		scanID)
+	if err != nil {
+		return nil, fmt.Errorf("counting asset changes for scan %s: %w", scanID, err)
+	}
+	defer rows.Close()
+
+	counts := make(map[string]map[model.AssetType]int)
+	for rows.Next() {
+		var changeType, assetType string
+		var n int
+		if err := rows.Scan(&changeType, &assetType, &n); err != nil {
+			return nil, fmt.Errorf("scanning asset change count: %w", err)
+		}
+		if _, ok := counts[changeType]; !ok {
+			counts[changeType] = make(map[model.AssetType]int)
+		}
+		counts[changeType][model.AssetType(assetType)] = n
+	}
+	return counts, rows.Err()
+}
+
+// ScanIsBaseline reports whether any asset_change for the scan carries the
+// baseline flag. Used by ScanDelta.IsBaseline.
+func (s *SQLiteStore) ScanIsBaseline(ctx context.Context, scanID string) (bool, error) {
+	var n int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM asset_changes WHERE scan_id = ? AND baseline = 1 LIMIT 1`,
+		scanID).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("checking baseline for scan %s: %w", scanID, err)
+	}
+	return n > 0, nil
+}

--- a/internal/storage/scan_aggregates.go
+++ b/internal/storage/scan_aggregates.go
@@ -33,7 +33,7 @@ func (s *SQLiteStore) CountAssetsByTypeForTarget(ctx context.Context, targetID s
 	if err != nil {
 		return nil, fmt.Errorf("counting assets by type for target %s: %w", targetID, err)
 	}
-	defer rows.Close()
+	defer rows.Close() //nolint:errcheck // close errors on a deferred cursor are not actionable
 
 	counts := make(map[model.AssetType]int)
 	for rows.Next() {
@@ -68,7 +68,7 @@ func (s *SQLiteStore) CountPortsByStatusForTarget(ctx context.Context, targetID 
 	if err != nil {
 		return nil, fmt.Errorf("counting ports by status for target %s: %w", targetID, err)
 	}
-	defer rows.Close()
+	defer rows.Close() //nolint:errcheck // close errors on a deferred cursor are not actionable
 
 	counts := make(map[string]int)
 	for rows.Next() {
@@ -99,7 +99,7 @@ func (s *SQLiteStore) CountFindingsBySeverityForTarget(ctx context.Context, targ
 	if err != nil {
 		return nil, fmt.Errorf("counting findings by severity for target %s: %w", targetID, err)
 	}
-	defer rows.Close()
+	defer rows.Close() //nolint:errcheck // close errors on a deferred cursor are not actionable
 
 	counts := make(map[model.Severity]int)
 	for rows.Next() {
@@ -124,7 +124,7 @@ func (s *SQLiteStore) CountFindingsByStatusForTarget(ctx context.Context, target
 	if err != nil {
 		return nil, fmt.Errorf("counting findings by status for target %s: %w", targetID, err)
 	}
-	defer rows.Close()
+	defer rows.Close() //nolint:errcheck // close errors on a deferred cursor are not actionable
 
 	counts := make(map[model.FindingStatus]int)
 	for rows.Next() {
@@ -152,7 +152,7 @@ func (s *SQLiteStore) AssetChangeCountsForScan(ctx context.Context, scanID strin
 	if err != nil {
 		return nil, fmt.Errorf("counting asset changes for scan %s: %w", scanID, err)
 	}
-	defer rows.Close()
+	defer rows.Close() //nolint:errcheck // close errors on a deferred cursor are not actionable
 
 	counts := make(map[string]map[model.AssetType]int)
 	for rows.Next() {

--- a/internal/storage/scan_aggregates_test.go
+++ b/internal/storage/scan_aggregates_test.go
@@ -1,0 +1,164 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// TestUpsertFindingScanIDLatestSemantics is the critical invariant of the
+// SPEC-QA3 refactor: scan_id must reflect the LATEST scan that observed the
+// finding, while first_seen_scan_id remains immutable at the originating
+// scan. Before this change, scan_id froze on first insert and lied.
+func TestUpsertFindingScanIDLatestSemantics(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	target := &model.Target{Value: "example.com"}
+	require.NoError(t, s.CreateTarget(ctx, target))
+
+	scan1 := &model.Scan{TargetID: target.ID, Type: model.ScanTypeFull, Status: model.ScanStatusRunning}
+	require.NoError(t, s.CreateScan(ctx, scan1))
+	scan2 := &model.Scan{TargetID: target.ID, Type: model.ScanTypeFull, Status: model.ScanStatusRunning}
+	require.NoError(t, s.CreateScan(ctx, scan2))
+
+	asset := &model.Asset{TargetID: target.ID, Type: model.AssetTypeSubdomain, Value: "sub.example.com", Status: model.AssetStatusNew}
+	require.NoError(t, s.UpsertAsset(ctx, asset))
+
+	// First observation in scan1.
+	f1 := &model.Finding{
+		AssetID: asset.ID, ScanID: scan1.ID,
+		TemplateID: "CVE-2024-0001", SourceTool: "nuclei",
+		Severity: model.SeverityHigh, Title: "Vuln", Status: model.FindingStatusOpen,
+	}
+	require.NoError(t, s.UpsertFinding(ctx, f1))
+
+	// Same finding re-observed in scan2 → scan_id flips to scan2,
+	// first_seen_scan_id stays on scan1.
+	f2 := &model.Finding{
+		AssetID: asset.ID, ScanID: scan2.ID,
+		TemplateID: "CVE-2024-0001", SourceTool: "nuclei",
+		Severity: model.SeverityHigh, Title: "Vuln", Status: model.FindingStatusOpen,
+	}
+	require.NoError(t, s.UpsertFinding(ctx, f2))
+
+	got, err := s.GetFinding(ctx, f1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, scan2.ID, got.ScanID, "scan_id must track the LATEST observing scan")
+	assert.Equal(t, scan1.ID, got.FirstSeenScanID, "first_seen_scan_id must be immutable")
+
+	// Querying "findings observed in scan2" must return this finding.
+	observedInScan2, err := s.ListFindings(ctx, FindingListOptions{ScanID: scan2.ID, Limit: 10})
+	require.NoError(t, err)
+	assert.Len(t, observedInScan2, 1, "scan2 should find the re-observed finding")
+
+	// Querying "findings observed in scan1" now returns empty — scan1 no
+	// longer owns the scan_id pointer. The discovery record survives via
+	// first_seen_scan_id.
+	observedInScan1, err := s.ListFindings(ctx, FindingListOptions{ScanID: scan1.ID, Limit: 10})
+	require.NoError(t, err)
+	assert.Empty(t, observedInScan1, "scan1 no longer holds the scan_id after scan2 re-observed")
+}
+
+// TestCountAssetsByTypeForTargetExcludesDisappeared asserts that the
+// target_state aggregate reflects live assets only. Disappeared assets are
+// excluded from "what currently exists" by design.
+func TestCountAssetsByTypeForTargetExcludesDisappeared(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	target := &model.Target{Value: "example.com"}
+	require.NoError(t, s.CreateTarget(ctx, target))
+
+	alive := &model.Asset{TargetID: target.ID, Type: model.AssetTypeSubdomain, Value: "alive.example.com", Status: model.AssetStatusActive}
+	require.NoError(t, s.UpsertAsset(ctx, alive))
+
+	gone := &model.Asset{TargetID: target.ID, Type: model.AssetTypeSubdomain, Value: "gone.example.com", Status: model.AssetStatusDisappeared}
+	require.NoError(t, s.UpsertAsset(ctx, gone))
+	require.NoError(t, s.UpdateAssetStatus(ctx, gone.ID, model.AssetStatusDisappeared))
+
+	counts, err := s.CountAssetsByTypeForTarget(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, counts[model.AssetTypeSubdomain], "disappeared assets must not count toward live state")
+}
+
+// TestCountPortsByStatusForTargetBucketsCorrectly asserts that ports split
+// cleanly into their metadata.status buckets. Ports with missing status
+// metadata bucket under "unknown" so the total always equals the
+// port_service asset count.
+func TestCountPortsByStatusForTargetBucketsCorrectly(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	target := &model.Target{Value: "example.com"}
+	require.NoError(t, s.CreateTarget(ctx, target))
+
+	cases := []struct {
+		value    string
+		metadata map[string]any
+	}{
+		{"1.2.3.4:80/tcp", map[string]any{"status": "open"}},
+		{"1.2.3.4:443/tcp", map[string]any{"status": "open"}},
+		{"1.2.3.4:8080/tcp", map[string]any{"status": "filtered"}},
+		{"1.2.3.4:9000/tcp", map[string]any{}}, // missing status → unknown
+	}
+	for _, c := range cases {
+		asset := &model.Asset{
+			TargetID: target.ID, Type: model.AssetTypePort,
+			Value: c.value, Status: model.AssetStatusActive,
+			Metadata: c.metadata,
+		}
+		require.NoError(t, s.UpsertAsset(ctx, asset))
+	}
+
+	counts, err := s.CountPortsByStatusForTarget(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, counts["open"])
+	assert.Equal(t, 1, counts["filtered"])
+	assert.Equal(t, 1, counts["unknown"])
+}
+
+// TestAssetChangeCountsForScanSkipsBaseline asserts that baseline asset
+// changes don't bubble into delta.new_assets. Baselines are flagged
+// separately via ScanIsBaseline.
+func TestAssetChangeCountsForScanSkipsBaseline(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	target := &model.Target{Value: "example.com"}
+	require.NoError(t, s.CreateTarget(ctx, target))
+
+	scan := &model.Scan{TargetID: target.ID, Type: model.ScanTypeFull, Status: model.ScanStatusRunning}
+	require.NoError(t, s.CreateScan(ctx, scan))
+
+	// Baseline change (first scan of this target).
+	baselineChange := &model.AssetChange{
+		TargetID: target.ID, ScanID: scan.ID,
+		ChangeType: model.ChangeTypeAppeared, Significance: model.SignificanceInfo,
+		AssetType: string(model.AssetTypeSubdomain), AssetValue: "baseline.example.com",
+		Summary: "baseline", Baseline: true,
+	}
+	require.NoError(t, s.CreateAssetChange(ctx, baselineChange))
+
+	// Real appeared change (genuinely new).
+	newChange := &model.AssetChange{
+		TargetID: target.ID, ScanID: scan.ID,
+		ChangeType: model.ChangeTypeAppeared, Significance: model.SignificanceCritical,
+		AssetType: string(model.AssetTypeSubdomain), AssetValue: "newcomer.example.com",
+		Summary: "new",
+	}
+	require.NoError(t, s.CreateAssetChange(ctx, newChange))
+
+	counts, err := s.AssetChangeCountsForScan(ctx, scan.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, counts[string(model.ChangeTypeAppeared)][model.AssetTypeSubdomain],
+		"only the non-baseline change should count")
+
+	isBaseline, err := s.ScanIsBaseline(ctx, scan.ID)
+	require.NoError(t, err)
+	assert.True(t, isBaseline, "ScanIsBaseline must surface the baseline flag independently")
+}

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -31,10 +31,11 @@ func TestNewSQLiteStore(t *testing.T) {
 		assert.NoError(t, err, "table %s should exist", table)
 	}
 
-	// Verify agent_meta seeded
+	// Verify agent_meta seeded. schema_version tracks the latest applied
+	// migration: 003 bumps it to "3".
 	v, err := s.GetMeta(ctx, "schema_version")
 	require.NoError(t, err)
-	assert.Equal(t, "1", v)
+	assert.Equal(t, "3", v)
 }
 
 func TestTargetCRUD(t *testing.T) {
@@ -190,7 +191,10 @@ func TestScanCRUD(t *testing.T) {
 	scan.Phase = "discovery"
 	scan.Progress = 25.0
 	scan.StartedAt = &now
-	scan.Stats = model.ScanStats{SubdomainsFound: 10}
+	scan.TargetState = model.TargetState{
+		AssetsByType: map[model.AssetType]int{model.AssetTypeSubdomain: 10},
+		AssetsTotal:  10,
+	}
 	require.NoError(t, s.UpdateScan(ctx, scan))
 
 	got, err = s.GetScan(ctx, scan.ID)
@@ -198,7 +202,8 @@ func TestScanCRUD(t *testing.T) {
 	assert.Equal(t, model.ScanStatusRunning, got.Status)
 	assert.Equal(t, "discovery", got.Phase)
 	assert.Equal(t, float32(25.0), got.Progress)
-	assert.Equal(t, 10, got.Stats.SubdomainsFound)
+	assert.Equal(t, 10, got.TargetState.AssetsByType[model.AssetTypeSubdomain])
+	assert.Equal(t, 10, got.TargetState.AssetsTotal)
 
 	// List
 	scans, err := s.ListScans(ctx, target.ID, 10)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -107,6 +107,14 @@ type Store interface {
 	CountFindingsByAssetIDs(ctx context.Context) (map[string]int, error)
 	LastScan(ctx context.Context) (*model.Scan, error)
 
+	// --- Scan aggregate queries (see scan_aggregates.go) ---
+	CountAssetsByTypeForTarget(ctx context.Context, targetID string) (map[model.AssetType]int, error)
+	CountPortsByStatusForTarget(ctx context.Context, targetID string) (map[string]int, error)
+	CountFindingsBySeverityForTarget(ctx context.Context, targetID string, status model.FindingStatus) (map[model.Severity]int, error)
+	CountFindingsByStatusForTarget(ctx context.Context, targetID string) (map[model.FindingStatus]int, error)
+	AssetChangeCountsForScan(ctx context.Context, scanID string) (map[string]map[model.AssetType]int, error)
+	ScanIsBaseline(ctx context.Context, scanID string) (bool, error)
+
 	Close() error
 }
 
@@ -156,23 +164,49 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 }
 
 func (s *SQLiteStore) runMigrations() error {
-	migration, err := migrationsFS.ReadFile("migrations/001_init.sql")
-	if err != nil {
-		return fmt.Errorf("reading migration 001: %w", err)
-	}
-	if _, err = s.db.Exec(string(migration)); err != nil {
-		return fmt.Errorf("executing migration 001: %w", err)
+	// Migrations are applied in numeric order. Each migration is idempotent
+	// against its own starting state, but we gate 003 on the presence of
+	// the legacy scans.stats column since 003 drops it. Running 003 twice
+	// against an already-migrated database would fail on the ALTER.
+	for _, m := range []string{"001_init.sql", "002_asset_changes.sql"} {
+		sqlBytes, err := migrationsFS.ReadFile("migrations/" + m)
+		if err != nil {
+			return fmt.Errorf("reading migration %s: %w", m, err)
+		}
+		if _, err = s.db.Exec(string(sqlBytes)); err != nil {
+			return fmt.Errorf("executing migration %s: %w", m, err)
+		}
 	}
 
-	migration002, err := migrationsFS.ReadFile("migrations/002_asset_changes.sql")
-	if err != nil {
-		return fmt.Errorf("reading migration 002: %w", err)
-	}
-	if _, err = s.db.Exec(string(migration002)); err != nil {
-		return fmt.Errorf("executing migration 002: %w", err)
+	schemaVersion, _ := s.getSchemaVersion()
+	if schemaVersion < 3 {
+		m003, err := migrationsFS.ReadFile("migrations/003_scan_state_model.sql")
+		if err != nil {
+			return fmt.Errorf("reading migration 003: %w", err)
+		}
+		if _, err = s.db.Exec(string(m003)); err != nil {
+			return fmt.Errorf("executing migration 003: %w", err)
+		}
 	}
 
 	return nil
+}
+
+// getSchemaVersion reads the current schema version from agent_meta. Returns
+// 0 and nil when the key is absent (fresh DB or pre-003 DB without the
+// schema_version key populated beyond the initial '1').
+func (s *SQLiteStore) getSchemaVersion() (int, error) {
+	var v string
+	err := s.db.QueryRow(`SELECT value FROM agent_meta WHERE key = 'schema_version'`).Scan(&v)
+	if err != nil {
+		return 0, err
+	}
+	var n int
+	_, scanErr := fmt.Sscanf(v, "%d", &n)
+	if scanErr != nil {
+		return 0, scanErr
+	}
+	return n, nil
 }
 
 func (s *SQLiteStore) Close() error {
@@ -297,16 +331,18 @@ func (s *SQLiteStore) CreateScan(ctx context.Context, sc *model.Scan) error {
 	sc.CreatedAt = now
 	sc.UpdatedAt = now
 
-	statsJSON, err := json.Marshal(sc.Stats)
+	stateJSON, deltaJSON, workJSON, err := marshalScanAggregates(sc)
 	if err != nil {
-		return fmt.Errorf("marshaling scan stats: %w", err)
+		return err
 	}
 
 	_, err = s.db.ExecContext(ctx,
-		`INSERT INTO scans (id, target_id, type, status, phase, progress, stats, started_at, finished_at, error, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO scans (id, target_id, type, status, phase, progress, target_state, delta, work,
+		                   started_at, finished_at, error, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		sc.ID, sc.TargetID, string(sc.Type), string(sc.Status), sc.Phase, sc.Progress,
-		string(statsJSON), timePtr(sc.StartedAt), timePtr(sc.FinishedAt),
+		stateJSON, deltaJSON, workJSON,
+		timePtr(sc.StartedAt), timePtr(sc.FinishedAt),
 		sc.Error, sc.CreatedAt.Format(timeFormat), sc.UpdatedAt.Format(timeFormat),
 	)
 	if err != nil {
@@ -315,17 +351,58 @@ func (s *SQLiteStore) CreateScan(ctx context.Context, sc *model.Scan) error {
 	return nil
 }
 
+// marshalScanAggregates serializes the three scan snapshot blobs. Returns
+// the three JSON strings in target_state / delta / work order.
+func marshalScanAggregates(sc *model.Scan) (string, string, string, error) {
+	stateJSON, err := json.Marshal(sc.TargetState)
+	if err != nil {
+		return "", "", "", fmt.Errorf("marshaling target_state: %w", err)
+	}
+	deltaJSON, err := json.Marshal(sc.Delta)
+	if err != nil {
+		return "", "", "", fmt.Errorf("marshaling delta: %w", err)
+	}
+	workJSON, err := json.Marshal(sc.Work)
+	if err != nil {
+		return "", "", "", fmt.Errorf("marshaling work: %w", err)
+	}
+	return string(stateJSON), string(deltaJSON), string(workJSON), nil
+}
+
+// unmarshalScanAggregates populates the three snapshot fields from their
+// JSON blobs. Empty / null blobs degrade cleanly to zero-valued structs.
+func unmarshalScanAggregates(sc *model.Scan, stateJSON, deltaJSON, workJSON string) error {
+	if stateJSON != "" {
+		if err := json.Unmarshal([]byte(stateJSON), &sc.TargetState); err != nil {
+			return fmt.Errorf("unmarshaling target_state: %w", err)
+		}
+	}
+	if deltaJSON != "" {
+		if err := json.Unmarshal([]byte(deltaJSON), &sc.Delta); err != nil {
+			return fmt.Errorf("unmarshaling delta: %w", err)
+		}
+	}
+	if workJSON != "" {
+		if err := json.Unmarshal([]byte(workJSON), &sc.Work); err != nil {
+			return fmt.Errorf("unmarshaling work: %w", err)
+		}
+	}
+	return nil
+}
+
 func (s *SQLiteStore) GetScan(ctx context.Context, id string) (*model.Scan, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, target_id, type, status, phase, progress, stats, started_at, finished_at, error, created_at, updated_at
+		`SELECT id, target_id, type, status, phase, progress, target_state, delta, work,
+		        started_at, finished_at, error, created_at, updated_at
 		 FROM scans WHERE id = ?`, id)
 
 	var sc model.Scan
-	var statsJSON string
+	var stateJSON, deltaJSON, workJSON string
 	var startedAt, finishedAt, createdAt, updatedAt sql.NullString
 
 	err := row.Scan(&sc.ID, &sc.TargetID, &sc.Type, &sc.Status, &sc.Phase, &sc.Progress,
-		&statsJSON, &startedAt, &finishedAt, &sc.Error, &createdAt, &updatedAt)
+		&stateJSON, &deltaJSON, &workJSON,
+		&startedAt, &finishedAt, &sc.Error, &createdAt, &updatedAt)
 	if err == sql.ErrNoRows {
 		return nil, ErrNotFound
 	}
@@ -333,8 +410,8 @@ func (s *SQLiteStore) GetScan(ctx context.Context, id string) (*model.Scan, erro
 		return nil, fmt.Errorf("scanning scan row: %w", err)
 	}
 
-	if err := json.Unmarshal([]byte(statsJSON), &sc.Stats); err != nil {
-		return nil, fmt.Errorf("unmarshaling scan stats: %w", err)
+	if err := unmarshalScanAggregates(&sc, stateJSON, deltaJSON, workJSON); err != nil {
+		return nil, err
 	}
 	sc.StartedAt = parseTimePtr(startedAt)
 	sc.FinishedAt = parseTimePtr(finishedAt)
@@ -346,15 +423,18 @@ func (s *SQLiteStore) GetScan(ctx context.Context, id string) (*model.Scan, erro
 
 func (s *SQLiteStore) UpdateScan(ctx context.Context, sc *model.Scan) error {
 	sc.UpdatedAt = time.Now().UTC()
-	statsJSON, err := json.Marshal(sc.Stats)
+	stateJSON, deltaJSON, workJSON, err := marshalScanAggregates(sc)
 	if err != nil {
-		return fmt.Errorf("marshaling scan stats: %w", err)
+		return err
 	}
 
 	_, err = s.db.ExecContext(ctx,
-		`UPDATE scans SET status=?, phase=?, progress=?, stats=?, started_at=?, finished_at=?, error=?, updated_at=?
+		`UPDATE scans SET status=?, phase=?, progress=?,
+		                  target_state=?, delta=?, work=?,
+		                  started_at=?, finished_at=?, error=?, updated_at=?
 		 WHERE id=?`,
-		string(sc.Status), sc.Phase, sc.Progress, string(statsJSON),
+		string(sc.Status), sc.Phase, sc.Progress,
+		stateJSON, deltaJSON, workJSON,
 		timePtr(sc.StartedAt), timePtr(sc.FinishedAt), sc.Error,
 		sc.UpdatedAt.Format(timeFormat), sc.ID,
 	)
@@ -369,7 +449,8 @@ func (s *SQLiteStore) ListScans(ctx context.Context, targetID string, limit int)
 		limit = 20
 	}
 
-	query := `SELECT id, target_id, type, status, phase, progress, stats, started_at, finished_at, error, created_at, updated_at FROM scans`
+	query := `SELECT id, target_id, type, status, phase, progress, target_state, delta, work,
+	                 started_at, finished_at, error, created_at, updated_at FROM scans`
 	args := []interface{}{}
 
 	if targetID != "" {
@@ -388,15 +469,16 @@ func (s *SQLiteStore) ListScans(ctx context.Context, targetID string, limit int)
 	scans := make([]model.Scan, 0)
 	for rows.Next() {
 		var sc model.Scan
-		var statsJSON string
+		var stateJSON, deltaJSON, workJSON string
 		var startedAt, finishedAt, createdAt, updatedAt sql.NullString
 
 		if err := rows.Scan(&sc.ID, &sc.TargetID, &sc.Type, &sc.Status, &sc.Phase, &sc.Progress,
-			&statsJSON, &startedAt, &finishedAt, &sc.Error, &createdAt, &updatedAt); err != nil {
+			&stateJSON, &deltaJSON, &workJSON,
+			&startedAt, &finishedAt, &sc.Error, &createdAt, &updatedAt); err != nil {
 			return nil, fmt.Errorf("scanning scan row: %w", err)
 		}
-		if err := json.Unmarshal([]byte(statsJSON), &sc.Stats); err != nil {
-			return nil, fmt.Errorf("unmarshaling scan stats: %w", err)
+		if err := unmarshalScanAggregates(&sc, stateJSON, deltaJSON, workJSON); err != nil {
+			return nil, err
 		}
 		sc.StartedAt = parseTimePtr(startedAt)
 		sc.FinishedAt = parseTimePtr(finishedAt)
@@ -541,6 +623,14 @@ func (s *SQLiteStore) UpsertFinding(ctx context.Context, f *model.Finding) error
 	}
 	f.UpdatedAt = now
 
+	// first_seen_scan_id captures the originating scan and never changes.
+	// If the caller didn't set it explicitly, default to the current scan
+	// on first insert; existing rows keep their original value via
+	// COALESCE in the ON CONFLICT clause below.
+	if f.FirstSeenScanID == "" {
+		f.FirstSeenScanID = f.ScanID
+	}
+
 	if f.References == nil {
 		f.References = []string{}
 	}
@@ -550,15 +640,27 @@ func (s *SQLiteStore) UpsertFinding(ctx context.Context, f *model.Finding) error
 	}
 
 	scanID := sqlNullString(f.ScanID)
+	firstSeenScanID := sqlNullString(f.FirstSeenScanID)
 
+	// ON CONFLICT semantics (SPEC-QA3):
+	//   * scan_id → updated to the latest observing scan. "findings observed
+	//     in scan X" becomes a meaningful COUNT(*) WHERE scan_id=X query.
+	//   * first_seen_scan_id → preserved via COALESCE; first discovery is
+	//     immutable.
+	//   * first_seen → preserved implicitly (column not in UPDATE).
 	_, err = s.db.ExecContext(ctx,
-		`INSERT INTO findings (id, asset_id, scan_id, template_id, template_name, severity, title, description,
-		   "references", remediation, evidence, cvss, cve, status, source_tool, confidence,
+		`INSERT INTO findings (id, asset_id, scan_id, first_seen_scan_id, template_id, template_name,
+		   severity, title, description, "references", remediation, evidence, cvss, cve, status, source_tool, confidence,
 		   first_seen, last_seen, resolved_at, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(asset_id, template_id, source_tool) DO UPDATE SET
-		   last_seen=excluded.last_seen, severity=excluded.severity, evidence=excluded.evidence, updated_at=excluded.updated_at`,
-		f.ID, f.AssetID, scanID, f.TemplateID, f.TemplateName,
+		   scan_id=excluded.scan_id,
+		   first_seen_scan_id=COALESCE(findings.first_seen_scan_id, excluded.first_seen_scan_id),
+		   last_seen=excluded.last_seen,
+		   severity=excluded.severity,
+		   evidence=excluded.evidence,
+		   updated_at=excluded.updated_at`,
+		f.ID, f.AssetID, scanID, firstSeenScanID, f.TemplateID, f.TemplateName,
 		string(f.Severity), f.Title, f.Description, string(refsJSON),
 		f.Remediation, f.Evidence, f.CVSS, sqlNullString(f.CVE),
 		string(f.Status), f.SourceTool, f.Confidence,
@@ -577,7 +679,7 @@ func (s *SQLiteStore) ListFindings(ctx context.Context, opts FindingListOptions)
 		opts.Limit = 50
 	}
 
-	query := `SELECT id, asset_id, scan_id, template_id, template_name, severity, title, description,
+	query := `SELECT id, asset_id, scan_id, first_seen_scan_id, template_id, template_name, severity, title, description,
 	   "references", remediation, evidence, cvss, cve, status, source_tool, confidence,
 	   first_seen, last_seen, resolved_at, created_at, updated_at
 	   FROM findings`
@@ -634,12 +736,12 @@ func (s *SQLiteStore) ListFindings(ctx context.Context, opts FindingListOptions)
 	findings := make([]model.Finding, 0)
 	for rows.Next() {
 		var f model.Finding
-		var scanID, cve, resolvedAt sql.NullString
+		var scanID, firstSeenScanID, cve, resolvedAt sql.NullString
 		var refsJSON string
 		var firstSeen, lastSeen, createdAt, updatedAt sql.NullString
 		var cvss sql.NullFloat64
 
-		if err := rows.Scan(&f.ID, &f.AssetID, &scanID, &f.TemplateID, &f.TemplateName,
+		if err := rows.Scan(&f.ID, &f.AssetID, &scanID, &firstSeenScanID, &f.TemplateID, &f.TemplateName,
 			&f.Severity, &f.Title, &f.Description, &refsJSON, &f.Remediation,
 			&f.Evidence, &cvss, &cve, &f.Status, &f.SourceTool, &f.Confidence,
 			&firstSeen, &lastSeen, &resolvedAt, &createdAt, &updatedAt); err != nil {
@@ -647,6 +749,7 @@ func (s *SQLiteStore) ListFindings(ctx context.Context, opts FindingListOptions)
 		}
 
 		f.ScanID = scanID.String
+		f.FirstSeenScanID = firstSeenScanID.String
 		f.CVE = cve.String
 		if cvss.Valid {
 			f.CVSS = cvss.Float64
@@ -1065,15 +1168,17 @@ func (s *SQLiteStore) CountFindingsByAssetIDs(ctx context.Context) (map[string]i
 
 func (s *SQLiteStore) LastScan(ctx context.Context) (*model.Scan, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, target_id, type, status, phase, progress, stats, started_at, finished_at, error, created_at, updated_at
+		`SELECT id, target_id, type, status, phase, progress, target_state, delta, work,
+		        started_at, finished_at, error, created_at, updated_at
 		 FROM scans ORDER BY created_at DESC LIMIT 1`)
 
 	var sc model.Scan
-	var statsJSON string
+	var stateJSON, deltaJSON, workJSON string
 	var startedAt, finishedAt, createdAt, updatedAt sql.NullString
 
 	err := row.Scan(&sc.ID, &sc.TargetID, &sc.Type, &sc.Status, &sc.Phase, &sc.Progress,
-		&statsJSON, &startedAt, &finishedAt, &sc.Error, &createdAt, &updatedAt)
+		&stateJSON, &deltaJSON, &workJSON,
+		&startedAt, &finishedAt, &sc.Error, &createdAt, &updatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -1081,8 +1186,8 @@ func (s *SQLiteStore) LastScan(ctx context.Context) (*model.Scan, error) {
 		return nil, fmt.Errorf("scanning last scan: %w", err)
 	}
 
-	if err := json.Unmarshal([]byte(statsJSON), &sc.Stats); err != nil {
-		return nil, fmt.Errorf("unmarshaling scan stats: %w", err)
+	if err := unmarshalScanAggregates(&sc, stateJSON, deltaJSON, workJSON); err != nil {
+		return nil, err
 	}
 	sc.StartedAt = parseTimePtr(startedAt)
 	sc.FinishedAt = parseTimePtr(finishedAt)
@@ -1128,18 +1233,18 @@ func (s *SQLiteStore) GetAsset(ctx context.Context, id string) (*model.Asset, er
 
 func (s *SQLiteStore) GetFinding(ctx context.Context, id string) (*model.Finding, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, asset_id, scan_id, template_id, template_name, severity, title, description,
+		`SELECT id, asset_id, scan_id, first_seen_scan_id, template_id, template_name, severity, title, description,
 		   "references", remediation, evidence, cvss, cve, status, source_tool, confidence,
 		   first_seen, last_seen, resolved_at, created_at, updated_at
 		 FROM findings WHERE id = ?`, id)
 
 	var f model.Finding
-	var scanID, cve, resolvedAt sql.NullString
+	var scanID, firstSeenScanID, cve, resolvedAt sql.NullString
 	var refsJSON string
 	var firstSeen, lastSeen, createdAt, updatedAt sql.NullString
 	var cvss sql.NullFloat64
 
-	err := row.Scan(&f.ID, &f.AssetID, &scanID, &f.TemplateID, &f.TemplateName,
+	err := row.Scan(&f.ID, &f.AssetID, &scanID, &firstSeenScanID, &f.TemplateID, &f.TemplateName,
 		&f.Severity, &f.Title, &f.Description, &refsJSON, &f.Remediation,
 		&f.Evidence, &cvss, &cve, &f.Status, &f.SourceTool, &f.Confidence,
 		&firstSeen, &lastSeen, &resolvedAt, &createdAt, &updatedAt)
@@ -1151,6 +1256,7 @@ func (s *SQLiteStore) GetFinding(ctx context.Context, id string) (*model.Finding
 	}
 
 	f.ScanID = scanID.String
+	f.FirstSeenScanID = firstSeenScanID.String
 	f.CVE = cve.String
 	if cvss.Valid {
 		f.CVSS = cvss.Float64

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -82,20 +82,34 @@ type overviewResponse struct {
 }
 
 
+// scanSummary mirrors the three-concept Scan model (agent-spec 2.0) so the
+// dashboard can render target_state / delta / work sections without a
+// second round-trip. FindingsCount is kept as a flat convenience for the
+// existing "Findings" cell; new consumers should read TargetState directly.
 type scanSummary struct {
-	ID              string     `json:"id"`
-	Target          string     `json:"target"`
-	Status          string     `json:"status"`
-	StartedAt       *time.Time `json:"started_at"`
-	FinishedAt      *time.Time `json:"finished_at"`
-	DurationSeconds int        `json:"duration_seconds"`
-	FindingsCount   int        `json:"findings_count"`
+	ID              string            `json:"id"`
+	Target          string            `json:"target"`
+	Status          string            `json:"status"`
+	StartedAt       *time.Time        `json:"started_at"`
+	FinishedAt      *time.Time        `json:"finished_at"`
+	DurationSeconds int               `json:"duration_seconds"`
+	FindingsCount   int               `json:"findings_count"`
+	TargetState     model.TargetState `json:"target_state"`
+	Delta           model.ScanDelta   `json:"delta"`
+	Work            model.ScanWork    `json:"work"`
 }
 
+// changeSummary is the dashboard's "Changes Since Last Scan" card payload.
+// Mirrors a flattened view of model.ScanDelta — totals collapsed across
+// asset types and severities so the small card stays readable. The richer
+// per-type breakdown lives in last_scan.delta for clients that want it.
 type changeSummary struct {
-	NewFindings       int `json:"new_findings"`
 	NewAssets         int `json:"new_assets"`
 	DisappearedAssets int `json:"disappeared_assets"`
+	ModifiedAssets    int `json:"modified_assets"`
+	NewFindings       int `json:"new_findings"`
+	ResolvedFindings  int `json:"resolved_findings"`
+	IsBaseline        bool `json:"is_baseline"`
 }
 
 type agentInfo struct {
@@ -191,30 +205,37 @@ func (h *handler) handleOverview(w http.ResponseWriter, r *http.Request) {
 			FinishedAt:      last.FinishedAt,
 			DurationSeconds: dur,
 			FindingsCount:   last.TargetState.FindingsOpenTotal,
+			TargetState:     last.TargetState,
+			Delta:           last.Delta,
+			Work:            last.Work,
 		}
-		resp.ChangesSinceLast = h.getChangeSummary(ctx, last.ID)
+		resp.ChangesSinceLast = changeSummaryFromDelta(last.Delta)
 	}
 
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func (h *handler) getChangeSummary(ctx context.Context, scanID string) *changeSummary {
-	changes, err := h.store.ListAssetChanges(ctx, storage.AssetChangeListOptions{
-		ScanID: scanID,
-		Limit:  1000,
-	})
-	if err != nil {
-		return nil
+// changeSummaryFromDelta flattens a ScanDelta into the dashboard's compact
+// "Changes Since Last Scan" card payload. Replaces the previous
+// getChangeSummary which re-queried asset_changes and never populated
+// new_findings (latent bug — see SUR-244 follow-up). Reads from the
+// already-persisted delta so backend and CLI agree on what changed.
+func changeSummaryFromDelta(delta model.ScanDelta) *changeSummary {
+	cs := &changeSummary{IsBaseline: delta.IsBaseline}
+	for _, n := range delta.NewAssets {
+		cs.NewAssets += n
 	}
-
-	cs := &changeSummary{}
-	for _, c := range changes {
-		switch c.ChangeType {
-		case model.ChangeTypeAppeared:
-			cs.NewAssets++
-		case model.ChangeTypeDisappeared:
-			cs.DisappearedAssets++
-		}
+	for _, n := range delta.DisappearedAssets {
+		cs.DisappearedAssets += n
+	}
+	for _, n := range delta.ModifiedAssets {
+		cs.ModifiedAssets += n
+	}
+	for _, n := range delta.NewFindings {
+		cs.NewFindings += n
+	}
+	for _, n := range delta.ResolvedFindings {
+		cs.ResolvedFindings += n
 	}
 	return cs
 }

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -242,11 +242,21 @@ func changeSummaryFromDelta(delta model.ScanDelta) *changeSummary {
 
 // --- Findings ---
 
+// findingEnriched extends a Finding with the affected asset's value and type
+// so the webui can render the distinguishing host/endpoint column without a
+// per-row round-trip. Asset fields are derived via a single bulk lookup
+// keyed by asset_id at list time.
+type findingEnriched struct {
+	model.Finding
+	AssetValue string `json:"asset_value,omitempty"`
+	AssetType  string `json:"asset_type,omitempty"`
+}
+
 type findingsResponse struct {
-	Findings []model.Finding `json:"findings"`
-	Total    int             `json:"total"`
-	Page     int             `json:"page"`
-	Limit    int             `json:"limit"`
+	Findings []findingEnriched `json:"findings"`
+	Total    int               `json:"total"`
+	Page     int               `json:"page"`
+	Limit    int               `json:"limit"`
 }
 
 func (h *handler) handleFindings(w http.ResponseWriter, r *http.Request) {
@@ -300,11 +310,50 @@ func (h *handler) handleFindings(w http.ResponseWriter, r *http.Request) {
 	total, _ := h.store.CountFindingsFiltered(r.Context(), opts)
 
 	writeJSON(w, http.StatusOK, findingsResponse{
-		Findings: findings,
+		Findings: h.enrichFindings(r.Context(), findings),
 		Total:    total,
 		Page:     page,
 		Limit:    limit,
 	})
+}
+
+// enrichFindings resolves each finding's asset_id to the asset's value and
+// type via a single pass over the unique asset_ids. Findings whose asset no
+// longer exists (e.g. deleted target) are returned with empty asset fields
+// rather than dropped — the raw finding data is still useful.
+//
+// Bulk-loading all referenced assets at once keeps list-page rendering at
+// O(1) DB round-trips regardless of page size.
+func (h *handler) enrichFindings(ctx context.Context, findings []model.Finding) []findingEnriched {
+	out := make([]findingEnriched, len(findings))
+	if len(findings) == 0 {
+		return out
+	}
+
+	// Collect unique asset_ids to avoid repeated lookups when many
+	// findings share the same host.
+	seen := make(map[string]struct{}, len(findings))
+	for _, f := range findings {
+		if f.AssetID != "" {
+			seen[f.AssetID] = struct{}{}
+		}
+	}
+	lookup := make(map[string]model.Asset, len(seen))
+	for id := range seen {
+		if a, err := h.store.GetAsset(ctx, id); err == nil && a != nil {
+			lookup[id] = *a
+		}
+	}
+
+	for i, f := range findings {
+		e := findingEnriched{Finding: f}
+		if a, ok := lookup[f.AssetID]; ok {
+			e.AssetValue = a.Value
+			e.AssetType = string(a.Type)
+		}
+		out[i] = e
+	}
+	return out
 }
 
 func (h *handler) handleFindingDetail(w http.ResponseWriter, r *http.Request) {

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -190,7 +190,7 @@ func (h *handler) handleOverview(w http.ResponseWriter, r *http.Request) {
 			StartedAt:       last.StartedAt,
 			FinishedAt:      last.FinishedAt,
 			DurationSeconds: dur,
-			FindingsCount:   last.Stats.FindingsTotal,
+			FindingsCount:   last.TargetState.FindingsOpenTotal,
 		}
 		resp.ChangesSinceLast = h.getChangeSummary(ctx, last.ID)
 	}
@@ -891,8 +891,8 @@ func (h *handler) handleCreateScan(w http.ResponseWriter, r *http.Request) {
 			log.Printf("[webui] scan error for %s: %v", target.Value, err)
 			return
 		}
-		log.Printf("[webui] scan completed for %s: %d findings, %d assets in %s",
-			target.Value, result.TotalFindings, result.TotalAssets, result.Duration)
+		log.Printf("[webui] scan completed for %s: %d findings open, %d assets in %s",
+			target.Value, result.TargetState.FindingsOpenTotal, result.TargetState.AssetsTotal, result.Duration)
 	}()
 
 	resp := map[string]any{

--- a/internal/webui/handlers_test.go
+++ b/internal/webui/handlers_test.go
@@ -48,11 +48,11 @@ func seedTestData(t *testing.T, s *storage.SQLiteStore) {
 		Progress:   100,
 		StartedAt:  &started,
 		FinishedAt: &now,
-		Stats: model.ScanStats{
-			SubdomainsFound:  3,
-			FindingsTotal:    2,
-			FindingsCritical: 1,
-			FindingsHigh:     1,
+		TargetState: model.TargetState{
+			AssetsByType:      map[model.AssetType]int{model.AssetTypeSubdomain: 3},
+			AssetsTotal:       3,
+			FindingsOpen:      map[model.Severity]int{model.SeverityCritical: 1, model.SeverityHigh: 1},
+			FindingsOpenTotal: 2,
 		},
 	}
 	require.NoError(t, s.CreateScan(ctx, scan))

--- a/internal/webui/handlers_test.go
+++ b/internal/webui/handlers_test.go
@@ -132,6 +132,38 @@ func TestHandleOverview(t *testing.T) {
 	require.Len(t, resp.ScoreBreakdown, 2)
 	assert.Equal(t, "critical", resp.ScoreBreakdown[0].Severity)
 	assert.Equal(t, 25, resp.ScoreBreakdown[0].Penalty)
+
+	// agent-spec 2.0: last_scan must surface the three aggregates so the
+	// dashboard can render them without a second round-trip.
+	assert.Equal(t, 3, resp.LastScan.TargetState.AssetsByType[model.AssetTypeSubdomain],
+		"last_scan.target_state must surface the persisted snapshot")
+	assert.Equal(t, 2, resp.LastScan.TargetState.FindingsOpenTotal)
+}
+
+// TestChangeSummaryFromDelta is the regression gate for the latent webui
+// bug where getChangeSummary always returned new_findings == 0 because it
+// recomputed from asset_changes (which only tracks asset deltas, not
+// findings). After the SUR-244 cleanup the dashboard reads the persisted
+// ScanDelta directly, so new_findings / resolved_findings are now correct.
+func TestChangeSummaryFromDelta(t *testing.T) {
+	delta := model.ScanDelta{
+		NewAssets:         map[model.AssetType]int{model.AssetTypeSubdomain: 2, model.AssetTypeURL: 1},
+		DisappearedAssets: map[model.AssetType]int{model.AssetTypeIPv4: 1},
+		ModifiedAssets:    map[model.AssetType]int{model.AssetTypePort: 1},
+		NewFindings:       map[model.Severity]int{model.SeverityCritical: 1, model.SeverityHigh: 2},
+		ResolvedFindings:  map[model.Severity]int{model.SeverityMedium: 1},
+	}
+
+	cs := changeSummaryFromDelta(delta)
+	assert.Equal(t, 3, cs.NewAssets, "totals across asset types")
+	assert.Equal(t, 1, cs.DisappearedAssets)
+	assert.Equal(t, 1, cs.ModifiedAssets)
+	assert.Equal(t, 3, cs.NewFindings, "must include findings, not just asset_changes (was always 0 pre-SUR-244)")
+	assert.Equal(t, 1, cs.ResolvedFindings)
+	assert.False(t, cs.IsBaseline)
+
+	baseline := changeSummaryFromDelta(model.ScanDelta{IsBaseline: true})
+	assert.True(t, baseline.IsBaseline, "baseline flag must propagate")
 }
 
 func TestHandleFindings(t *testing.T) {

--- a/internal/webui/security.go
+++ b/internal/webui/security.go
@@ -62,8 +62,24 @@ func allowedOrigins(port int) []string {
 // securityHeaders sets the baseline response headers on every response.
 // Cache-Control: no-store is added for /api/* so JSON snapshots are never
 // cached by intermediaries (or by the browser tab).
+//
+// CSP rationale (loopback UI):
+//   - script-src 'unsafe-inline' is required because the SPA shell uses
+//     inline <script> blocks for bootstrap (token injection, route hash
+//     handling). All scripts are self-authored and there is no third-party
+//     content surface.
+//   - style-src 'unsafe-inline' is required because the rendered HTML
+//     uses ad-hoc style="..." attributes for one-off per-element values
+//     (progress bar widths, severity colors, layout tweaks). Without it
+//     CSP silently drops every inline style — e.g. the running-scan
+//     progress bar always rendered at 100% because style="width:N%" was
+//     never parsed (SUR-244 follow-up). Switching to JS-set styles or
+//     nonce/hash-based CSP would tighten this further; deferred for now.
+//   - script/style execution risk is bounded by the loopback bind +
+//     bearer-token-on-/api gates; remote callers can't reach the UI to
+//     exploit either.
 func securityHeaders(next http.Handler) http.Handler {
-	const csp = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self'; " +
+	const csp = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; " +
 		"img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; " +
 		"base-uri 'none'; form-action 'none'"
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -456,9 +456,17 @@ tr.finding-detail-row td.finding-detail-cell {
   justify-content: flex-end;
 }
 
-.finding-asset {
+/* TYPE cell is narrow (badge-only) so a whole column of "Port service",
+   "Url", "Technology" lines up cleanly. Width is explicit to prevent
+   the longer titles from stretching it. */
+.finding-asset-type {
+  width: 120px;
+  white-space: nowrap;
+}
+
+.finding-asset-value {
   font-size: 11px;
-  max-width: 340px;
+  max-width: 360px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -483,6 +483,116 @@ tr.finding-detail-row td.finding-detail-cell {
   letter-spacing: 0.04em;
 }
 
+/* === Pipeline node accordion (scan detail) ================================
+   Each pipeline node in the scan-detail view can expand inline to show the
+   per-tool telemetry the detection wrappers captured (command, stderr,
+   config, summary). Visual language mirrors the findings table accordion so
+   the interaction is learned once. */
+
+.pipeline-node.pipeline-node-clickable {
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background 0.15s ease;
+}
+
+.pipeline-node.pipeline-node-clickable:hover .pipeline-content {
+  background: var(--bg-hover);
+}
+
+.pipeline-node.pipeline-node-open .pipeline-content {
+  background: var(--bg-hover);
+}
+
+.pipeline-content {
+  padding: 6px 10px;
+  border-radius: 4px;
+  transition: background 0.15s ease;
+}
+
+.pipeline-chevron {
+  margin-left: auto;
+  font-size: 11px;
+  transition: transform 0.15s ease;
+  display: inline-block;
+}
+
+.pipeline-node-open .pipeline-chevron {
+  transform: rotate(90deg);
+  color: var(--accent);
+}
+
+.pipeline-detail {
+  margin-top: 8px;
+  padding: 12px 14px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+.pipeline-detail-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-size: 12px;
+}
+
+.pipeline-detail-section + .pipeline-detail-section {
+  margin-top: 0;
+}
+
+.pipeline-detail-heading {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+
+.pipeline-detail-heading-error {
+  color: var(--sev-critical, #f85149);
+}
+
+.pipeline-detail-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+.pipeline-detail-pre {
+  margin: 0;
+  padding: 8px 10px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--text-primary);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 240px;
+}
+
+/* Stderr/error blocks get a subtle red left border to draw the eye when
+   something went wrong. Stays readable in dark mode. */
+.pipeline-detail-pre.pipeline-detail-stderr {
+  border-left: 2px solid var(--sev-critical, #f85149);
+}
+
+.pipeline-detail-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 16px;
+  font-size: 12px;
+  word-break: break-all;
+}
+
+.pipeline-detail-meta {
+  font-size: 11px;
+  padding-top: 4px;
+  border-top: 1px dashed var(--border);
+}
+
 .mono {
   font-family: var(--font-mono);
   font-size: 12px;

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -362,6 +362,119 @@ tr:hover td { background: var(--bg-hover); }
 
 tr.clickable { cursor: pointer; }
 
+/* === Findings table accordion (scan detail) === */
+
+/* Summary rows are clickable with a visible chevron that rotates when
+   the paired detail row is expanded. We avoid CSS transitions on [hidden]
+   because hidden is binary — the UX just needs a crisp open/closed
+   state, not an animation. */
+tr.finding-row {
+  cursor: pointer;
+}
+
+tr.finding-row td {
+  /* Collapse the border between summary and its expanded detail row so
+     the accordion reads as one visual unit. */
+  transition: background 0.15s ease;
+}
+
+tr.finding-row-open td {
+  background: var(--bg-hover);
+  border-bottom-color: transparent;
+}
+
+.finding-chevron {
+  width: 16px;
+  text-align: center;
+  font-size: 11px;
+  transition: transform 0.15s ease;
+  display: inline-block;
+}
+
+tr.finding-row-open .finding-chevron {
+  transform: rotate(90deg);
+  color: var(--accent);
+}
+
+tr.finding-detail-row td.finding-detail-cell {
+  /* Detail row spans the full table width; kill the default row padding
+     so the nested .finding-detail-body controls its own spacing. */
+  padding: 0;
+  background: var(--bg-primary);
+  border-bottom: 1px solid var(--border);
+}
+
+.finding-detail-body {
+  padding: 14px 18px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.finding-detail-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 16px;
+  font-size: 12px;
+}
+
+.finding-detail-section {
+  font-size: 12px;
+}
+
+.finding-detail-heading {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+
+.finding-detail-text {
+  color: var(--text-primary);
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.finding-detail-evidence {
+  margin: 0;
+  padding: 8px 10px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--text-primary);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  max-height: 240px;
+}
+
+.finding-detail-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.finding-asset {
+  font-size: 11px;
+  max-width: 340px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Compact muted badge used for asset type tags inside the ASSET column.
+   Sized smaller than the existing .badge variants to sit inline without
+   pushing row height. */
+.badge.badge-muted {
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
 .mono {
   font-family: var(--font-mono);
   font-size: 12px;

--- a/internal/webui/static/js/pages/dashboard.js
+++ b/internal/webui/static/js/pages/dashboard.js
@@ -27,27 +27,13 @@ const DashboardPage = {
       : '<div class="score-breakdown">No findings</div>';
 
     const lastScanHtml = d.last_scan
-      ? `<div class="detail-grid">
-           <span class="detail-label">Target</span>
-           <span class="detail-value mono">${escapeHtml(d.last_scan.target)}</span>
-           <span class="detail-label">Status</span>
-           <span class="detail-value">${Components.statusBadge(d.last_scan.status)}</span>
-           <span class="detail-label">Duration</span>
-           <span class="detail-value">${Components.formatDuration(d.last_scan.duration_seconds)}</span>
-           <span class="detail-label">Findings</span>
-           <span class="detail-value">${d.last_scan.findings_count}</span>
-           <span class="detail-label">Finished</span>
-           <span class="detail-value">${Components.timeAgo(d.last_scan.finished_at)}</span>
-         </div>`
+      ? renderLastScanCard(d.last_scan)
       : '<p class="text-muted">No scans yet. Run <code>surfbot scan &lt;target&gt;</code> to get started.</p>';
 
-    const changesHtml = d.changes_since_last
-      ? `<div style="display:flex;gap:24px;padding:8px 0">
-           <div><span style="font-size:20px;font-weight:700;color:var(--success)">+${d.changes_since_last.new_assets}</span><br><span class="text-muted" style="font-size:12px">New assets</span></div>
-           <div><span style="font-size:20px;font-weight:700;color:var(--danger)">-${d.changes_since_last.disappeared_assets}</span><br><span class="text-muted" style="font-size:12px">Disappeared</span></div>
-           <div><span style="font-size:20px;font-weight:700;color:var(--sev-medium)">${d.changes_since_last.new_findings || 0}</span><br><span class="text-muted" style="font-size:12px">New findings</span></div>
-         </div>`
-      : '';
+    // changes_since_last reads ScanDelta from the persisted scan row (no
+    // longer recomputed from asset_changes). new_findings is now correct
+    // — the previous getChangeSummary always returned 0 here.
+    const changesHtml = renderChangesCard(d.changes_since_last);
 
     return `
       <div class="page-header">
@@ -121,6 +107,83 @@ function formatAssetTypes(types) {
   return Object.entries(types)
     .map(([k, v]) => `${v} ${k}`)
     .join(', ');
+}
+
+// renderLastScanCard renders the dashboard's "Last Scan" card. Reads
+// last_scan.target_state for asset/finding counts so the user sees the
+// shape of the target the scan observed, not just a flat findings number.
+function renderLastScanCard(s) {
+  const state = s.target_state || {};
+  const assets = state.assets_by_type || {};
+  const ports = state.ports_by_status || {};
+
+  // Compose a single-line "what the target looks like" summary. Skip
+  // zero-valued buckets so the line stays readable.
+  const stateParts = [];
+  if (assets.subdomain > 0) stateParts.push(`${assets.subdomain} subdomain${assets.subdomain === 1 ? '' : 's'}`);
+  if ((assets.ipv4 || 0) + (assets.ipv6 || 0) > 0) stateParts.push(`${(assets.ipv4 || 0) + (assets.ipv6 || 0)} IPs`);
+  if (ports.open > 0) {
+    let portsLine = `${ports.open} open port${ports.open === 1 ? '' : 's'}`;
+    if (ports.filtered > 0) portsLine += ` (${ports.filtered} filtered)`;
+    stateParts.push(portsLine);
+  }
+  if (assets.url > 0) stateParts.push(`${assets.url} endpoint${assets.url === 1 ? '' : 's'}`);
+  if (assets.technology > 0) stateParts.push(`${assets.technology} tech`);
+
+  const stateLine = stateParts.length > 0
+    ? `<div class="text-muted" style="font-size:13px;margin-top:4px">${stateParts.join(' · ')}</div>`
+    : '';
+
+  const work = s.work || {};
+  const workLine = work.tools_run > 0
+    ? `<div class="text-muted" style="font-size:12px;margin-top:4px">${work.tools_run} tools${work.tools_failed > 0 ? `, ${work.tools_failed} failed` : ''}</div>`
+    : '';
+
+  return `<div class="detail-grid">
+    <span class="detail-label">Target</span>
+    <span class="detail-value mono">${escapeHtml(s.target)}</span>
+    <span class="detail-label">Status</span>
+    <span class="detail-value">${Components.statusBadge(s.status)}</span>
+    <span class="detail-label">Duration</span>
+    <span class="detail-value">${Components.formatDuration(s.duration_seconds)}</span>
+    <span class="detail-label">Findings open</span>
+    <span class="detail-value">${s.findings_count}</span>
+    <span class="detail-label">Finished</span>
+    <span class="detail-value">${Components.timeAgo(s.finished_at)}</span>
+  </div>${stateLine}${workLine}`;
+}
+
+// renderChangesCard renders the "Changes Since Last Scan" card. Reads from
+// the persisted ScanDelta (same source as the CLI's PrintChangeSummary), so
+// dashboard and CLI report the same numbers.
+function renderChangesCard(c) {
+  if (!c) return '';
+  if (c.is_baseline) {
+    return '<p class="text-muted" style="margin:8px 0 0">Baseline scan — first run. Subsequent scans will show what changed.</p>';
+  }
+  const total = (c.new_assets || 0) + (c.disappeared_assets || 0) + (c.modified_assets || 0)
+              + (c.new_findings || 0) + (c.resolved_findings || 0);
+  if (total === 0) {
+    return '<p class="text-muted" style="margin:8px 0 0">No changes since last scan.</p>';
+  }
+
+  const cells = [];
+  if ((c.new_assets || 0) > 0) {
+    cells.push(`<div><span style="font-size:20px;font-weight:700;color:var(--success)">+${c.new_assets}</span><br><span class="text-muted" style="font-size:12px">New assets</span></div>`);
+  }
+  if ((c.disappeared_assets || 0) > 0) {
+    cells.push(`<div><span style="font-size:20px;font-weight:700;color:var(--danger)">−${c.disappeared_assets}</span><br><span class="text-muted" style="font-size:12px">Disappeared</span></div>`);
+  }
+  if ((c.modified_assets || 0) > 0) {
+    cells.push(`<div><span style="font-size:20px;font-weight:700;color:var(--sev-medium)">~${c.modified_assets}</span><br><span class="text-muted" style="font-size:12px">Modified</span></div>`);
+  }
+  if ((c.new_findings || 0) > 0) {
+    cells.push(`<div><span style="font-size:20px;font-weight:700;color:var(--success)">+${c.new_findings}</span><br><span class="text-muted" style="font-size:12px">New findings</span></div>`);
+  }
+  if ((c.resolved_findings || 0) > 0) {
+    cells.push(`<div><span style="font-size:20px;font-weight:700;color:var(--success)">✓${c.resolved_findings}</span><br><span class="text-muted" style="font-size:12px">Resolved</span></div>`);
+  }
+  return `<div style="display:flex;gap:24px;padding:8px 0;flex-wrap:wrap">${cells.join('')}</div>`;
 }
 
 function updateSidebarBadge(sevCounts) {

--- a/internal/webui/static/js/pages/scans.js
+++ b/internal/webui/static/js/pages/scans.js
@@ -421,25 +421,137 @@ const ScansPage = {
       </div>`;
     }
 
-    const rows = findings.map(f => `
-      <tr class="clickable" onclick="location.hash='#/findings/${f.id}'">
-        <td>${Components.severityBadge ? Components.severityBadge(f.severity) : `<span class="badge badge-${f.severity}">${f.severity}</span>`}</td>
-        <td>${escapeHtml(f.title)}</td>
-        <td class="mono text-muted" style="font-size:11px">${escapeHtml(f.template_id || '-')}</td>
-        <td class="mono text-muted" style="font-size:11px">${escapeHtml(f.source_tool || '-')}</td>
-        <td>${Components.statusBadge(f.status)}</td>
-      </tr>
-    `).join('');
+    // Two <tr> per finding: a clickable summary row and a collapsible
+    // detail row that is expanded inline on click. Keeping the detail
+    // inline (rather than navigating to /findings/{id}) preserves the
+    // surrounding scan context so the user can compare rows without
+    // losing their place.
+    //
+    // The ASSET column surfaces the distinguishing host/endpoint so
+    // findings from the same template against different targets stop
+    // looking identical in the list (the common case: "HTTP Missing
+    // Security Headers" × 9 with no hint of what's affected).
+    const rows = findings.map((f, idx) => {
+      const assetLabel = this.formatAssetCell(f);
+      const detailHTML = this.renderFindingDetail(f);
+      return `
+        <tr class="finding-row" data-finding-idx="${idx}" title="Click to expand">
+          <td>${Components.severityBadge ? Components.severityBadge(f.severity) : `<span class="badge badge-${f.severity}">${f.severity}</span>`}</td>
+          <td>${escapeHtml(f.title)}</td>
+          <td class="finding-asset mono" title="${escapeHtml(f.asset_value || '')}">${assetLabel}</td>
+          <td class="mono text-muted" style="font-size:11px">${escapeHtml(f.template_id || '-')}</td>
+          <td class="mono text-muted" style="font-size:11px">${escapeHtml(f.source_tool || '-')}</td>
+          <td>${Components.statusBadge(f.status)}</td>
+          <td class="finding-chevron text-muted" aria-hidden="true">▸</td>
+        </tr>
+        <tr class="finding-detail-row" data-finding-idx="${idx}" hidden>
+          <td colspan="7" class="finding-detail-cell">${detailHTML}</td>
+        </tr>
+      `;
+    }).join('');
 
     return `<div class="card">
       <div class="card-label">Findings <span class="text-muted" style="font-weight:400;text-transform:none">(${findings.length})</span></div>
       <div class="table-container" style="border:none;margin:8px 0 0">
-        <table>
-          <thead><tr><th>Severity</th><th>Title</th><th>Template</th><th>Tool</th><th>Status</th></tr></thead>
+        <table class="findings-table">
+          <thead><tr>
+            <th>Severity</th>
+            <th>Title</th>
+            <th>Asset</th>
+            <th>Template</th>
+            <th>Tool</th>
+            <th>Status</th>
+            <th aria-label="expand"></th>
+          </tr></thead>
           <tbody>${rows}</tbody>
         </table>
       </div>
     </div>`;
+  },
+
+  // formatAssetCell renders the asset column. Prefers the human value
+  // (e.g. "https://example.com"), truncated to keep the row compact.
+  // Falls back to the asset_id short hash or an em dash.
+  formatAssetCell(f) {
+    if (f.asset_value) {
+      const label = f.asset_value.length > 48 ? f.asset_value.slice(0, 45) + '…' : f.asset_value;
+      const typeTag = f.asset_type
+        ? `<span class="badge badge-muted" style="margin-right:6px;font-size:10px">${escapeHtml(this.titleCase(f.asset_type))}</span>`
+        : '';
+      return typeTag + escapeHtml(label);
+    }
+    if (f.asset_id) {
+      return `<span class="text-muted">${f.asset_id.slice(0, 8)}</span>`;
+    }
+    return '<span class="text-muted">—</span>';
+  },
+
+  // renderFindingDetail renders the expanded-row content for a single
+  // finding. Shows the distinguishing bits the list row omits (evidence,
+  // description, confidence/CVSS/CVE, timestamps) and offers a "View
+  // finding" link for the full-page view.
+  renderFindingDetail(f) {
+    const meta = [];
+    if (f.asset_value) {
+      meta.push({ label: 'Asset', value: `<span class="mono">${escapeHtml(f.asset_value)}</span>` });
+    }
+    if (f.cvss) meta.push({ label: 'CVSS', value: String(f.cvss) });
+    if (f.cve) meta.push({ label: 'CVE', value: `<span class="mono">${escapeHtml(f.cve)}</span>` });
+    if (typeof f.confidence === 'number') meta.push({ label: 'Confidence', value: f.confidence + '%' });
+    if (f.first_seen) meta.push({ label: 'First seen', value: Components.timeAgo(f.first_seen) });
+    if (f.last_seen) meta.push({ label: 'Last seen', value: Components.timeAgo(f.last_seen) });
+
+    const metaGrid = meta.length > 0
+      ? `<div class="finding-detail-grid">${meta.map(m => `<span class="detail-label">${m.label}</span><span class="detail-value">${m.value}</span>`).join('')}</div>`
+      : '';
+
+    const desc = f.description
+      ? `<div class="finding-detail-section"><div class="finding-detail-heading">Description</div><div class="finding-detail-text">${escapeHtml(f.description)}</div></div>`
+      : '';
+    const evidence = f.evidence
+      ? `<div class="finding-detail-section"><div class="finding-detail-heading">Evidence</div><pre class="finding-detail-evidence">${escapeHtml(f.evidence)}</pre></div>`
+      : '';
+    const remediation = f.remediation
+      ? `<div class="finding-detail-section"><div class="finding-detail-heading">Remediation</div><div class="finding-detail-text">${escapeHtml(f.remediation)}</div></div>`
+      : '';
+
+    const viewBtn = `<a href="#/findings/${f.id}" class="btn btn-sm" onclick="event.stopPropagation()">View finding →</a>`;
+
+    return `
+      <div class="finding-detail-body">
+        ${metaGrid}
+        ${desc}
+        ${evidence}
+        ${remediation}
+        <div class="finding-detail-actions">${viewBtn}</div>
+      </div>
+    `;
+  },
+
+  // bindFindingsAccordion wires click handlers on finding summary rows
+  // to toggle their paired detail row. Uses data-finding-idx for
+  // pairing so repeated re-renders (polling) don't lose or duplicate
+  // listeners — we re-bind fresh each time.
+  bindFindingsAccordion() {
+    document.querySelectorAll('.finding-row').forEach(row => {
+      row.addEventListener('click', (e) => {
+        // Ignore clicks that originated on interactive descendants so
+        // the "View finding" link continues to navigate instead of
+        // toggling.
+        if (e.target.closest('a, button')) return;
+        const idx = row.dataset.findingIdx;
+        const detail = document.querySelector(`.finding-detail-row[data-finding-idx="${idx}"]`);
+        if (!detail) return;
+        const isOpen = !detail.hasAttribute('hidden');
+        if (isOpen) {
+          detail.setAttribute('hidden', '');
+          row.classList.remove('finding-row-open');
+        } else {
+          detail.removeAttribute('hidden');
+          row.classList.add('finding-row-open');
+        }
+      });
+    });
   },
 
   // agent-spec 2.0: a Scan exposes three semantically distinct aggregates.
@@ -684,6 +796,11 @@ const ScansPage = {
         ` : ''}
       </div>
     `;
+
+    // Findings-table accordion: rebind after every render (polling may
+    // re-render the whole detail, and template literal innerHTML drops
+    // previous listeners).
+    this.bindFindingsAccordion();
 
     // Bind cancel button
     if (isRunning) {

--- a/internal/webui/static/js/pages/scans.js
+++ b/internal/webui/static/js/pages/scans.js
@@ -106,7 +106,7 @@ const ScansPage = {
           <td>${Components.statusBadge(s.status)}</td>
           <td>${s.type}</td>
           <td class="mono">${dur}</td>
-          <td>${s.stats.findings_total || 0} findings</td>
+          <td>${(s.target_state && s.target_state.findings_open_total) || 0} findings</td>
           <td class="text-muted">${Components.timeAgo(s.created_at)}</td>
         </tr>
       `;
@@ -442,34 +442,42 @@ const ScansPage = {
     </div>`;
   },
 
-  renderScanStats(stats) {
-    // Only show stats that have non-zero values
-    const items = [
-      { label: 'Subdomains', value: stats.subdomains_found },
-      { label: 'IPs Resolved', value: stats.ips_resolved },
-      { label: 'Ports Scanned', value: stats.ports_scanned },
-      { label: 'Open Ports', value: stats.open_ports },
-      { label: 'HTTP Probed', value: stats.http_probed },
-      { label: 'Findings', value: stats.findings_total },
+  renderScanStats(scan) {
+    // agent-spec 2.0: scan exposes target_state (DB-derived snapshot),
+    // delta (what this scan changed), and work (telemetry). Render all
+    // three if they have content.
+    const state = scan.target_state || {};
+    const assets = state.assets_by_type || {};
+    const ports = state.ports_by_status || {};
+
+    const stateItems = [
+      { label: 'Subdomains', value: assets.subdomain },
+      { label: 'IPs (v4)', value: assets.ipv4 },
+      { label: 'IPs (v6)', value: assets.ipv6 },
+      { label: 'Ports (open)', value: ports.open },
+      { label: 'Ports (filtered)', value: ports.filtered },
+      { label: 'Endpoints', value: assets.url },
+      { label: 'Technologies', value: assets.technology },
+      { label: 'Findings open', value: state.findings_open_total },
     ].filter(i => i.value > 0);
 
-    if (items.length === 0) return '';
+    if (stateItems.length === 0) return '';
 
-    const sevs = {
-      critical: stats.findings_critical || 0,
-      high: stats.findings_high || 0,
-      medium: stats.findings_medium || 0,
-      low: stats.findings_low || 0,
-      info: stats.findings_info || 0,
-    };
+    const sevs = state.findings_open || {};
     const hasSev = Object.values(sevs).some(v => v > 0);
 
     return `<div class="card">
-      <div class="card-label">Scan Stats</div>
+      <div class="card-label">Target state</div>
       <div class="detail-grid" style="margin-top:8px">
-        ${items.map(i => `<span class="detail-label">${i.label}</span><span class="detail-value">${i.value}</span>`).join('')}
+        ${stateItems.map(i => `<span class="detail-label">${i.label}</span><span class="detail-value">${i.value}</span>`).join('')}
       </div>
-      ${hasSev ? Components.severityBars(sevs) : ''}
+      ${hasSev ? Components.severityBars({
+        critical: sevs.critical || 0,
+        high: sevs.high || 0,
+        medium: sevs.medium || 0,
+        low: sevs.low || 0,
+        info: sevs.info || 0,
+      }) : ''}
     </div>`;
   },
 
@@ -545,7 +553,7 @@ const ScansPage = {
 
         ${this.renderFindings(findings, s.id)}
 
-        ${this.renderScanStats(s.stats)}
+        ${this.renderScanStats(s)}
 
         ${data.changes.length > 0 ? `
           <div>

--- a/internal/webui/static/js/pages/scans.js
+++ b/internal/webui/static/js/pages/scans.js
@@ -432,14 +432,15 @@ const ScansPage = {
     // looking identical in the list (the common case: "HTTP Missing
     // Security Headers" × 9 with no hint of what's affected).
     const rows = findings.map((f, idx) => {
-      const assetLabel = this.formatAssetCell(f);
+      const assetTypeCell = this.formatAssetTypeCell(f);
+      const assetValueCell = this.formatAssetValueCell(f);
       const detailHTML = this.renderFindingDetail(f);
       return `
         <tr class="finding-row" data-finding-idx="${idx}" title="Click to expand">
           <td>${Components.severityBadge ? Components.severityBadge(f.severity) : `<span class="badge badge-${f.severity}">${f.severity}</span>`}</td>
           <td>${escapeHtml(f.title)}</td>
-          <td class="finding-asset mono" title="${escapeHtml(f.asset_value || '')}">${assetLabel}</td>
-          <td class="mono text-muted" style="font-size:11px">${escapeHtml(f.template_id || '-')}</td>
+          <td class="finding-asset-type">${assetTypeCell}</td>
+          <td class="finding-asset-value mono" title="${escapeHtml(f.asset_value || '')}">${assetValueCell}</td>
           <td class="mono text-muted" style="font-size:11px">${escapeHtml(f.source_tool || '-')}</td>
           <td>${Components.statusBadge(f.status)}</td>
           <td class="finding-chevron text-muted" aria-hidden="true">▸</td>
@@ -457,8 +458,8 @@ const ScansPage = {
           <thead><tr>
             <th>Severity</th>
             <th>Title</th>
+            <th>Type</th>
             <th>Asset</th>
-            <th>Template</th>
             <th>Tool</th>
             <th>Status</th>
             <th aria-label="expand"></th>
@@ -469,16 +470,20 @@ const ScansPage = {
     </div>`;
   },
 
-  // formatAssetCell renders the asset column. Prefers the human value
-  // (e.g. "https://example.com"), truncated to keep the row compact.
-  // Falls back to the asset_id short hash or an em dash.
-  formatAssetCell(f) {
+  // Asset is split into two cells so each column is scannable on its own:
+  // TYPE uses a uniform-width muted badge (good for eyeballing groupings
+  // like "all port_service findings"), while ASSET carries the raw value
+  // in monospace. template_id drops out of the main table entirely —
+  // it's reference-level detail better shown in the accordion.
+  formatAssetTypeCell(f) {
+    if (!f.asset_type) return '<span class="text-muted">—</span>';
+    return `<span class="badge badge-muted">${escapeHtml(this.titleCase(f.asset_type))}</span>`;
+  },
+
+  formatAssetValueCell(f) {
     if (f.asset_value) {
-      const label = f.asset_value.length > 48 ? f.asset_value.slice(0, 45) + '…' : f.asset_value;
-      const typeTag = f.asset_type
-        ? `<span class="badge badge-muted" style="margin-right:6px;font-size:10px">${escapeHtml(this.titleCase(f.asset_type))}</span>`
-        : '';
-      return typeTag + escapeHtml(label);
+      const label = f.asset_value.length > 60 ? f.asset_value.slice(0, 57) + '…' : f.asset_value;
+      return escapeHtml(label);
     }
     if (f.asset_id) {
       return `<span class="text-muted">${f.asset_id.slice(0, 8)}</span>`;
@@ -494,6 +499,9 @@ const ScansPage = {
     const meta = [];
     if (f.asset_value) {
       meta.push({ label: 'Asset', value: `<span class="mono">${escapeHtml(f.asset_value)}</span>` });
+    }
+    if (f.template_id) {
+      meta.push({ label: 'Template', value: `<span class="mono">${escapeHtml(f.template_id)}</span>` });
     }
     if (f.cvss) meta.push({ label: 'CVSS', value: String(f.cvss) });
     if (f.cve) meta.push({ label: 'CVE', value: `<span class="mono">${escapeHtml(f.cve)}</span>` });

--- a/internal/webui/static/js/pages/scans.js
+++ b/internal/webui/static/js/pages/scans.js
@@ -384,13 +384,21 @@ const ScansPage = {
         duration = `<span class="tool-duration mono" data-started="${tr.started_at}">${this.formatElapsed(elapsed)}</span>`;
       } else if (tr.duration_ms > 0) {
         duration = `<span class="tool-duration mono">${this.formatDurationMs(tr.duration_ms)}</span>`;
+      } else if (tr.status === 'completed') {
+        // Sub-millisecond runs show as <1ms rather than silently omitting
+        // the column — otherwise subfinder looks like it has no data.
+        duration = `<span class="tool-duration mono text-muted">&lt;1ms</span>`;
       }
 
       const stats = [];
-      if (tr.targets_count > 0) stats.push(`<span class="stat-badge">${tr.targets_count} targets</span>`);
-      if (tr.findings_count > 0) stats.push(`<span class="stat-badge stat-badge-finding">${tr.findings_count} results</span>`);
+      if (tr.targets_count > 0) stats.push(`<span class="stat-badge">${tr.targets_count} ${tr.targets_count === 1 ? 'target' : 'targets'}</span>`);
+      if (tr.findings_count > 0) stats.push(`<span class="stat-badge stat-badge-finding" title="Raw findings emitted by the tool before storage dedup">${tr.findings_count} emitted</span>`);
 
-      return `<div class="pipeline-node ${statusClass}">
+      // Clicking the whole node toggles the paired log detail row.
+      // Providing a hint chevron makes the affordance discoverable.
+      const hasLogs = this.toolRunHasLogs(tr);
+
+      return `<div class="pipeline-node ${statusClass}${hasLogs ? ' pipeline-node-clickable' : ''}" data-tr-idx="${i}"${hasLogs ? ' title="Click to view logs"' : ''}>
         <div class="pipeline-connector">
           <div class="pipeline-dot"></div>
           ${isLast ? '' : '<div class="pipeline-vline"></div>'}
@@ -401,8 +409,10 @@ const ScansPage = {
             <span class="tool-name">${escapeHtml(tr.tool_name)}</span>
             ${Components.statusBadge(tr.status)}
             ${duration}
+            ${hasLogs ? '<span class="pipeline-chevron text-muted" aria-hidden="true">▸</span>' : ''}
           </div>
           ${stats.length > 0 ? `<div class="pipeline-stats">${stats.join('')}</div>` : ''}
+          ${hasLogs ? `<div class="pipeline-detail" data-tr-idx="${i}" hidden>${this.renderToolRunDetail(tr)}</div>` : ''}
         </div>
       </div>`;
     }).join('');
@@ -411,6 +421,106 @@ const ScansPage = {
       <div class="card-label">Pipeline</div>
       <div class="pipeline-view">${nodes}</div>
     </div>`;
+  },
+
+  // A tool run "has logs" worth showing if it carries any of the enriched
+  // telemetry fields the detection wrappers fill in. Nodes without logs
+  // (e.g. skipped-because-no-urls) stay non-clickable.
+  toolRunHasLogs(tr) {
+    if (tr.output_summary) return true;
+    if (tr.error_message) return true;
+    const cfg = tr.config || {};
+    return !!(cfg.command || cfg.stderr_tail || (cfg.input_preview && cfg.input_preview.length > 0));
+  },
+
+  // renderToolRunDetail builds the accordion content for one pipeline
+  // node. Surfaces command args, output summary, input preview, tool-
+  // specific config keys, error message, and stderr tail — all captured
+  // in the wrapper layer (see internal/detection/*.go) and persisted in
+  // tool_runs.config.
+  renderToolRunDetail(tr) {
+    const cfg = tr.config || {};
+    const parts = [];
+
+    if (tr.output_summary) {
+      parts.push(`<div class="pipeline-detail-section">
+        <div class="pipeline-detail-heading">Summary</div>
+        <div class="pipeline-detail-text">${escapeHtml(tr.output_summary)}</div>
+      </div>`);
+    }
+
+    if (cfg.command) {
+      parts.push(`<div class="pipeline-detail-section">
+        <div class="pipeline-detail-heading">Command</div>
+        <pre class="pipeline-detail-pre">${escapeHtml(cfg.command)}</pre>
+      </div>`);
+    }
+
+    // Per-tool config (the keys that aren't the generic exec context).
+    // Presenting them as a definition list keeps the layout predictable.
+    const genericKeys = new Set(['command', 'stderr_tail', 'exit_code', 'input_preview', 'inputs_truncated']);
+    const toolKeys = Object.keys(cfg).filter(k => !genericKeys.has(k));
+    if (toolKeys.length > 0) {
+      const rows = toolKeys.map(k => `<span class="detail-label">${escapeHtml(k)}</span><span class="detail-value mono">${escapeHtml(this.formatConfigValue(cfg[k]))}</span>`).join('');
+      parts.push(`<div class="pipeline-detail-section">
+        <div class="pipeline-detail-heading">Config</div>
+        <div class="pipeline-detail-grid">${rows}</div>
+      </div>`);
+    }
+
+    if (cfg.input_preview && cfg.input_preview.length > 0) {
+      const truncated = cfg.inputs_truncated ? ' <span class="text-muted">(truncated)</span>' : '';
+      parts.push(`<div class="pipeline-detail-section">
+        <div class="pipeline-detail-heading">Inputs${truncated}</div>
+        <pre class="pipeline-detail-pre">${cfg.input_preview.map(escapeHtml).join('\n')}</pre>
+      </div>`);
+    }
+
+    if (cfg.stderr_tail) {
+      parts.push(`<div class="pipeline-detail-section">
+        <div class="pipeline-detail-heading">Stderr tail</div>
+        <pre class="pipeline-detail-pre pipeline-detail-stderr">${escapeHtml(cfg.stderr_tail)}</pre>
+      </div>`);
+    }
+
+    if (tr.error_message) {
+      parts.push(`<div class="pipeline-detail-section">
+        <div class="pipeline-detail-heading pipeline-detail-heading-error">Error</div>
+        <pre class="pipeline-detail-pre pipeline-detail-stderr">${escapeHtml(tr.error_message)}</pre>
+      </div>`);
+    }
+
+    // Meta row at the bottom with timestamps and exit code.
+    const meta = [];
+    if (tr.started_at) meta.push(`started ${Components.timeAgo(tr.started_at)}`);
+    if (typeof cfg.exit_code === 'number') meta.push(`exit ${cfg.exit_code}`);
+    if (meta.length > 0) {
+      parts.push(`<div class="pipeline-detail-meta text-muted">${meta.join(' · ')}</div>`);
+    }
+
+    return `<div class="pipeline-detail-body">${parts.join('')}</div>`;
+  },
+
+  // bindPipelineAccordion wires click handlers on pipeline nodes.
+  // Re-invoked after every render (polling re-renders the whole detail)
+  // so listeners are always fresh.
+  bindPipelineAccordion() {
+    document.querySelectorAll('.pipeline-node-clickable').forEach(node => {
+      node.addEventListener('click', (e) => {
+        if (e.target.closest('a, button')) return;
+        const idx = node.dataset.trIdx;
+        const detail = node.querySelector(`.pipeline-detail[data-tr-idx="${idx}"]`);
+        if (!detail) return;
+        const isOpen = !detail.hasAttribute('hidden');
+        if (isOpen) {
+          detail.setAttribute('hidden', '');
+          node.classList.remove('pipeline-node-open');
+        } else {
+          detail.removeAttribute('hidden');
+          node.classList.add('pipeline-node-open');
+        }
+      });
+    });
   },
 
   renderFindings(findings, scanId) {
@@ -722,6 +832,28 @@ const ScansPage = {
     return s.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
   },
 
+  // formatConfigValue renders a tool-run config value for the config grid.
+  // Arrays become comma lists, objects become compact JSON, everything
+  // else falls back to String(). Long strings get trimmed so the row
+  // doesn't blow out the width.
+  formatConfigValue(v) {
+    if (v == null) return '—';
+    if (Array.isArray(v)) {
+      const joined = v.map(x => String(x)).join(', ');
+      return joined.length > 120 ? joined.slice(0, 117) + '…' : joined;
+    }
+    if (typeof v === 'object') {
+      try {
+        const j = JSON.stringify(v);
+        return j.length > 120 ? j.slice(0, 117) + '…' : j;
+      } catch {
+        return '[object]';
+      }
+    }
+    const s = String(v);
+    return s.length > 120 ? s.slice(0, 117) + '…' : s;
+  },
+
   formatElapsed(seconds) {
     if (seconds < 60) return seconds + 's';
     return Math.floor(seconds / 60) + 'm ' + (seconds % 60) + 's';
@@ -805,10 +937,11 @@ const ScansPage = {
       </div>
     `;
 
-    // Findings-table accordion: rebind after every render (polling may
-    // re-render the whole detail, and template literal innerHTML drops
+    // Accordions (findings + pipeline): rebind after every render (polling
+    // may re-render the whole detail, and template literal innerHTML drops
     // previous listeners).
     this.bindFindingsAccordion();
+    this.bindPipelineAccordion();
 
     // Bind cancel button
     if (isRunning) {

--- a/internal/webui/static/js/pages/scans.js
+++ b/internal/webui/static/js/pages/scans.js
@@ -894,10 +894,17 @@ const ScansPage = {
         </div>`
       : '';
 
+    // Asset Changes table is noisy during a baseline scan — every asset
+    // the target has gets an "appeared (Baseline)" row that duplicates the
+    // Target State card. The delta card already says "Baseline scan — run
+    // again to detect changes", so hide the raw table to avoid repeating
+    // the same info in three places (Target State + Changes card + Asset
+    // Changes table). Non-baseline scans render the table as before.
+    const isBaseline = !!(s.delta && s.delta.is_baseline);
     const changeRows = data.changes.map(c => `
       <tr>
         <td><span class="change-${c.change_type}">${c.change_type}</span></td>
-        <td>${c.asset_type}</td>
+        <td>${escapeHtml(this.titleCase(c.asset_type || ''))}</td>
         <td class="mono">${escapeHtml(c.asset_value)}</td>
         <td>${escapeHtml(c.summary || '-')}</td>
       </tr>
@@ -928,7 +935,7 @@ const ScansPage = {
 
         ${this.renderScanAggregates(s)}
 
-        ${data.changes.length > 0 ? `
+        ${(!isBaseline && data.changes.length > 0) ? `
           <div>
             <h3 style="margin-bottom:16px">Asset Changes <span class="text-muted" style="font-size:13px;font-weight:400">(${data.changes.length})</span></h3>
             ${Components.table(['Change', 'Type', 'Value', 'Summary'], [changeRows])}
@@ -967,6 +974,13 @@ const ScansPage = {
   async renderDetail(app, id) {
     this.stopPolling();
     app.innerHTML = '<div class="loading">Loading scan...</div>';
+
+    // Reset the main scroll container so navigating between scan details
+    // lands at the top instead of wherever the previous page was
+    // scrolled to. Window scrollY is already 0 (body doesn't scroll);
+    // it's the inner <main class="content"> that holds the scrollbar.
+    const scroller = document.querySelector('main.content');
+    if (scroller) scroller.scrollTop = 0;
 
     try {
       const [data, findingsData] = await Promise.all([

--- a/internal/webui/static/js/pages/scans.js
+++ b/internal/webui/static/js/pages/scans.js
@@ -442,10 +442,24 @@ const ScansPage = {
     </div>`;
   },
 
-  renderScanStats(scan) {
-    // agent-spec 2.0: scan exposes target_state (DB-derived snapshot),
-    // delta (what this scan changed), and work (telemetry). Render all
-    // three if they have content.
+  // agent-spec 2.0: a Scan exposes three semantically distinct aggregates.
+  // Each gets its own card so the user can read them as separate questions:
+  //
+  //   Target state — what currently exists on the target
+  //   Changes      — what THIS scan changed vs. prior state
+  //   Work         — telemetry of the execution itself
+  //
+  // Mirrors the three-block layout of `surfbot scan` CLI output for
+  // CLI ↔ webui parity.
+  renderScanAggregates(scan) {
+    return `
+      ${this.renderTargetStateBlock(scan)}
+      ${this.renderScanDeltaBlock(scan)}
+      ${this.renderScanWorkBlock(scan)}
+    `;
+  },
+
+  renderTargetStateBlock(scan) {
     const state = scan.target_state || {};
     const assets = state.assets_by_type || {};
     const ports = state.ports_by_status || {};
@@ -461,6 +475,15 @@ const ScansPage = {
       { label: 'Findings open', value: state.findings_open_total },
     ].filter(i => i.value > 0);
 
+    // AssetType is an open vocabulary — surface keys we don't recognize
+    // explicitly so a tool that emits e.g. "cloud_bucket" still shows up.
+    const known = new Set(['subdomain', 'ipv4', 'ipv6', 'port_service', 'url', 'technology', 'domain', 'service']);
+    Object.entries(assets).forEach(([k, v]) => {
+      if (!known.has(k) && v > 0) {
+        stateItems.push({ label: this.titleCase(k), value: v });
+      }
+    });
+
     if (stateItems.length === 0) return '';
 
     const sevs = state.findings_open || {};
@@ -469,7 +492,7 @@ const ScansPage = {
     return `<div class="card">
       <div class="card-label">Target state</div>
       <div class="detail-grid" style="margin-top:8px">
-        ${stateItems.map(i => `<span class="detail-label">${i.label}</span><span class="detail-value">${i.value}</span>`).join('')}
+        ${stateItems.map(i => `<span class="detail-label">${escapeHtml(i.label)}</span><span class="detail-value">${i.value}</span>`).join('')}
       </div>
       ${hasSev ? Components.severityBars({
         critical: sevs.critical || 0,
@@ -479,6 +502,104 @@ const ScansPage = {
         info: sevs.info || 0,
       }) : ''}
     </div>`;
+  },
+
+  renderScanDeltaBlock(scan) {
+    const delta = scan.delta || {};
+
+    // Baseline scans have no meaningful delta — surface that honestly
+    // instead of showing zeros that look like "nothing happened".
+    if (delta.is_baseline) {
+      return `<div class="card">
+        <div class="card-label">Changes</div>
+        <p class="text-muted" style="margin-top:8px">Baseline scan — run again to detect changes.</p>
+      </div>`;
+    }
+
+    const sumMap = (m) => Object.values(m || {}).reduce((a, b) => a + b, 0);
+    const newAssetsTotal = sumMap(delta.new_assets);
+    const disAssetsTotal = sumMap(delta.disappeared_assets);
+    const modAssetsTotal = sumMap(delta.modified_assets);
+    const newFindingsTotal = sumMap(delta.new_findings);
+    const resolvedFindingsTotal = sumMap(delta.resolved_findings);
+    const total = newAssetsTotal + disAssetsTotal + modAssetsTotal + newFindingsTotal + resolvedFindingsTotal;
+
+    if (total === 0) {
+      return `<div class="card">
+        <div class="card-label">Changes</div>
+        <p class="text-muted" style="margin-top:8px">No changes since last scan.</p>
+      </div>`;
+    }
+
+    const formatTypeBreakdown = (m) => {
+      const entries = Object.entries(m || {}).filter(([, v]) => v > 0);
+      if (entries.length === 0) return '';
+      return ' <span class="text-muted">(' + entries.map(([k, v]) => `${v} ${this.titleCase(k)}`).join(', ') + ')</span>';
+    };
+
+    const formatSevBreakdown = (m) => {
+      const order = ['critical', 'high', 'medium', 'low', 'info'];
+      const parts = order.filter(s => (m || {})[s] > 0).map(s => `${m[s]} ${s}`);
+      if (parts.length === 0) return '';
+      return ' <span class="text-muted">(' + parts.join(', ') + ')</span>';
+    };
+
+    const rows = [];
+    if (newAssetsTotal > 0) {
+      rows.push(`<span class="detail-label" style="color:var(--success)">+ New assets</span><span class="detail-value">${newAssetsTotal}${formatTypeBreakdown(delta.new_assets)}</span>`);
+    }
+    if (disAssetsTotal > 0) {
+      rows.push(`<span class="detail-label" style="color:var(--danger)">− Disappeared assets</span><span class="detail-value">${disAssetsTotal}${formatTypeBreakdown(delta.disappeared_assets)}</span>`);
+    }
+    if (modAssetsTotal > 0) {
+      rows.push(`<span class="detail-label" style="color:var(--sev-medium)">~ Modified assets</span><span class="detail-value">${modAssetsTotal}${formatTypeBreakdown(delta.modified_assets)}</span>`);
+    }
+    if (newFindingsTotal > 0) {
+      rows.push(`<span class="detail-label" style="color:var(--success)">+ New findings</span><span class="detail-value">${newFindingsTotal}${formatSevBreakdown(delta.new_findings)}</span>`);
+    }
+    if (resolvedFindingsTotal > 0) {
+      rows.push(`<span class="detail-label" style="color:var(--success)">✓ Resolved findings</span><span class="detail-value">${resolvedFindingsTotal}</span>`);
+    }
+
+    return `<div class="card">
+      <div class="card-label">Changes</div>
+      <div class="detail-grid" style="margin-top:8px">
+        ${rows.join('')}
+      </div>
+    </div>`;
+  },
+
+  renderScanWorkBlock(scan) {
+    const work = scan.work || {};
+    if (!work.tools_run) return '';
+
+    const items = [
+      { label: 'Duration', value: this.formatDurationMs(work.duration_ms || 0) },
+      { label: 'Tools run', value: work.tools_run },
+    ];
+    if (work.tools_failed > 0) items.push({ label: 'Tools failed', value: work.tools_failed });
+    if (work.tools_skipped > 0) items.push({ label: 'Tools skipped', value: work.tools_skipped });
+    if (work.raw_emissions > 0) {
+      // raw_emissions is the pre-storage-dedup tool output. Surfacing it
+      // in the UI helps debug noisy detectors (e.g. nuclei emitting many
+      // duplicates that storage merges into a few unique findings).
+      items.push({ label: 'Raw emissions', value: `${work.raw_emissions} <span class="text-muted">(pre-dedup)</span>` });
+    }
+    if (work.phases_run && work.phases_run.length > 0) {
+      items.push({ label: 'Phases', value: work.phases_run.map(escapeHtml).join(' → ') });
+    }
+
+    return `<div class="card">
+      <div class="card-label">Work</div>
+      <div class="detail-grid" style="margin-top:8px">
+        ${items.map(i => `<span class="detail-label">${i.label}</span><span class="detail-value">${i.value}</span>`).join('')}
+      </div>
+    </div>`;
+  },
+
+  titleCase(s) {
+    if (!s) return s;
+    return s.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
   },
 
   formatElapsed(seconds) {
@@ -553,7 +674,7 @@ const ScansPage = {
 
         ${this.renderFindings(findings, s.id)}
 
-        ${this.renderScanStats(s)}
+        ${this.renderScanAggregates(s)}
 
         ${data.changes.length > 0 ? `
           <div>


### PR DESCRIPTION
## Summary

Replaces the legacy `ScanStats` aggregate with three semantically distinct concepts populated from DB ground truth at end-of-scan: `TargetState`, `ScanDelta`, `ScanWork`. Closes SUR-244 / SPEC-QA3.

The old model conflated three different questions ("what does the target look like?", "what did this scan change?", "what work did this scan do?") into one mutable in-memory accumulator that drifted from the database. The new model answers each question separately, with each aggregate sourced from a single set of DB queries that match exactly what the corresponding `list` subcommands return.

## Why this scope

The narrow SPEC-QA3 spec proposed a rename of `ScanStats` fields. Audit showed the deeper problem: stats were derived from in-memory counters that never reconciled with persistence (e.g. `FindingsTotal` counted nuclei emissions before storage-level dedup; `OpenPorts` included `status=filtered` ports after SPEC-QA2). A rename couldn't fix that. Pre-launch we have the freedom to break the contract and get the data model right — the user explicitly asked for a holistic refactor over a narrow patch.

## What changed

### Data model (commit 247af81)

- **`ScanStats` deleted.** `Scan` now exposes:
  - `TargetState` — snapshot of the target at scan completion. Maps keyed by `AssetType` / `Severity` / `FindingStatus` so new keys appear without struct changes.
  - `ScanDelta` — what this scan changed (asset_changes + finding diff).
  - `ScanWork` — telemetry from `tool_runs`, including `RawEmissions` (pre-dedup tool output count, useful for debugging tool noise).
- **Migration 003** adds the three JSON columns, drops the legacy `stats` blob, adds `findings.first_seen_scan_id` (backfilled from existing `scan_id`), and **drops the CHECK constraint on `assets.type`** so AssetType is now an open vocabulary — new detection tools can emit new asset types without a SQL migration. Validation moves to Go.
- **`UpsertFinding` semantics fixed:** `scan_id` now updates on conflict to track the latest observing scan; `first_seen_scan_id` is preserved immutably. This also fixes a latent bug in `ComputeFindingChanges` where re-observed findings were misclassified as resolved.
- New storage helpers in `internal/storage/scan_aggregates.go` for the per-target counts.

### Pipeline (commit a7102f2)

- `updateStats` deleted. New `FinalizeTargetState` / `FinalizeScanDelta` / `FinalizeScanWork` run after the diff phase and read from the DB.
- `PipelineResult` exposes the three aggregates; `TotalAssets`/`TotalFindings`/`Stats` removed.
- `WriteJSONResult` emits the new shape (agent-spec 2.0).
- `PrintSummary` rewritten with three sections (TARGET STATE / FINDINGS / WORK).
- `ChangeSummary` and `BuildChangeSummary` deleted; `PrintChangeSummary` takes a `ScanDelta` directly.
- Side-fix: `printPhaseSummary("assessment")` no longer emits `len(Assets)+total` (mixed-type bug).
- Side-fix: `tool_runs.findings_count` now stores findings only, not `assets+findings` (column name was misleading).

### Agent-spec (commit 06faf99)

- **`SpecVersion` bumped to 2.0.0** (breaking).
- New schemas exposed at `types.TargetState`, `types.ScanDelta`, `types.ScanWork`.
- `Asset.type` declared as open vocabulary in the schema; `Severity` / `FindingStatus` / `AssetStatus` stay closed (universal concepts).
- `Finding` gains `first_seen_scan_id` with explicit semantics in the description.
- `docs/agent-spec.md` 2.0.0 changelog with full 1.x → 2.0 field mapping and the open-vs-closed vocabulary rule.

### Webui consumers (commit 8811105)

- `scanSummary.FindingsCount` / scan completion log read from `TargetState`.
- `renderScanStats` rewritten to read `target_state.assets_by_type` / `ports_by_status` / `findings_open`. Adds a "Ports (filtered)" row alongside "Ports (open)".

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./... -race` green across all packages
- [x] `surfbot agent-spec --version` reports `spec_version=2.0.0`
- [x] `surfbot agent-spec | jq .types.ScanResult.properties` shows `target_state` / `delta` / `work`, no `stats`
- [x] **Acceptance test (SPEC-QA3 R10):** `TestFindingDedupMatchesTargetState` — nuclei emits 5 findings with 2 dup pairs, storage merges to 3, `TargetState.FindingsOpenTotal == 3`, persisted scan row matches, `Work.RawEmissions == 5`
- [x] `TestUpsertFindingScanIDLatestSemantics` — re-observed finding has `scan_id = scan2`, `first_seen_scan_id = scan1`; `ListFindings(ScanID: scan2)` returns it, `ScanID: scan1` no longer does
- [x] `TestCountAssetsByTypeForTargetExcludesDisappeared` — disappeared assets don't inflate target_state
- [x] `TestCountPortsByStatusForTargetBucketsCorrectly` — open / filtered / unknown buckets distinct
- [x] `TestTargetStatePortsBucket` — end-to-end SPEC-QA2 status separation through pipeline
- [ ] Manual smoke: run a real scan against a non-prod target, verify `surfbot scan list --format=json` matches `surfbot finding list --target ... | wc -l`

## Migration / rollback

Migration 003 is **destructive** (drops `scans.stats`). Pre-launch the trade-off is acceptable. Rollback would require restoring from a SQLite backup; no down-migration shipped.

## Extensibility verified

- Adding a new tool in an existing phase: zero structural changes.
- Adding a tool with a new `AssetType` (e.g. `cloud_bucket`): one Go constant, zero schema, zero agent-spec structural change.
- Adding a new finding severity: stays closed by design (CVSS-aligned).
- Adding a new pipeline phase: still requires touching the orchestrator switch — out of scope here, called out as future tech debt.