### PR TITLE
align findings card with scan ownership + empty delta on baseline

### DIFF
--- a/internal/pipeline/finalize.go
+++ b/internal/pipeline/finalize.go
@@ -93,8 +93,14 @@ func FinalizeScanDelta(
 	}
 	delta.IsBaseline = isBaseline
 
-	// Baseline scans have every asset flagged appeared+baseline; we don't
-	// bubble those into new_assets because they're not a true delta.
+	// Baseline scans have every asset flagged appeared+baseline and every
+	// finding is technically "new" too (it's the first time we see
+	// anything about this target). We zero out the whole delta payload
+	// in that case — Target State already counts everything, so populating
+	// delta would triple-report the same numbers. Consumers key off
+	// is_baseline=true to know "all state here was discovered by this
+	// scan". SUR-244 audit fix: previously new_findings was populated
+	// while new_assets was empty, producing an inconsistent delta shape.
 	if !isBaseline {
 		changeCounts, err := store.AssetChangeCountsForScan(ctx, scanID)
 		if err != nil {
@@ -109,13 +115,12 @@ func FinalizeScanDelta(
 		if m := changeCounts[string(model.ChangeTypeModified)]; m != nil {
 			delta.ModifiedAssets = m
 		}
-	}
-
-	for _, f := range newFindings {
-		delta.NewFindings[f.Severity]++
-	}
-	for _, f := range resolvedFindings {
-		delta.ResolvedFindings[f.Severity]++
+		for _, f := range newFindings {
+			delta.NewFindings[f.Severity]++
+		}
+		for _, f := range resolvedFindings {
+			delta.ResolvedFindings[f.Severity]++
+		}
 	}
 	// ReturnedFindings ("resolved then re-opened") is not yet computed by
 	// the diff phase — the detection of reopened findings would require

--- a/internal/pipeline/finalize_test.go
+++ b/internal/pipeline/finalize_test.go
@@ -160,3 +160,107 @@ func TestTargetStatePortsBucket(t *testing.T) {
 	assert.Equal(t, 2, result.TargetState.PortsByStatus["open"], "open ports bucketed separately")
 	assert.Equal(t, 1, result.TargetState.PortsByStatus["filtered"], "filtered ports bucketed separately")
 }
+
+// TestBaselineDeltaIsEmpty guards the SUR-244 P0 invariant: when a scan
+// is a baseline (first run against a target), the delta payload is
+// uniformly empty across all buckets, regardless of what the scan
+// observed. Consumers key off is_baseline=true to know "all state here
+// is new"; populating delta.new_findings while leaving delta.new_assets
+// empty (the pre-fix behavior) produced an inconsistent shape that
+// LLMs and dashboards had to special-case.
+func TestBaselineDeltaIsEmpty(t *testing.T) {
+	s := newTestStore(t)
+	target := createTarget(t, s, "example.com")
+	ctx := context.Background()
+
+	// Baseline scan that also produces a finding. Pre-fix this would
+	// yield delta.new_findings = {high: 1} while delta.new_assets = {}.
+	tools := []detection.DetectionTool{
+		&mockTool{name: "subfinder", phase: "discovery",
+			assets: []model.Asset{{Type: model.AssetTypeSubdomain, Value: "a.example.com", Status: model.AssetStatusNew}}},
+		&mockTool{name: "dnsx", phase: "resolution",
+			assets: []model.Asset{{Type: model.AssetTypeIPv4, Value: "1.2.3.4", Status: model.AssetStatusNew}}},
+		&mockTool{name: "naabu", phase: "port_scan",
+			assets: []model.Asset{{Type: model.AssetTypePort, Value: "1.2.3.4:443/tcp", Status: model.AssetStatusNew, Metadata: map[string]any{"status": "open"}}}},
+		&mockTool{name: "httpx", phase: "http_probe",
+			assets: []model.Asset{{Type: model.AssetTypeURL, Value: "https://a.example.com", Status: model.AssetStatusNew}}},
+		&mockTool{
+			name: "nuclei", phase: "assessment",
+			findings: []model.Finding{
+				{TemplateID: "CVE-X", Severity: model.SeverityHigh, Title: "High vuln", Status: model.FindingStatusOpen, SourceTool: "nuclei"},
+			},
+		},
+	}
+
+	reg := mockRegistry(tools...)
+	pipe := New(s, reg)
+	result, err := pipe.Run(ctx, target.ID, PipelineOptions{ScanType: model.ScanTypeFull})
+	require.NoError(t, err)
+
+	d := result.Delta
+	assert.True(t, d.IsBaseline, "first scan must be flagged baseline")
+	assert.Empty(t, d.NewAssets, "baseline: new_assets must be empty")
+	assert.Empty(t, d.DisappearedAssets, "baseline: disappeared_assets must be empty")
+	assert.Empty(t, d.ModifiedAssets, "baseline: modified_assets must be empty")
+	assert.Empty(t, d.NewFindings, "baseline: new_findings must be empty (was populated pre-fix)")
+	assert.Empty(t, d.ResolvedFindings, "baseline: resolved_findings must be empty")
+	assert.Empty(t, d.ReturnedFindings, "baseline: returned_findings must be empty")
+
+	// Target State is how the consumer should learn about what exists
+	// after a baseline scan — verify the finding shows up there.
+	assert.Equal(t, 1, result.TargetState.FindingsOpenTotal,
+		"target_state must reflect what the baseline observed (single source of truth for baselines)")
+}
+
+// TestFindingsScanScopeIncludesDiscovered covers the storage-level half of
+// the SUR-244 P0 fix: a finding observed by scan1 and re-observed by
+// scan2 must stay visible in scan1's detail view. ScanScope=scan1 must
+// match both findings that scan1 observed last (scan_id=scan1) AND
+// findings that scan1 discovered originally (first_seen_scan_id=scan1),
+// regardless of who observed them last.
+func TestFindingsScanScopeIncludesDiscovered(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	target := &model.Target{Value: "example.com"}
+	require.NoError(t, s.CreateTarget(ctx, target))
+
+	scan1 := &model.Scan{TargetID: target.ID, Type: model.ScanTypeFull, Status: model.ScanStatusRunning}
+	require.NoError(t, s.CreateScan(ctx, scan1))
+	scan2 := &model.Scan{TargetID: target.ID, Type: model.ScanTypeFull, Status: model.ScanStatusRunning}
+	require.NoError(t, s.CreateScan(ctx, scan2))
+
+	asset := &model.Asset{TargetID: target.ID, Type: model.AssetTypeSubdomain, Value: "a.example.com", Status: model.AssetStatusNew}
+	require.NoError(t, s.UpsertAsset(ctx, asset))
+
+	// scan1 discovers the finding.
+	require.NoError(t, s.UpsertFinding(ctx, &model.Finding{
+		AssetID: asset.ID, ScanID: scan1.ID,
+		TemplateID: "T-1", SourceTool: "nuclei",
+		Severity: model.SeverityHigh, Title: "v", Status: model.FindingStatusOpen,
+	}))
+	// scan2 re-observes it → scan_id flips to scan2, first_seen_scan_id
+	// stays on scan1 (tested separately in storage/scan_aggregates_test.go).
+	require.NoError(t, s.UpsertFinding(ctx, &model.Finding{
+		AssetID: asset.ID, ScanID: scan2.ID,
+		TemplateID: "T-1", SourceTool: "nuclei",
+		Severity: model.SeverityHigh, Title: "v", Status: model.FindingStatusOpen,
+	}))
+
+	// Stricter ScanID filter: scan1 has nothing (scan_id now points at scan2).
+	byScan1ID, err := s.ListFindings(ctx, storage.FindingListOptions{ScanID: scan1.ID, Limit: 10})
+	require.NoError(t, err)
+	assert.Empty(t, byScan1ID, "ScanID=scan1 returns empty after re-observation — expected")
+
+	// Broader ScanScope filter: scan1 still owns the finding via
+	// first_seen_scan_id. This is what the scan-detail UI should use.
+	byScan1Scope, err := s.ListFindings(ctx, storage.FindingListOptions{ScanScope: scan1.ID, Limit: 10})
+	require.NoError(t, err)
+	assert.Len(t, byScan1Scope, 1, "ScanScope=scan1 must include findings scan1 originally discovered")
+
+	// scan2 picks it up via either filter (it's the latest observer AND
+	// its ScanScope includes the finding via scan_id match).
+	byScan2Scope, err := s.ListFindings(ctx, storage.FindingListOptions{ScanScope: scan2.ID, Limit: 10})
+	require.NoError(t, err)
+	assert.Len(t, byScan2Scope, 1, "ScanScope=scan2 must include findings scan2 re-observed")
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -45,8 +45,21 @@ type AssetChangeListOptions struct {
 
 // FindingListOptions configures finding listing queries.
 type FindingListOptions struct {
-	AssetID    string
-	ScanID     string
+	AssetID string
+
+	// ScanID filters by the LATEST scan that observed the finding
+	// (model.Finding.ScanID, updated on every upsert). Use this when you
+	// want "the exact set of findings whose last touch was scan X".
+	ScanID string
+
+	// ScanScope filters by "observed by OR discovered by" a scan — i.e.
+	// scan_id = X OR first_seen_scan_id = X. This is the right filter for
+	// "findings that belong to scan X" in a UX sense: it includes findings
+	// a later scan re-observed (they still count as part of the detail
+	// page for the scan that discovered them) as well as findings freshly
+	// observed by X. Use this in the scan-detail view. See SUR-244 audit.
+	ScanScope string
+
 	TargetID   string
 	TemplateID string
 	Host       string
@@ -698,6 +711,14 @@ func (s *SQLiteStore) ListFindings(ctx context.Context, opts FindingListOptions)
 		where = append(where, "scan_id = ?")
 		args = append(args, opts.ScanID)
 	}
+	// ScanScope: include findings that either (a) were last observed by
+	// this scan, or (b) were originally discovered by it — so a later
+	// scan re-observing a finding doesn't make it disappear from the
+	// detail view of the scan that first found it. See SUR-244.
+	if opts.ScanScope != "" {
+		where = append(where, "(scan_id = ? OR first_seen_scan_id = ?)")
+		args = append(args, opts.ScanScope, opts.ScanScope)
+	}
 	if opts.Severity != "" {
 		where = append(where, "severity = ?")
 		args = append(args, string(opts.Severity))
@@ -1065,6 +1086,14 @@ func (s *SQLiteStore) CountFindingsFiltered(ctx context.Context, opts FindingLis
 	if opts.ScanID != "" {
 		where = append(where, "scan_id = ?")
 		args = append(args, opts.ScanID)
+	}
+	// ScanScope: include findings that either (a) were last observed by
+	// this scan, or (b) were originally discovered by it — so a later
+	// scan re-observing a finding doesn't make it disappear from the
+	// detail view of the scan that first found it. See SUR-244.
+	if opts.ScanScope != "" {
+		where = append(where, "(scan_id = ? OR first_seen_scan_id = ?)")
+		args = append(args, opts.ScanScope, opts.ScanScope)
 	}
 	if opts.Severity != "" {
 		where = append(where, "severity = ?")

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -294,6 +294,19 @@ func (h *handler) handleFindings(w http.ResponseWriter, r *http.Request) {
 		}
 		opts.ScanID = scanID
 	}
+	// scan_scope matches findings that were either last observed by the
+	// given scan OR originally discovered by it. Used by the scan detail
+	// view so findings don't disappear from their discovering scan when a
+	// later scan re-observes them (see SUR-244 audit). Kept as a separate
+	// param from scan_id so the stricter "latest observation" filter
+	// remains available for analysis queries.
+	if scope := r.URL.Query().Get("scan_scope"); scope != "" {
+		if _, err := uuid.Parse(scope); err != nil {
+			writeError(w, http.StatusBadRequest, "scan_scope must be a valid UUID")
+			return
+		}
+		opts.ScanScope = scope
+	}
 	if tmpl := r.URL.Query().Get("template_id"); tmpl != "" {
 		opts.TemplateID = tmpl
 	}

--- a/internal/webui/static/js/pages/scans.js
+++ b/internal/webui/static/js/pages/scans.js
@@ -562,7 +562,7 @@ const ScansPage = {
     }).join('');
 
     return `<div class="card">
-      <div class="card-label">Findings <span class="text-muted" style="font-weight:400;text-transform:none">(${findings.length})</span></div>
+      <div class="card-label">Findings from this scan <span class="text-muted" style="font-weight:400;text-transform:none">(${findings.length})</span></div>
       <div class="table-container" style="border:none;margin:8px 0 0">
         <table class="findings-table">
           <thead><tr>
@@ -985,7 +985,10 @@ const ScansPage = {
     try {
       const [data, findingsData] = await Promise.all([
         API.scan(id),
-        API.findings({ scan_id: id, limit: 100 }),
+        // scan_scope (not scan_id) so findings discovered by this scan
+        // but later re-observed by a newer scan still show up here
+        // instead of silently disappearing. See SUR-244 audit.
+        API.findings({ scan_scope: id, limit: 100 }),
       ]);
       this.renderDetailContent(app, data, findingsData.findings || []);
 
@@ -1012,7 +1015,10 @@ const ScansPage = {
       try {
         const [data, findingsData] = await Promise.all([
           API.scan(id),
-          API.findings({ scan_id: id, limit: 100 }),
+          // scan_scope (not scan_id) so findings discovered by this scan
+        // but later re-observed by a newer scan still show up here
+        // instead of silently disappearing. See SUR-244 audit.
+        API.findings({ scan_scope: id, limit: 100 }),
         ]);
         if (data.scan.status !== 'running') {
           this.stopPolling();


### PR DESCRIPTION
## Summary

Two P0 bugs from the SUR-244 audit, both about *what "findings of a scan" means*:

1. **Findings card (18) vs target_state (27) mismatch.** The scan-detail page filtered the findings list by `Finding.ScanID` (latest-observer), but `target_state.findings_open_total` counts every open finding on the target. When scan2 re-observed findings scan1 originally discovered, those findings vanished from scan1's detail page while the number at the top still counted them — a 9-row ghost on this repo's example.

2. **Baseline delta was asymmetric.** `FinalizeScanDelta` zeroed asset buckets on a baseline (correct) but kept populating finding buckets. LLMs and the UI had to special-case "trust findings on baseline, ignore assets" — and the UI ended up showing "Baseline scan — run again" while hiding the finding counts that were still in the JSON.

## Changes

### `FindingListOptions.ScanScope` — new filter
`(scan_id = X OR first_seen_scan_id = X)`. That's the filter for "findings that belong to scan X" in a UX sense: last-observed OR originally-discovered. `ScanID` stays available for the stricter analysis query "findings whose latest touch was X".

### `/api/v1/findings?scan_scope=<uuid>`
New query param, validated as UUID, separate from `scan_id` so the strict filter remains addressable.

### Webui scan detail
- `API.findings({ scan_scope: id, limit: 100 })` instead of `{ scan_id: id }`.
- Card label renamed "Findings from this scan" so the scope is explicit.

### `FinalizeScanDelta` zeroes everything on baseline
Previously:
```
is_baseline=true → new_assets={}, new_findings={high:1}  // asymmetric
```
Now:
```
is_baseline=true → every bucket empty, period
```
The operator / LLM reads `target_state` for what exists and `is_baseline=true` as the signal for "all of it was just observed by this scan". Single source of truth; no more cross-field special-casing.

## Tests
- `TestBaselineDeltaIsEmpty` — baseline with a nuclei finding; asserts all six delta maps empty, `target_state.findings_open_total` reflects what was observed.
- `TestFindingsScanScopeIncludesDiscovered` — scan1 discovers, scan2 re-observes; `ScanScope=scan1` still returns the finding (via `first_seen_scan_id`), `ScanID=scan1` does not (scan_id now points at scan2).

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./... -race` green (all packages)
- [x] `golangci-lint run ./...` 0 issues
- [x] New tests: baseline invariant + first_seen_scan_id visibility
- [ ] Manual: navigate to an older scan's detail, confirm "Findings from this scan" shows findings that newer scans re-observed

## Follow-ups left for later
- Tabla de findings del Findings main view (global): decidir si también cambia a `scan_scope` semantics donde aplique.
- Delta `returned_findings` sigue siempre vacío (no computed by the diff phase). Separately tracked.