### PR TITLE
webui: polish scan detail, add target detail view, surface subfinder sources

### DIFF
--- a/internal/detection/subfinder.go
+++ b/internal/detection/subfinder.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -78,12 +79,22 @@ func (s *SubfinderTool) Run(ctx context.Context, inputs []string, opts RunOption
 			fmt.Fprintf(&stderrAcc, "[subfinder] %s: %v\n", domain, enumErr)
 		}
 
-		// enumerated is map[subdomain]map[source]struct{}. We only care
-		// about the subdomain keys.
-		for sub := range enumerated {
+		// enumerated is map[subdomain]map[source]struct{}. Persist the
+		// sources alongside the subdomain so operators can judge
+		// confidence (e.g. "only crt.sh knows about this — may be old").
+		for sub, sourceSet := range enumerated {
 			sub = strings.ToLower(strings.TrimSpace(sub))
 			if sub == "" {
 				continue
+			}
+			metadata := map[string]interface{}{}
+			if len(sourceSet) > 0 {
+				sources := make([]string, 0, len(sourceSet))
+				for src := range sourceSet {
+					sources = append(sources, src)
+				}
+				sort.Strings(sources)
+				metadata["sources"] = sources
 			}
 			result.Assets = append(result.Assets, model.Asset{
 				ID:        uuid.New().String(),
@@ -91,7 +102,7 @@ func (s *SubfinderTool) Run(ctx context.Context, inputs []string, opts RunOption
 				Value:     sub,
 				Status:    model.AssetStatusNew,
 				Tags:      []string{},
-				Metadata:  map[string]interface{}{},
+				Metadata:  metadata,
 				FirstSeen: time.Now().UTC(),
 				LastSeen:  time.Now().UTC(),
 			})

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -81,7 +81,6 @@ type overviewResponse struct {
 	Agent              agentInfo               `json:"agent"`
 }
 
-
 // scanSummary mirrors the three-concept Scan model (agent-spec 2.0) so the
 // dashboard can render target_state / delta / work sections without a
 // second round-trip. FindingsCount is kept as a flat convenience for the
@@ -104,11 +103,11 @@ type scanSummary struct {
 // asset types and severities so the small card stays readable. The richer
 // per-type breakdown lives in last_scan.delta for clients that want it.
 type changeSummary struct {
-	NewAssets         int `json:"new_assets"`
-	DisappearedAssets int `json:"disappeared_assets"`
-	ModifiedAssets    int `json:"modified_assets"`
-	NewFindings       int `json:"new_findings"`
-	ResolvedFindings  int `json:"resolved_findings"`
+	NewAssets         int  `json:"new_assets"`
+	DisappearedAssets int  `json:"disappeared_assets"`
+	ModifiedAssets    int  `json:"modified_assets"`
+	NewFindings       int  `json:"new_findings"`
+	ResolvedFindings  int  `json:"resolved_findings"`
 	IsBaseline        bool `json:"is_baseline"`
 }
 
@@ -399,9 +398,9 @@ func (h *handler) handleFindingDetail(w http.ResponseWriter, r *http.Request) {
 
 type groupedFindingsResponse struct {
 	Groups []storage.GroupedFinding `json:"groups"`
-	Total  int                     `json:"total"`
-	Page   int                     `json:"page"`
-	Limit  int                     `json:"limit"`
+	Total  int                      `json:"total"`
+	Page   int                      `json:"page"`
+	Limit  int                      `json:"limit"`
 }
 
 func (h *handler) handleFindingsGrouped(w http.ResponseWriter, r *http.Request) {
@@ -833,12 +832,12 @@ func (h *handler) handleTargetDetail(w http.ResponseWriter, r *http.Request) {
 	enriched := h.enrichFindings(r.Context(), findings)
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"target":         t,
-		"finding_count":  findingCount,
-		"asset_count":    assetCount,
-		"scan_count":     scanCount,
-		"latest_scan":    latest,
-		"recent_scans":   scans,
+		"target":          t,
+		"finding_count":   findingCount,
+		"asset_count":     assetCount,
+		"scan_count":      scanCount,
+		"latest_scan":     latest,
+		"recent_scans":    scans,
 		"recent_findings": enriched,
 	})
 }

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -775,6 +775,74 @@ func (h *handler) handleCreateTarget(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, map[string]any{"target": t})
 }
 
+// handleTargetDetail returns everything the target detail page needs in one
+// round trip: the target row, aggregate counts, the latest completed scan
+// (which carries TargetState + Delta + Work aggregates), and a handful of
+// recent scans. Composing server-side avoids the SPA having to chain four
+// API calls just to paint one page.
+func (h *handler) handleTargetDetail(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/api/v1/targets/")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing target id")
+		return
+	}
+
+	t, err := h.store.GetTarget(r.Context(), id)
+	if err != nil {
+		t, err = h.store.GetTargetByValue(r.Context(), id)
+	}
+	if err != nil || t == nil {
+		writeError(w, http.StatusNotFound, "target not found")
+		return
+	}
+
+	findingCount, _ := h.store.CountFindingsByTargetID(r.Context(), t.ID)
+	assetCount, _ := h.store.CountAssetsByTargetID(r.Context(), t.ID)
+	scanCount, _ := h.store.CountScansByTargetID(r.Context(), t.ID)
+
+	scans, _ := h.store.ListScans(r.Context(), t.ID, 10)
+	if scans == nil {
+		scans = make([]model.Scan, 0)
+	}
+
+	// Latest completed scan carries the aggregate snapshot rendered in
+	// the "Target state" card. Running scans still have placeholder
+	// aggregates, so prefer a completed one when available.
+	var latest *model.Scan
+	for i := range scans {
+		if scans[i].Status == model.ScanStatusCompleted {
+			latest = &scans[i]
+			break
+		}
+	}
+	if latest == nil && len(scans) > 0 {
+		latest = &scans[0]
+	}
+
+	// Don't filter by status — a target with all-resolved findings would
+	// otherwise show an empty "findings" card while the stats summary up
+	// top still reports `finding_count=N`. Let the UI render each row with
+	// its own status badge and let the user see the full picture.
+	findings, _ := h.store.ListFindings(r.Context(), storage.FindingListOptions{
+		TargetID: t.ID,
+		Limit:    20,
+	})
+	if findings == nil {
+		findings = make([]model.Finding, 0)
+	}
+	enriched := h.enrichFindings(r.Context(), findings)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"target":         t,
+		"finding_count":  findingCount,
+		"asset_count":    assetCount,
+		"scan_count":     scanCount,
+		"latest_scan":    latest,
+		"recent_scans":   scans,
+		"recent_findings": enriched,
+	})
+}
+
 func (h *handler) handleDeleteTarget(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -80,7 +80,16 @@ func NewServer(store *storage.SQLiteStore, opts ServerOptions) (*http.Server, ne
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		}
 	})
-	mux.HandleFunc("/api/v1/targets/", h.handleDeleteTarget)
+	mux.HandleFunc("/api/v1/targets/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			h.handleTargetDetail(w, r)
+		case http.MethodDelete:
+			h.handleDeleteTarget(w, r)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+	})
 
 	// Schedule: GET config, PUT config
 	mux.HandleFunc("/api/v1/schedule", h.handleSchedule)

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -678,6 +678,41 @@ tr.finding-detail-row td.finding-detail-cell {
   word-break: break-all;
 }
 
+.detail-grid-message {
+  grid-template-columns: 1fr;
+  color: var(--text-muted);
+}
+
+.detail-divider {
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  margin-top: 4px;
+}
+
+.detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  margin-bottom: 8px;
+}
+
+.detail-meta-sep {
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+
+.scan-detail-target-link {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.scan-detail-target-link:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
 /* === JSON Viewer === */
 .json-viewer {
   background: var(--bg-primary);

--- a/internal/webui/static/js/api.js
+++ b/internal/webui/static/js/api.js
@@ -71,6 +71,7 @@ const API = {
   scans(params)         { return this.get('/scans' + toQuery(params)); },
   scan(id)              { return this.get('/scans/' + id); },
   targets()             { return this.get('/targets'); },
+  target(id)            { return this.get('/targets/' + id); },
   tools()               { return this.get('/tools'); },
   availableTools()      { return this.get('/tools/available'); },
   scanStatus()          { return this.get('/scans/status'); },

--- a/internal/webui/static/js/app.js
+++ b/internal/webui/static/js/app.js
@@ -7,6 +7,7 @@ const Router = {
     { pattern: /^#\/assets/, page: 'assets', render: () => AssetsPage.render(app, parseQueryParams()) },
     { pattern: /^#\/scans\/(.+)$/, page: 'scans', render: (m) => ScansPage.render(app, { id: m[1] }) },
     { pattern: /^#\/scans/, page: 'scans', render: () => ScansPage.render(app, parseQueryParams()) },
+    { pattern: /^#\/targets\/(.+)$/, page: 'targets', render: (m) => TargetsPage.render(app, { id: m[1] }) },
     { pattern: /^#\/targets/, page: 'targets', render: () => TargetsPage.render(app) },
     { pattern: /^#\/tools/, page: 'tools', render: () => ToolsPage.render(app) },
     { pattern: /^#\/settings\/schedule/, page: 'settings', render: () => SettingsSchedulePage.render(app) },

--- a/internal/webui/static/js/components.js
+++ b/internal/webui/static/js/components.js
@@ -75,8 +75,10 @@ const Components = {
 
   severityBars(counts) {
     const severities = ['critical', 'high', 'medium', 'low', 'info'];
-    const max = Math.max(1, ...severities.map(s => counts[s] || 0));
-    return `<div class="sev-bars">${severities.map(sev => {
+    const visible = severities.filter(s => (counts[s] || 0) > 0);
+    if (visible.length === 0) return '';
+    const max = Math.max(1, ...visible.map(s => counts[s] || 0));
+    return `<div class="sev-bars">${visible.map(sev => {
       const count = counts[sev] || 0;
       const pct = (count / max) * 100;
       return `<div class="sev-bar-row">

--- a/internal/webui/static/js/pages/scans.js
+++ b/internal/webui/static/js/pages/scans.js
@@ -267,7 +267,6 @@ const ScansPage = {
     { key: 'port_scan', label: 'Ports' },
     { key: 'http_probe', label: 'HTTP' },
     { key: 'assessment', label: 'Analyzing' },
-    { key: 'completed', label: 'Complete' },
   ],
 
   TOOL_ICONS: {
@@ -296,16 +295,7 @@ const ScansPage = {
       let content = num;
       let stepClass = 'phase-step';
 
-      if (p.key === 'completed') {
-        // Last step: "Complete"
-        if (isTerminal && scan.status === 'completed') {
-          circleClass += ' phase-done'; content = '\u2713'; stepClass += ' done';
-        } else if (scan.status === 'failed') {
-          circleClass += ' phase-failed'; content = '\u2717';
-        } else if (scan.status === 'cancelled') {
-          circleClass += ' phase-cancelled'; content = '\u2013';
-        }
-      } else if (isTerminal && scan.status === 'completed' && ran.has(p.key)) {
+      if (isTerminal && scan.status === 'completed' && ran.has(p.key)) {
         circleClass += ' phase-done'; content = '\u2713'; stepClass += ' done';
       } else if (isTerminal && scan.status === 'completed' && !ran.has(p.key)) {
         circleClass += ' phase-skipped'; content = '\u2013'; stepClass += ' skipped';
@@ -593,10 +583,13 @@ const ScansPage = {
   formatAssetValueCell(f) {
     if (f.asset_value) {
       const label = f.asset_value.length > 60 ? f.asset_value.slice(0, 57) + '…' : f.asset_value;
+      if (f.asset_id) {
+        return `<a href="#/assets/${f.asset_id}" onclick="event.stopPropagation()">${escapeHtml(label)}</a>`;
+      }
       return escapeHtml(label);
     }
     if (f.asset_id) {
-      return `<span class="text-muted">${f.asset_id.slice(0, 8)}</span>`;
+      return `<a href="#/assets/${f.asset_id}" class="text-muted" onclick="event.stopPropagation()">${f.asset_id.slice(0, 8)}</a>`;
     }
     return '<span class="text-muted">—</span>';
   },
@@ -694,6 +687,11 @@ const ScansPage = {
     const assets = state.assets_by_type || {};
     const ports = state.ports_by_status || {};
 
+    // Ordering mirrors internal/pipeline/pipeline.go printTargetStateBlock:
+    // KnownAssetTypes order for assets, with ports broken down by status
+    // slotted in after port_service, and any unknown asset types (open
+    // vocabulary) appended alphabetically at the tail. Findings open
+    // closes the card after a divider.
     const stateItems = [
       { label: 'Subdomains', value: assets.subdomain },
       { label: 'IPs (v4)', value: assets.ipv4 },
@@ -702,17 +700,19 @@ const ScansPage = {
       { label: 'Ports (filtered)', value: ports.filtered },
       { label: 'Endpoints', value: assets.url },
       { label: 'Technologies', value: assets.technology },
-      { label: 'Findings open', value: state.findings_open_total },
+      { label: 'Domains', value: assets.domain },
+      { label: 'Services', value: assets.service },
     ].filter(i => i.value > 0);
 
-    // AssetType is an open vocabulary — surface keys we don't recognize
-    // explicitly so a tool that emits e.g. "cloud_bucket" still shows up.
     const known = new Set(['subdomain', 'ipv4', 'ipv6', 'port_service', 'url', 'technology', 'domain', 'service']);
-    Object.entries(assets).forEach(([k, v]) => {
-      if (!known.has(k) && v > 0) {
-        stateItems.push({ label: this.titleCase(k), value: v });
-      }
-    });
+    const extras = Object.entries(assets)
+      .filter(([k, v]) => !known.has(k) && v > 0)
+      .sort(([a], [b]) => a.localeCompare(b));
+    extras.forEach(([k, v]) => stateItems.push({ label: this.titleCase(k), value: v }));
+
+    if (state.findings_open_total > 0) {
+      stateItems.push({ label: 'Findings open', value: state.findings_open_total, divider: true });
+    }
 
     if (stateItems.length === 0) return '';
 
@@ -722,7 +722,10 @@ const ScansPage = {
     return `<div class="card">
       <div class="card-label">Target state</div>
       <div class="detail-grid" style="margin-top:8px">
-        ${stateItems.map(i => `<span class="detail-label">${escapeHtml(i.label)}</span><span class="detail-value">${i.value}</span>`).join('')}
+        ${stateItems.map(i => {
+          const dividerCls = i.divider ? ' detail-divider' : '';
+          return `<span class="detail-label${dividerCls}">${escapeHtml(i.label)}</span><span class="detail-value${dividerCls}">${i.value}</span>`;
+        }).join('')}
       </div>
       ${hasSev ? Components.severityBars({
         critical: sevs.critical || 0,
@@ -742,7 +745,9 @@ const ScansPage = {
     if (delta.is_baseline) {
       return `<div class="card">
         <div class="card-label">Changes</div>
-        <p class="text-muted" style="margin-top:8px">Baseline scan — run again to detect changes.</p>
+        <div class="detail-grid detail-grid-message" style="margin-top:8px">
+          <span class="text-muted">Baseline scan — run again to detect changes.</span>
+        </div>
       </div>`;
     }
 
@@ -757,7 +762,9 @@ const ScansPage = {
     if (total === 0) {
       return `<div class="card">
         <div class="card-label">Changes</div>
-        <p class="text-muted" style="margin-top:8px">No changes since last scan.</p>
+        <div class="detail-grid detail-grid-message" style="margin-top:8px">
+          <span class="text-muted">No changes since last scan.</span>
+        </div>
       </div>`;
     }
 
@@ -901,14 +908,34 @@ const ScansPage = {
     // the same info in three places (Target State + Changes card + Asset
     // Changes table). Non-baseline scans render the table as before.
     const isBaseline = !!(s.delta && s.delta.is_baseline);
-    const changeRows = data.changes.map(c => `
+    const changeRows = data.changes.map(c => {
+      const valueCell = c.asset_id
+        ? `<a href="#/assets/${c.asset_id}">${escapeHtml(c.asset_value)}</a>`
+        : escapeHtml(c.asset_value);
+      return `
       <tr>
         <td><span class="change-${c.change_type}">${c.change_type}</span></td>
         <td>${escapeHtml(this.titleCase(c.asset_type || ''))}</td>
-        <td class="mono">${escapeHtml(c.asset_value)}</td>
+        <td class="mono">${valueCell}</td>
         <td>${escapeHtml(c.summary || '-')}</td>
       </tr>
-    `).join('');
+    `;
+    }).join('');
+
+    const targetLink = s.target_id
+      ? `<a href="#/targets/${s.target_id}" class="mono scan-detail-target-link">${escapeHtml(data.target)}</a>`
+      : `<span class="text-muted mono">${escapeHtml(data.target)}</span>`;
+
+    const metaParts = [
+      targetLink,
+      `<span class="text-muted">${dur}</span>`,
+    ];
+    if (s.finished_at) {
+      metaParts.push(`<span class="text-muted">finished ${Components.timeAgo(s.finished_at)}</span>`);
+    } else if (isRunning && s.started_at) {
+      metaParts.push(`<span class="text-muted">started ${Components.timeAgo(s.started_at)}</span>`);
+    }
+    const metaRow = `<div class="detail-meta">${metaParts.join(' <span class="detail-meta-sep">\u00B7</span> ')}</div>`;
 
     app.innerHTML = `
       ${Components.backLink('#/scans', 'Back to scans')}
@@ -918,10 +945,9 @@ const ScansPage = {
             ${Components.statusBadge(s.status)}
             <h2>Scan ${Components.truncateID(s.id)}</h2>
             ${typeBadge}
-            <span class="text-muted mono" style="font-size:12px;margin-left:8px">${escapeHtml(data.target)}</span>
-            <span class="text-muted" style="font-size:12px;margin-left:4px">${dur}</span>
             <div style="margin-left:auto">${cancelBtn}</div>
           </div>
+          ${metaRow}
           ${timestamps.length > 0 ? `<div class="text-muted" style="font-size:11px;margin-top:4px">${timestamps.join(' \u00B7 ')}</div>` : ''}
 
           ${this.renderPhaseIndicator(s, data.tool_runs)}

--- a/internal/webui/static/js/pages/targets.js
+++ b/internal/webui/static/js/pages/targets.js
@@ -1,6 +1,10 @@
-// Targets page
+// Targets page (list + detail)
 const TargetsPage = {
-  async render(app) {
+  async render(app, params) {
+    if (params && params.id) {
+      return this.renderDetail(app, params.id);
+    }
+
     app.innerHTML = '<div class="loading">Loading targets...</div>';
 
     try {
@@ -38,8 +42,11 @@ const TargetsPage = {
       `;
     }
 
+    // Rows navigate to the detail view on click. The actions cell stops
+    // propagation per-button so the row-level handler doesn't swallow the
+    // scan/findings/delete clicks.
     const rows = targets.map(t => `
-      <tr>
+      <tr class="clickable" onclick="location.hash='#/targets/${t.id}'">
         <td class="mono">${escapeHtml(t.value)}</td>
         <td><span class="badge badge-info">${t.type}</span></td>
         <td>${t.scope}</td>
@@ -48,7 +55,7 @@ const TargetsPage = {
         <td>${t.scan_count}</td>
         <td class="text-muted">${t.last_scan_at ? Components.timeAgo(t.last_scan_at) : 'never'}</td>
         <td>${t.enabled ? '<span style="color:var(--success)">active</span>' : '<span class="text-muted">disabled</span>'}</td>
-        <td class="actions-cell">
+        <td class="actions-cell" onclick="event.stopPropagation()">
           <button class="btn btn-sm btn-accent" onclick="TargetsPage.scanTarget('${t.id}', '${escapeHtml(t.value)}')" title="Scan">
             <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"/></svg>
           </button>
@@ -104,6 +111,242 @@ const TargetsPage = {
     });
   },
 
+  // --- Target Detail View ---
+
+  async renderDetail(app, id) {
+    app.innerHTML = '<div class="loading">Loading target...</div>';
+
+    const scroller = document.querySelector('main.content');
+    if (scroller) scroller.scrollTop = 0;
+
+    try {
+      const data = await API.target(id);
+      this.renderDetailContent(app, data);
+    } catch (err) {
+      app.innerHTML = Components.emptyState('Not Found', 'Target not found.');
+    }
+  },
+
+  renderDetailContent(app, data) {
+    const t = data.target;
+    const latest = data.latest_scan;
+    const scans = data.recent_scans || [];
+    const findings = data.recent_findings || [];
+
+    const typeBadge = `<span class="badge badge-info">${escapeHtml(t.type || 'domain')}</span>`;
+    const scopeBadge = `<span class="badge badge-muted">${escapeHtml(t.scope || 'external')}</span>`;
+    const enabledBadge = t.enabled
+      ? '<span style="color:var(--success)">active</span>'
+      : '<span class="text-muted">disabled</span>';
+
+    const metaParts = [
+      enabledBadge,
+      `<span class="text-muted">${data.scan_count} scan${data.scan_count === 1 ? '' : 's'}</span>`,
+      `<span class="text-muted">${data.asset_count} asset${data.asset_count === 1 ? '' : 's'}</span>`,
+      `<span class="text-muted">${data.finding_count} finding${data.finding_count === 1 ? '' : 's'}</span>`,
+    ];
+    if (t.last_scan_at) {
+      metaParts.push(`<span class="text-muted">last scan ${Components.timeAgo(t.last_scan_at)}</span>`);
+    } else {
+      metaParts.push('<span class="text-muted">never scanned</span>');
+    }
+    const metaRow = `<div class="detail-meta">${metaParts.join(' <span class="detail-meta-sep">\u00B7</span> ')}</div>`;
+
+    const stateCard = latest ? this.renderTargetStateCard(latest) : '';
+    const findingsCard = this.renderRecentFindings(findings);
+    const scansCard = this.renderRecentScans(scans);
+
+    app.innerHTML = `
+      ${Components.backLink('#/targets', 'Back to targets')}
+      <div class="scan-detail-stack">
+        <div class="detail-panel">
+          <div class="detail-header">
+            ${typeBadge}
+            <h2 class="mono">${escapeHtml(t.value)}</h2>
+            ${scopeBadge}
+            <div style="margin-left:auto">
+              <button class="btn btn-sm btn-accent" id="target-scan-btn">Scan now</button>
+              <button class="btn btn-sm btn-ghost" id="target-findings-btn">Findings</button>
+              <button class="btn btn-sm btn-ghost" id="target-assets-btn">Assets</button>
+              <button class="btn btn-sm btn-danger" id="target-delete-btn">Delete</button>
+            </div>
+          </div>
+          ${metaRow}
+        </div>
+
+        ${stateCard}
+        ${findingsCard}
+        ${scansCard}
+      </div>
+    `;
+
+    // Wire action buttons.
+    const scanBtn = document.getElementById('target-scan-btn');
+    if (scanBtn) scanBtn.addEventListener('click', () => this.scanTarget(t.id, t.value));
+    const fBtn = document.getElementById('target-findings-btn');
+    if (fBtn) fBtn.addEventListener('click', () => this.viewFindings(t.id));
+    const aBtn = document.getElementById('target-assets-btn');
+    if (aBtn) aBtn.addEventListener('click', () => { location.hash = '#/assets?target_id=' + t.id; });
+    const dBtn = document.getElementById('target-delete-btn');
+    if (dBtn) dBtn.addEventListener('click', () => this.deleteTarget(t.id, t.value));
+  },
+
+  renderTargetStateCard(scan) {
+    const state = scan.target_state || {};
+    const assets = state.assets_by_type || {};
+    const ports = state.ports_by_status || {};
+
+    // Mirror scan-detail Target state ordering (KnownAssetTypes order, with
+    // ports broken down by status). Keeps target / scan detail consistent.
+    const items = [
+      { label: 'Subdomains', value: assets.subdomain },
+      { label: 'IPs (v4)', value: assets.ipv4 },
+      { label: 'IPs (v6)', value: assets.ipv6 },
+      { label: 'Ports (open)', value: ports.open },
+      { label: 'Ports (filtered)', value: ports.filtered },
+      { label: 'Endpoints', value: assets.url },
+      { label: 'Technologies', value: assets.technology },
+      { label: 'Domains', value: assets.domain },
+      { label: 'Services', value: assets.service },
+    ].filter(i => i.value > 0);
+
+    const known = new Set(['subdomain', 'ipv4', 'ipv6', 'port_service', 'url', 'technology', 'domain', 'service']);
+    Object.entries(assets)
+      .filter(([k, v]) => !known.has(k) && v > 0)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .forEach(([k, v]) => items.push({ label: this.titleCase(k), value: v }));
+
+    if (state.findings_open_total > 0) {
+      items.push({ label: 'Findings open', value: state.findings_open_total, divider: true });
+    }
+
+    if (items.length === 0) {
+      return `<div class="card">
+        <div class="card-label">Target state</div>
+        <div class="detail-grid detail-grid-message" style="margin-top:8px">
+          <span class="text-muted">No state recorded yet — run a scan to populate.</span>
+        </div>
+      </div>`;
+    }
+
+    const sevs = state.findings_open || {};
+    const hasSev = Object.values(sevs).some(v => v > 0);
+
+    const scanLink = `<a href="#/scans/${scan.id}" class="text-muted" style="font-weight:400;text-transform:none;font-size:11px;margin-left:8px">from scan ${Components.truncateID(scan.id)} \u00B7 ${Components.timeAgo(scan.finished_at || scan.created_at)}</a>`;
+
+    return `<div class="card">
+      <div class="card-label">Target state${scanLink}</div>
+      <div class="detail-grid" style="margin-top:8px">
+        ${items.map(i => {
+          const cls = i.divider ? ' detail-divider' : '';
+          return `<span class="detail-label${cls}">${escapeHtml(i.label)}</span><span class="detail-value${cls}">${i.value}</span>`;
+        }).join('')}
+      </div>
+      ${hasSev ? Components.severityBars({
+        critical: sevs.critical || 0,
+        high: sevs.high || 0,
+        medium: sevs.medium || 0,
+        low: sevs.low || 0,
+        info: sevs.info || 0,
+      }) : ''}
+    </div>`;
+  },
+
+  renderRecentFindings(findings) {
+    if (findings.length === 0) {
+      return `<div class="card">
+        <div class="card-label">Recent findings</div>
+        <div class="detail-grid detail-grid-message" style="margin-top:8px">
+          <span class="text-muted">No findings recorded for this target.</span>
+        </div>
+      </div>`;
+    }
+
+    const rows = findings.map(f => {
+      const assetCell = f.asset_id
+        ? `<a href="#/assets/${f.asset_id}" class="mono" onclick="event.stopPropagation()">${escapeHtml(f.asset_value || '—')}</a>`
+        : `<span class="mono text-muted">${escapeHtml(f.asset_value || '—')}</span>`;
+      return `
+        <tr class="clickable" onclick="location.hash='#/findings/${f.id}'">
+          <td>${Components.severityBadge ? Components.severityBadge(f.severity) : `<span class="badge badge-${f.severity}">${f.severity}</span>`}</td>
+          <td>${escapeHtml(f.title)}</td>
+          <td>${assetCell}</td>
+          <td>${Components.statusBadge(f.status)}</td>
+          <td class="text-muted">${f.source_tool ? escapeHtml(f.source_tool) : '-'}</td>
+          <td class="text-muted">${f.last_seen ? Components.timeAgo(f.last_seen) : '-'}</td>
+        </tr>
+      `;
+    }).join('');
+
+    return `<div class="card">
+      <div class="card-label">Recent findings <span class="text-muted" style="font-weight:400;text-transform:none">(${findings.length})</span></div>
+      <div class="table-container" style="border:none;margin:8px 0 0">
+        <table>
+          <thead><tr>
+            <th scope="col">Severity</th>
+            <th scope="col">Title</th>
+            <th scope="col">Asset</th>
+            <th scope="col">Status</th>
+            <th scope="col">Tool</th>
+            <th scope="col">Last seen</th>
+          </tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
+    </div>`;
+  },
+
+  renderRecentScans(scans) {
+    if (scans.length === 0) {
+      return `<div class="card">
+        <div class="card-label">Recent scans</div>
+        <div class="detail-grid detail-grid-message" style="margin-top:8px">
+          <span class="text-muted">No scans recorded for this target yet.</span>
+        </div>
+      </div>`;
+    }
+
+    const rows = scans.map(s => {
+      let dur = '-';
+      if (s.started_at && s.finished_at) {
+        dur = Components.formatDuration(Math.floor((new Date(s.finished_at) - new Date(s.started_at)) / 1000));
+      }
+      const findingsOpen = (s.target_state && s.target_state.findings_open_total) || 0;
+      return `
+        <tr class="clickable" onclick="location.hash='#/scans/${s.id}'">
+          <td class="mono">${Components.truncateID(s.id)}</td>
+          <td>${Components.statusBadge(s.status)}</td>
+          <td>${s.type}</td>
+          <td class="mono">${dur}</td>
+          <td>${findingsOpen} findings</td>
+          <td class="text-muted">${Components.timeAgo(s.created_at)}</td>
+        </tr>
+      `;
+    }).join('');
+
+    return `<div class="card">
+      <div class="card-label">Recent scans <span class="text-muted" style="font-weight:400;text-transform:none">(${scans.length})</span></div>
+      <div class="table-container" style="border:none;margin:8px 0 0">
+        <table>
+          <thead><tr>
+            <th scope="col">ID</th>
+            <th scope="col">Status</th>
+            <th scope="col">Type</th>
+            <th scope="col">Duration</th>
+            <th scope="col">Results</th>
+            <th scope="col">When</th>
+          </tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
+    </div>`;
+  },
+
+  titleCase(s) {
+    if (!s) return s;
+    return s.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+  },
+
   viewFindings(targetId) {
     location.hash = '#/findings?target_id=' + targetId;
   },
@@ -124,6 +367,7 @@ const TargetsPage = {
 
     try {
       await API.deleteTarget(id);
+      location.hash = '#/targets';
       TargetsPage.render(document.getElementById('app'));
     } catch (err) {
       alert('Failed to delete target: ' + err.message);


### PR DESCRIPTION
## Summary

Implements [SPEC-UX1](SPEC-UX1-webui-polish.md) (webui polish follow-ups to PRs #13/#14/#15) plus a brand-new **target detail view** that fills the navigability gap on `/targets`.

### 1. Scan detail polish (R1–R8 from SPEC-UX1)
- **Navigability:** asset values in the findings table, target name in the scan header, and asset values in the Asset Changes table are now links to their respective detail pages — no more copying IDs from text.
- **Phase indicator:** removed the bogus 6th "COMPLETE" circle (status, not phase).
- **Severity bars:** rows with `count=0` are hidden; the whole block disappears when all severities are zero.
- **Layout consistency:** the "Changes" card on baseline / no-change scans now renders inside the same grid wrapper as Target State / Work, so the three cards line up.
- **CLI ↔ web parity:** TARGET STATE order now mirrors `internal/pipeline/pipeline.go` `printTargetStateBlock` exactly (KnownAssetTypes order, alphabetic tail for unknowns, divider before Findings open).
- **Header:** split into two rows (status + id + type badges, then target link · duration · finished-ago) for legibility.

### 2. Target detail view (`#/targets/<id>`)
New `GET /api/v1/targets/{id}` endpoint composes target + counts + latest completed scan (with TargetState aggregates) + recent scans + recent findings in a single round trip. The SPA now renders:
- Header with target value, type/scope badges, and action buttons (Scan now / Findings / Assets / Delete).
- **Target state** card mirroring the scan-detail aggregates (same ordering, same severity bars).
- **Recent findings** table (Severity / Title / Asset / Status / Tool / Last seen) — clickable rows go to finding detail, asset values link to asset detail.
- **Recent scans** table — clickable rows go to scan detail.
- Rows on `/targets` list are now clickable; the actions cell stops propagation so per-row buttons keep working.

### 3. Subfinder sources metadata (R10)
`detection.SubfinderTool.Run` now persists the per-subdomain source list (sorted) into `Asset.Metadata["sources"]`, so operators can judge confidence ("only crt.sh saw this — may be old"). The SDK already returned this map; we were just throwing it away.

## Test plan

- [x] `go test ./... -race` — all green
- [x] `golangci-lint run ./...` — 0 issues
- [x] Manual: scan detail header, severity-zero hiding, target detail page, action buttons, deep links to assets/scans/findings work end-to-end against a populated SQLite store
- [x] Verified findings card on a target with all-resolved findings shows them with their status badge instead of a misleading "no open findings" message

## Out of scope (deferred)

- R9 (resolved-in-scan tooltip) — needs a backend enrichment field; left for a follow-up
- Schedule settings page redesign — proposed redesign discussed in conversation; will land as a separate PR