### PR TITLE
embed subfinder SDK in-process, remove binary dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,11 @@ require (
 	github.com/kardianos/service v1.2.4
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
+	github.com/projectdiscovery/goflags v0.1.74
 	github.com/projectdiscovery/nuclei/v3 v3.7.1
+	github.com/projectdiscovery/subfinder/v2 v2.13.0
 	github.com/spf13/cobra v1.9.1
+	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
@@ -108,6 +111,7 @@ require (
 	github.com/cnf/structhash v0.0.0-20250313080605-df4c6cc74a9a // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
+	github.com/corpix/uarand v0.2.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.5.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/davidmz/go-pageant v1.0.2 // indirect
@@ -176,6 +180,7 @@ require (
 	github.com/gosimple/slug v1.15.0 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/h2non/filetype v1.1.3 // indirect
+	github.com/hako/durafmt v0.0.0-20210316092057-3a2c319c1acd // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
@@ -267,14 +272,15 @@ require (
 	github.com/projectdiscovery/asnmap v1.1.1 // indirect
 	github.com/projectdiscovery/blackrock v0.0.1 // indirect
 	github.com/projectdiscovery/cdncheck v1.2.25 // indirect
+	github.com/projectdiscovery/chaos-client v0.5.2 // indirect
 	github.com/projectdiscovery/clistats v0.1.1 // indirect
+	github.com/projectdiscovery/dnsx v1.2.3 // indirect
 	github.com/projectdiscovery/dsl v0.8.13 // indirect
 	github.com/projectdiscovery/fastdialer v0.5.4 // indirect
 	github.com/projectdiscovery/fasttemplate v0.0.2 // indirect
 	github.com/projectdiscovery/freeport v0.0.7 // indirect
 	github.com/projectdiscovery/gcache v0.0.0-20241015120333-12546c6e3f4c // indirect
 	github.com/projectdiscovery/go-smb2 v0.0.0-20240129202741-052cc450c6cb // indirect
-	github.com/projectdiscovery/goflags v0.1.74 // indirect
 	github.com/projectdiscovery/gologger v1.1.68 // indirect
 	github.com/projectdiscovery/gostruct v0.0.2 // indirect
 	github.com/projectdiscovery/gozero v0.1.1-0.20251027191944-a4ea43320b81 // indirect
@@ -322,7 +328,6 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.9.2 // indirect
-	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/tidwall/btree v1.8.1 // indirect
@@ -337,6 +342,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.15 // indirect
 	github.com/tklauser/numcpus v0.10.0 // indirect
 	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc // indirect
+	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
 	github.com/trivago/tgo v1.0.7 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,8 @@ github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151X
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
+github.com/corpix/uarand v0.2.0 h1:U98xXwud/AVuCpkpgfPF7J5TQgr7R5tqT8VZP5KWbzE=
+github.com/corpix/uarand v0.2.0/go.mod h1:/3Z1QIqWkDIhf6XWn/08/uMHoQ8JUoTIKc2iPchBOmM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.5.1 h1:eYgfMq5yryL4fbWfkLpFFy2ukSELzaJOTaUTuh+oF48=
 github.com/cyphar/filepath-securejoin v0.5.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
@@ -552,6 +554,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5uk
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
+github.com/hako/durafmt v0.0.0-20210316092057-3a2c319c1acd h1:FsX+T6wA8spPe4c1K9vi7T0LvNCO1TTqiL8u7Wok2hw=
+github.com/hako/durafmt v0.0.0-20210316092057-3a2c319c1acd/go.mod h1:VzxiSdG6j1pi7rwGm/xYI5RbtpBgM8sARDXlvEvxlu0=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
@@ -830,8 +834,12 @@ github.com/projectdiscovery/blackrock v0.0.1 h1:lHQqhaaEFjgf5WkuItbpeCZv2DUIE45k
 github.com/projectdiscovery/blackrock v0.0.1/go.mod h1:ANUtjDfaVrqB453bzToU+YB4cUbvBRpLvEwoWIwlTss=
 github.com/projectdiscovery/cdncheck v1.2.25 h1:LtsH1nmJP7yJNYURszutVWTbyKeSLPS2O6HhiaBKP/Y=
 github.com/projectdiscovery/cdncheck v1.2.25/go.mod h1:Y1KQmACY+AifbuPX/W7o8lWssiWmAZ5d/KG8qkmFm9I=
+github.com/projectdiscovery/chaos-client v0.5.2 h1:dN+7GXEypsJAbCD//dBcUxzAEAEH1fjc/7Rf4F/RiNU=
+github.com/projectdiscovery/chaos-client v0.5.2/go.mod h1:KnoJ/NJPhll42uaqlDga6oafFfNw5l2XI2ajRijtDuU=
 github.com/projectdiscovery/clistats v0.1.1 h1:8mwbdbwTU4aT88TJvwIzTpiNeow3XnAB72JIg66c8wE=
 github.com/projectdiscovery/clistats v0.1.1/go.mod h1:4LtTC9Oy//RiuT1+76MfTg8Hqs7FQp1JIGBM3nHK6a0=
+github.com/projectdiscovery/dnsx v1.2.3 h1:S87U9kYuuqqvMFyen8mZQy1FMuR5EGCsXHqfHPQAeuc=
+github.com/projectdiscovery/dnsx v1.2.3/go.mod h1:NjAEyJt6+meNqZqnYHL4ZPxXfysuva+et56Eq/e1cVE=
 github.com/projectdiscovery/dsl v0.8.13 h1:HjjHta7c02saH2tUGs8CN5vDeE2MyWvCV32koT8ZCWs=
 github.com/projectdiscovery/dsl v0.8.13/go.mod h1:hgFaXhz/JuO+HqIXqBqYIR3ntPnqTo38MJJAzb5tIbg=
 github.com/projectdiscovery/fastdialer v0.5.4 h1:+0oesDDqZcIPE5bNDmm/Xm9Xm3yjnhl4xwP+h5D1TE4=
@@ -884,6 +892,8 @@ github.com/projectdiscovery/sarif v0.0.1 h1:C2Tyj0SGOKbCLgHrx83vaE6YkzXEVrMXYRGL
 github.com/projectdiscovery/sarif v0.0.1/go.mod h1:cEYlDu8amcPf6b9dSakcz2nNnJsoz4aR6peERwV+wuQ=
 github.com/projectdiscovery/stringsutil v0.0.2 h1:uzmw3IVLJSMW1kEg8eCStG/cGbYYZAja8BH3LqqJXMA=
 github.com/projectdiscovery/stringsutil v0.0.2/go.mod h1:EJ3w6bC5fBYjVou6ryzodQq37D5c6qbAYQpGmAy+DC0=
+github.com/projectdiscovery/subfinder/v2 v2.13.0 h1:RHf5vl54V6RNH//Pxhoh/wOptc1w7mde/GD8RPUw+JI=
+github.com/projectdiscovery/subfinder/v2 v2.13.0/go.mod h1:mtbBMU/wLFTg/z9BoM5c6OE9MUvQSTrw7WqLbFpJ0pw=
 github.com/projectdiscovery/tlsx v1.2.2 h1:Y96QBqeD2anpzEtBl4kqNbwzXh2TrzJuXfgiBLvK+SE=
 github.com/projectdiscovery/tlsx v1.2.2/go.mod h1:ZJl9F1sSl0sdwE+lR0yuNHVX4Zx6tCSTqnNxnHCFZB4=
 github.com/projectdiscovery/uncover v1.2.0 h1:31tjYa0v8FB8Ch8hJTxb+2t63vsljdOo0OSFylJcX4M=
@@ -1052,6 +1062,8 @@ github.com/tklauser/numcpus v0.10.0 h1:18njr6LDBk1zuna922MgdjQuJFjrdppsZG60sHGfj
 github.com/tklauser/numcpus v0.10.0/go.mod h1:BiTKazU708GQTYF4mB+cmlpT2Is1gLk7XVuEeem8LsQ=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc h1:9lRDQMhESg+zvGYmW5DyG0UqvY96Bu5QYsTLvCHdrgo=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc/go.mod h1:bciPuU6GHm1iF1pBvUfxfsH0Wmnc2VbpgvbI9ZWuIRs=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
 github.com/trivago/tgo v1.0.7 h1:uaWH/XIy9aWYWpjm2CU3RpcqZXmX2ysQ9/Go+d9gyrM=
 github.com/trivago/tgo v1.0.7/go.mod h1:w4dpD+3tzNIIiIfkWWa85w5/B77tlvdZckQ+6PkFnhc=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=

--- a/internal/detection/detection_test.go
+++ b/internal/detection/detection_test.go
@@ -55,12 +55,19 @@ func TestAvailableTools(t *testing.T) {
 }
 
 func TestToolMetadata(t *testing.T) {
+	// ToolKind classification (see detection.go):
+	//   Native  — pure Go implementation, no external SDK dependency
+	//             (dnsx uses net.DefaultResolver; naabu/httpx use
+	//             in-house scanners built on stdlib).
+	//   Library — driven by an external SDK linked into the binary
+	//             (nuclei uses projectdiscovery/nuclei/v3/lib;
+	//             subfinder uses projectdiscovery/subfinder/v2/pkg/runner).
 	expected := []struct {
 		name  string
 		phase string
 		kind  ToolKind
 	}{
-		{"subfinder", "discovery", ToolKindNative},
+		{"subfinder", "discovery", ToolKindLibrary},
 		{"dnsx", "resolution", ToolKindNative},
 		{"naabu", "port_scan", ToolKindNative},
 		{"httpx", "http_probe", ToolKindNative},

--- a/internal/detection/subfinder.go
+++ b/internal/detection/subfinder.go
@@ -5,71 +5,86 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/projectdiscovery/goflags"
+	subfinderRunner "github.com/projectdiscovery/subfinder/v2/pkg/runner"
 
 	"github.com/surfbot-io/surfbot-agent/internal/model"
 )
 
-// SubfinderTool discovers subdomains using the subfinder binary as a subprocess.
+// SubfinderTool discovers subdomains by driving the upstream subfinder SDK
+// in-process. Previously this shelled out to a `subfinder` binary on PATH;
+// that created a hidden install dependency — users who ran the binary
+// without installing the ProjectDiscovery toolchain silently got empty
+// discovery results. Embedding the SDK aligns subfinder with how nuclei /
+// naabu / httpx / dnsx already run (all Library-kind, no subprocess) and
+// removes the install-time surprise.
 type SubfinderTool struct{}
 
 func NewSubfinderTool() *SubfinderTool { return &SubfinderTool{} }
 
 func (s *SubfinderTool) Name() string   { return "subfinder" }
 func (s *SubfinderTool) Phase() string  { return "discovery" }
-func (s *SubfinderTool) Kind() ToolKind { return ToolKindNative }
+func (s *SubfinderTool) Kind() ToolKind { return ToolKindLibrary }
 
-func (s *SubfinderTool) Available() bool {
-	_, err := exec.LookPath("subfinder")
-	return err == nil
+// Available always returns true — the SDK is linked into the binary so
+// there's no runtime requirement to check. Kept so the DetectionTool
+// interface contract stays uniform across tools.
+func (s *SubfinderTool) Available() bool { return true }
+
+func (s *SubfinderTool) Command() string { return "discover" }
+func (s *SubfinderTool) Description() string {
+	return "Discover subdomains for a target domain using passive sources"
 }
-
-func (s *SubfinderTool) Command() string       { return "discover" }
-func (s *SubfinderTool) Description() string   { return "Discover subdomains for a target domain using passive sources" }
 func (s *SubfinderTool) InputType() string     { return "domains" }
 func (s *SubfinderTool) OutputTypes() []string { return []string{"subdomain"} }
 
 func (s *SubfinderTool) Run(ctx context.Context, inputs []string, opts RunOptions) (*RunResult, error) {
 	startedAt := time.Now().UTC()
 
-	if !s.Available() {
-		tr := buildToolRun(s, startedAt, model.ToolRunSkipped, "subfinder binary not found in PATH", len(inputs), 0)
-		attachExecContext(&tr, "", 0, "", inputs)
+	if len(inputs) == 0 {
+		tr := buildToolRun(s, startedAt, model.ToolRunCompleted, "", 0, 0)
+		tr.OutputSummary = "No input domains — skipped."
+		attachExecContext(&tr, subfinderCommandLabel(opts), 0, "", inputs)
 		return &RunResult{ToolRun: tr}, nil
 	}
 
+	options := buildSubfinderOptions(opts)
+	runner, err := subfinderRunner.NewRunner(options)
+	if err != nil {
+		tr := buildToolRun(s, startedAt, model.ToolRunFailed, err.Error(), len(inputs), 0)
+		attachExecContext(&tr, subfinderCommandLabel(opts), 1, err.Error(), inputs)
+		return &RunResult{ToolRun: tr}, fmt.Errorf("subfinder runner init: %w", err)
+	}
+
 	result := &RunResult{}
-	// Accumulate stderr and last-run command across per-domain executions
-	// so the tool_run record shows what actually ran end-to-end even when
-	// subfinder is invoked once per input.
 	var stderrAcc strings.Builder
-	var lastCmd string
-	var lastExit int
+	// io.Discard for the per-enumeration writer: we read results from the
+	// return-value map, not the stdout-style sink. The SDK requires
+	// non-nil writers though.
+	writers := []io.Writer{io.Discard}
 
 	for _, domain := range inputs {
-		subs, cmdStr, stderrTail, exitCode, err := s.enumerate(ctx, domain, opts)
-		lastCmd = cmdStr
-		lastExit = exitCode
-		if stderrTail != "" {
-			stderrAcc.WriteString(stderrTail)
-			stderrAcc.WriteByte('\n')
-		}
-		if err != nil {
-			tr := buildToolRun(s, startedAt, model.ToolRunFailed, err.Error(), len(inputs), 0)
-			attachExecContext(&tr, cmdStr, exitCode, stderrAcc.String(), inputs)
-			result.ToolRun = tr
-			return result, nil
+		enumerated, enumErr := runner.EnumerateSingleDomainWithCtx(ctx, domain, writers)
+		if enumErr != nil {
+			// Continue on per-domain error — subfinder frequently fails
+			// one source while others succeed, and we want whatever we
+			// got. Log the error into the tool_run stderr surface.
+			fmt.Fprintf(&stderrAcc, "[subfinder] %s: %v\n", domain, enumErr)
 		}
 
-		// Always include the root domain
-		subs[strings.ToLower(domain)] = struct{}{}
-
-		for sub := range subs {
+		// enumerated is map[subdomain]map[source]struct{}. We only care
+		// about the subdomain keys.
+		for sub := range enumerated {
+			sub = strings.ToLower(strings.TrimSpace(sub))
+			if sub == "" {
+				continue
+			}
 			result.Assets = append(result.Assets, model.Asset{
 				ID:        uuid.New().String(),
 				Type:      model.AssetTypeSubdomain,
@@ -81,54 +96,108 @@ func (s *SubfinderTool) Run(ctx context.Context, inputs []string, opts RunOption
 				LastSeen:  time.Now().UTC(),
 			})
 		}
+
+		// Always include the root domain itself so downstream phases have
+		// something to work with even if passive sources returned nothing.
+		rootAsset := model.Asset{
+			ID:        uuid.New().String(),
+			Type:      model.AssetTypeSubdomain,
+			Value:     strings.ToLower(domain),
+			Status:    model.AssetStatusNew,
+			Tags:      []string{},
+			Metadata:  map[string]interface{}{},
+			FirstSeen: time.Now().UTC(),
+			LastSeen:  time.Now().UTC(),
+		}
+		if _, found := enumerated[rootAsset.Value]; !found {
+			result.Assets = append(result.Assets, rootAsset)
+		}
 	}
 
 	tr := buildToolRun(s, startedAt, model.ToolRunCompleted, "", len(inputs), len(result.Assets))
-	tr.OutputSummary = fmt.Sprintf("Discovered %d subdomain(s) across %d input domain(s)", len(result.Assets), len(inputs))
-	attachExecContext(&tr, lastCmd, lastExit, stderrAcc.String(), inputs)
+	tr.OutputSummary = fmt.Sprintf("Discovered %d subdomain(s) across %d input domain(s) via subfinder SDK (passive)",
+		len(result.Assets), len(inputs))
+	attachExecContext(&tr, subfinderCommandLabel(opts), 0, stderrAcc.String(), inputs)
+	tr.Config["threads"] = options.Threads
+	tr.Config["timeout_sec"] = options.Timeout
+	tr.Config["max_enumeration_time_min"] = options.MaxEnumerationTime
 	result.ToolRun = tr
 	return result, nil
 }
 
-func (s *SubfinderTool) enumerate(ctx context.Context, domain string, opts RunOptions) (map[string]struct{}, string, string, int, error) {
-	args := []string{
-		"-d", domain,
-		"-silent",
-		"-duc", // disable update check
-	}
-
-	if opts.Timeout > 0 {
-		args = append(args, "-timeout", fmt.Sprintf("%d", opts.Timeout))
-	}
-
-	if threads, ok := opts.ExtraArgs["threads"]; ok {
-		args = append(args, "-t", threads)
-	}
-
-	// daemon-context-audited (SPEC-X1): subfinder is the only real
-	// subprocess in the detection pipeline; using CommandContext ensures
-	// runner-cancellation propagates so `daemon stop` leaves no orphans.
-	cmd := exec.CommandContext(ctx, "subfinder", args...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	cmdStr := "subfinder " + strings.Join(args, " ")
-	runErr := cmd.Run()
-	exitCode := 0
-	if runErr != nil {
-		exitCode = cmd.ProcessState.ExitCode()
-		// If we got some output, parse it anyway — subfinder sometimes
-		// fails the overall process but produces partial results.
-		if stdout.Len() == 0 {
-			return nil, cmdStr, stderr.String(), exitCode, fmt.Errorf("subfinder failed: %s", stderr.String())
+// buildSubfinderOptions translates pipeline RunOptions + ExtraArgs into
+// subfinder SDK options. Defaults favor correctness over speed — All=true
+// uses every available passive source, which mirrors what the CLI
+// `subfinder -all` does. Keys that require external auth (Shodan, GitHub)
+// will silently return nothing if the user hasn't configured
+// ~/.config/subfinder/provider-config.yaml; that's the upstream behavior
+// and we don't pretend otherwise.
+func buildSubfinderOptions(opts RunOptions) *subfinderRunner.Options {
+	threads := 10
+	if v, ok := opts.ExtraArgs["threads"]; ok {
+		if n, err := parseInt(v); err == nil && n > 0 {
+			threads = n
 		}
 	}
 
-	return ParseSubfinderOutput(stdout.Bytes()), cmdStr, stderr.String(), exitCode, nil
+	timeout := 30
+	if opts.Timeout > 0 {
+		timeout = opts.Timeout
+	}
+
+	maxEnum := 10
+	if v, ok := opts.ExtraArgs["max_enumeration_time"]; ok {
+		if n, err := parseInt(v); err == nil && n > 0 {
+			maxEnum = n
+		}
+	}
+
+	// Domain field is populated per-call via EnumerateSingleDomainWithCtx,
+	// so we don't set it here — that field is only used by RunEnumeration().
+	return &subfinderRunner.Options{
+		Threads:            threads,
+		Timeout:            timeout,
+		MaxEnumerationTime: maxEnum,
+		All:                true,
+		Silent:             true,
+		NoColor:            true,
+		DisableUpdateCheck: true,
+		// Output must be non-nil to avoid a nil-pointer when the SDK
+		// writes progress lines. io.Discard drops them.
+		Output:         io.Discard,
+		Domain:         goflags.StringSlice{},
+		Sources:        goflags.StringSlice{},
+		ExcludeSources: goflags.StringSlice{},
+	}
+}
+
+func subfinderCommandLabel(opts RunOptions) string {
+	threads := "10"
+	if v, ok := opts.ExtraArgs["threads"]; ok && v != "" {
+		threads = v
+	}
+	return fmt.Sprintf("subfinder (SDK in-process, all-sources, threads=%s, timeout=%ds)",
+		threads, maxInt(opts.Timeout, 30))
+}
+
+func maxInt(v, fallback int) int {
+	if v > 0 {
+		return v
+	}
+	return fallback
+}
+
+// parseInt is a local int parser used by buildSubfinderOptions to avoid
+// pulling strconv just for two call sites.
+func parseInt(s string) (int, error) {
+	var n int
+	_, err := fmt.Sscanf(s, "%d", &n)
+	return n, err
 }
 
 // ParseSubfinderOutput parses subfinder text output (one subdomain per line).
+// Retained for test coverage of the historic text-based parser; no longer
+// used by Run() now that results come straight from the SDK map return.
 func ParseSubfinderOutput(data []byte) map[string]struct{} {
 	results := make(map[string]struct{})
 	scanner := bufio.NewScanner(bytes.NewReader(data))

--- a/internal/detection/subfinder_test.go
+++ b/internal/detection/subfinder_test.go
@@ -1,7 +1,6 @@
 package detection
 
 import (
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,12 +29,22 @@ func TestSubfinderOutputDedup(t *testing.T) {
 	assert.Contains(t, results, "api.example.com")
 }
 
+// TestSubfinderAvailable documents the SDK-embedded contract: since the
+// tool no longer shells out to a binary, Available() is a constant true.
+// Preserving the test ensures nobody silently regresses this by bringing
+// back a binary dependency.
 func TestSubfinderAvailable(t *testing.T) {
 	s := NewSubfinderTool()
-	available := s.Available()
+	assert.True(t, s.Available(),
+		"subfinder is SDK-embedded (ToolKindLibrary); Available must be unconditionally true")
+	assert.Equal(t, ToolKindLibrary, s.Kind(),
+		"subfinder was migrated from a subprocess binary to the SDK — ToolKind must reflect that")
+}
 
-	_, err := exec.LookPath("subfinder")
-	expectedAvailable := err == nil
-
-	assert.Equal(t, expectedAvailable, available)
+// TestSubfinderKindIsLibrary pins the contract at the Kind level too so a
+// future change that flips Kind back to Native without updating Available
+// also fails.
+func TestSubfinderKindIsLibrary(t *testing.T) {
+	s := NewSubfinderTool()
+	assert.Equal(t, ToolKindLibrary, s.Kind())
 }


### PR DESCRIPTION
## Summary

`subfinder` was the only detection tool still shelling out to an external binary. Users who ran the surfbot binary without also having `subfinder` installed (via `go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest`) saw discovery silently degrade to zero subdomains and the tool reported as `status=skipped` with `error_message=subfinder binary not found in PATH`. A full scan against `lacuerda.net` went from **103 discovered subdomains to 0**.

Fix: drive subfinder via its public `pkg/runner` SDK, mirroring the pattern nuclei already uses. Single `go get` pulls the transitive deps and the binary now carries subfinder natively.

## What changes

- **`internal/detection/subfinder.go`**
  - Import `github.com/projectdiscovery/subfinder/v2/pkg/runner`.
  - `Kind()` flips `ToolKindNative → ToolKindLibrary` (aligns with nuclei — "driven by an external SDK linked into the binary").
  - `Available()` unconditionally returns `true`; the SDK is linked in.
  - `Run()` builds a `runner.Options` (all sources, silent, no-color, no update check, configurable threads/timeout) and calls `EnumerateSingleDomainWithCtx` per input. Returns the same `map[subdomain]...` the binary piped to stdout; we iterate keys.
  - Root domain is always added as a safety net so downstream phases have input even when passive sources return empty.
  - `RunResult.ToolRun` enrichment mirrors the other tools: `output_summary`, `stderr_tail` of per-source errors, `config.threads / timeout_sec / max_enumeration_time_min`.
  - Legacy `ParseSubfinderOutput` / `ParseSubfinderFile` kept for the test corpus that exercises the line-based parser.

- **`internal/detection/subfinder_test.go`**
  - `TestSubfinderAvailable` rewritten to assert the SDK contract (unconditionally `true`, `Kind == Library`). New `TestSubfinderKindIsLibrary` pins the kind separately so a future revert of either half alone still fails CI.

- **`internal/detection/detection_test.go`**
  - `TestToolMetadata` updated: subfinder is now `Library`. Comment in the test documents the Native vs Library distinction (pure-Go-stdlib vs external-SDK) since it was previously ambiguous.

- **`go.mod` / `go.sum`**
  - `github.com/projectdiscovery/subfinder/v2 v2.13.0` plus transitive deps.

## Verification

Real scan on `lacuerda.net` — discovery phase:

```
Phase 1/5: discovery — subfinder
    Found 103 subdomains        ← previously 0 (binary not on PATH)
Phase 2/5: resolution — dnsx
    Resolved 20 IPs (9 IPv4, 11 IPv6)
```

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./... -race` green across all packages
- [x] `golangci-lint run ./...` 0 issues
- [x] End-to-end scan against `lacuerda.net` discovers 103 subdomains via the SDK
- [x] `TestSubfinderKindIsLibrary` pins the Kind contract

## Non-goals
- **Provider config auth keys** (Shodan, GitHub, etc.). Upstream subfinder behavior: sources requiring auth silently no-op when no `~/.config/subfinder/provider-config.yaml` is present. Users who want those can drop a config file following the SDK docs. Documenting/automating that is a separate concern.