### PR TITLE
sched1.1: data model foundations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -330,6 +330,7 @@ require (
 	github.com/spf13/cast v1.9.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
+	github.com/teambition/rrule-go v1.8.2 // indirect
 	github.com/tidwall/btree v1.8.1 // indirect
 	github.com/tidwall/buntdb v1.3.2 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1031,6 +1031,8 @@ github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFd
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tarunKoyalwar/goleak v0.0.0-20240429141123-0efa90dbdcf9 h1:GXIyLuIJ5Qk46lI8WJ83qHBZKUI3zhmMmuoY9HICUIQ=
 github.com/tarunKoyalwar/goleak v0.0.0-20240429141123-0efa90dbdcf9/go.mod h1:uQdBQGrE1fZ2EyOs0pLcCDd1bBV4rSThieuIIGhXZ50=
+github.com/teambition/rrule-go v1.8.2 h1:lIjpjvWTj9fFUZCmuoVDrKVOtdiyzbzc93qTmRVe/J8=
+github.com/teambition/rrule-go v1.8.2/go.mod h1:Ieq5AbrKGciP1V//Wq8ktsTXwSwJHDD5mD/wLBGl3p4=
 github.com/tidwall/assert v0.1.0 h1:aWcKyRBUAdLoVebxo95N7+YZVTFF/ASTr7BN4sLP6XI=
 github.com/tidwall/assert v0.1.0/go.mod h1:QLYtGyeqse53vuELQheYl9dngGCJQ+mTtlxcktb+Kj8=
 github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=

--- a/internal/daemon/intervalsched/migrate_legacy.go
+++ b/internal/daemon/intervalsched/migrate_legacy.go
@@ -176,30 +176,30 @@ func MigrateLegacyScheduleConfig(
 // durationToRRule maps a ScheduleConfig.FullScanInterval duration onto
 // an RFC-5545 RRULE. Mappings defined by SPEC-SCHED1 R21 step 4:
 //
-//	 15m   → FREQ=MINUTELY;INTERVAL=15
-//	 1h    → FREQ=HOURLY
-//	 6h    → FREQ=HOURLY;INTERVAL=6
-//	 24h   → FREQ=DAILY
-//	 7d    → FREQ=WEEKLY
-//	 30d   → FREQ=MONTHLY
-//	 other → FREQ=DAILY (fallback)
-//	 <1m   → ErrInvalidLegacyInterval
+//	15m   → FREQ=MINUTELY;INTERVAL=15
+//	1h    → FREQ=HOURLY
+//	6h    → FREQ=HOURLY;INTERVAL=6
+//	24h   → FREQ=DAILY
+//	7d    → FREQ=WEEKLY
+//	30d   → FREQ=MONTHLY
+//	other → FREQ=DAILY (fallback)
+//	<1m   → ErrInvalidLegacyInterval
 func durationToRRule(d time.Duration) (string, error) {
 	if d < time.Minute {
 		return "", fmt.Errorf("%w: %s (min 1m)", ErrInvalidLegacyInterval, d)
 	}
-	switch {
-	case d == 15*time.Minute:
+	switch d {
+	case 15 * time.Minute:
 		return "FREQ=MINUTELY;INTERVAL=15", nil
-	case d == time.Hour:
+	case time.Hour:
 		return "FREQ=HOURLY", nil
-	case d == 6*time.Hour:
+	case 6 * time.Hour:
 		return "FREQ=HOURLY;INTERVAL=6", nil
-	case d == 24*time.Hour:
+	case 24 * time.Hour:
 		return "FREQ=DAILY", nil
-	case d == 7*24*time.Hour:
+	case 7 * 24 * time.Hour:
 		return "FREQ=WEEKLY", nil
-	case d == 30*24*time.Hour:
+	case 30 * 24 * time.Hour:
 		return "FREQ=MONTHLY", nil
 	default:
 		return "FREQ=DAILY", nil

--- a/internal/daemon/intervalsched/migrate_legacy.go
+++ b/internal/daemon/intervalsched/migrate_legacy.go
@@ -1,0 +1,280 @@
+package intervalsched
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// ErrInvalidLegacyInterval is returned when full_scan_interval parses to
+// a value the scheduler cannot express as a safe RRULE (sub-minute
+// cadence, zero/negative, unparseable).
+var ErrInvalidLegacyInterval = errors.New("invalid legacy interval")
+
+// LegacyMigrationBackend is the narrow surface MigrateLegacyScheduleConfig
+// needs from the storage layer. It abstracts storage.SQLiteStore so
+// tests can inject faults without a real SQLite dependency.
+type LegacyMigrationBackend interface {
+	Transact(ctx context.Context, fn func(context.Context, storage.TxStores) error) error
+	ListTargets(ctx context.Context) ([]model.Target, error)
+}
+
+// MigrationReport describes what MigrateLegacyScheduleConfig did or why
+// it skipped. Non-empty SkippedReason means no DB writes occurred.
+type MigrationReport struct {
+	TemplateID       string
+	TargetsMigrated  int
+	SchedulesCreated int
+	SkippedReason    string
+}
+
+// MigrateLegacyScheduleConfig is a one-shot promotion of
+// <stateDir>/schedule.config.json to a first-class `default` template,
+// updated schedule_defaults, and per-target `default` schedules. It is
+// idempotent: once it renames the source file to
+// schedule.config.json.migrated, subsequent invocations return
+// SkippedReason="already_migrated" without touching the database.
+//
+// NOT YET WIRED into daemon boot — PR SCHED1.2 handles that. This PR
+// only compiles and tests the function.
+func MigrateLegacyScheduleConfig(
+	ctx context.Context,
+	stateDir string,
+	backend LegacyMigrationBackend,
+	logger *slog.Logger,
+) (MigrationReport, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	sentinel := filepath.Join(stateDir, "schedule.config.json.migrated")
+	source := filepath.Join(stateDir, "schedule.config.json")
+
+	if _, err := os.Stat(sentinel); err == nil {
+		return MigrationReport{SkippedReason: "already_migrated"}, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return MigrationReport{}, fmt.Errorf("stat sentinel: %w", err)
+	}
+
+	if _, err := os.Stat(source); errors.Is(err, os.ErrNotExist) {
+		return MigrationReport{SkippedReason: "no_legacy_file"}, nil
+	} else if err != nil {
+		return MigrationReport{}, fmt.Errorf("stat source: %w", err)
+	}
+
+	cfg, err := NewScheduleConfigStore(source).Load()
+	if err != nil {
+		return MigrationReport{}, fmt.Errorf("load legacy config: %w", err)
+	}
+
+	full, err := time.ParseDuration(cfg.FullScanInterval)
+	if err != nil {
+		return MigrationReport{}, fmt.Errorf("parse full_scan_interval %q: %w", cfg.FullScanInterval, err)
+	}
+	rrule, err := durationToRRule(full)
+	if err != nil {
+		return MigrationReport{}, err
+	}
+
+	targets, err := backend.ListTargets(ctx)
+	if err != nil {
+		return MigrationReport{}, fmt.Errorf("list targets: %w", err)
+	}
+
+	report := MigrationReport{}
+	timezone := cfg.MaintenanceWindow.Timezone
+	if timezone == "" {
+		timezone = "UTC"
+	}
+	maintWin := legacyWindowToMaintenance(cfg.MaintenanceWindow)
+
+	err = backend.Transact(ctx, func(ctx context.Context, stores storage.TxStores) error {
+		tmpl := &model.Template{
+			Name:        "default",
+			Description: "migrated from schedule.config.json",
+			RRule:       rrule,
+			Timezone:    timezone,
+			ToolConfig:  legacyToolsToConfig(cfg.QuickCheckTools),
+			IsSystem:    true,
+		}
+		if maintWin != nil {
+			tmpl.MaintenanceWindow = maintWin
+		}
+		if err := stores.Templates.Create(ctx, tmpl); err != nil {
+			return fmt.Errorf("create default template: %w", err)
+		}
+		report.TemplateID = tmpl.ID
+
+		defaults, err := stores.ScheduleDefaults.Get(ctx)
+		if err != nil {
+			return fmt.Errorf("get schedule defaults: %w", err)
+		}
+		defaults.DefaultTemplateID = &tmpl.ID
+		defaults.DefaultRRule = rrule
+		defaults.DefaultTimezone = timezone
+		defaults.RunOnStart = cfg.RunOnStart
+		if jitter, err := time.ParseDuration(cfg.Jitter); err == nil && jitter > 0 {
+			defaults.JitterSeconds = int(jitter.Seconds())
+		}
+		if maintWin != nil {
+			defaults.DefaultMaintenanceWindow = maintWin
+		}
+		if err := stores.ScheduleDefaults.Update(ctx, defaults); err != nil {
+			return fmt.Errorf("update schedule defaults: %w", err)
+		}
+
+		nextRun := computeInitialNextRun(cfg, time.Now().UTC())
+		for _, tgt := range targets {
+			if !tgt.Enabled {
+				continue
+			}
+			s := &model.Schedule{
+				TargetID:   tgt.ID,
+				Name:       "default",
+				RRule:      rrule,
+				DTStart:    time.Now().UTC(),
+				Timezone:   timezone,
+				TemplateID: &tmpl.ID,
+				Overrides:  []string{},
+				ToolConfig: model.ToolConfig{},
+				Enabled:    true,
+				NextRunAt:  nextRun,
+			}
+			if err := stores.Schedules.Create(ctx, s); err != nil {
+				return fmt.Errorf("create schedule for target %s: %w", tgt.ID, err)
+			}
+			report.TargetsMigrated++
+			report.SchedulesCreated++
+		}
+		return nil
+	})
+	if err != nil {
+		return MigrationReport{}, err
+	}
+
+	if err := os.Rename(source, sentinel); err != nil {
+		return MigrationReport{}, fmt.Errorf("rename source to sentinel: %w", err)
+	}
+
+	logger.Info("migrated schedule.config.json",
+		"template", "default",
+		"template_id", report.TemplateID,
+		"schedules_created", report.SchedulesCreated,
+		"targets_migrated", report.TargetsMigrated,
+	)
+	return report, nil
+}
+
+// durationToRRule maps a ScheduleConfig.FullScanInterval duration onto
+// an RFC-5545 RRULE. Mappings defined by SPEC-SCHED1 R21 step 4:
+//
+//	 15m   → FREQ=MINUTELY;INTERVAL=15
+//	 1h    → FREQ=HOURLY
+//	 6h    → FREQ=HOURLY;INTERVAL=6
+//	 24h   → FREQ=DAILY
+//	 7d    → FREQ=WEEKLY
+//	 30d   → FREQ=MONTHLY
+//	 other → FREQ=DAILY (fallback)
+//	 <1m   → ErrInvalidLegacyInterval
+func durationToRRule(d time.Duration) (string, error) {
+	if d < time.Minute {
+		return "", fmt.Errorf("%w: %s (min 1m)", ErrInvalidLegacyInterval, d)
+	}
+	switch {
+	case d == 15*time.Minute:
+		return "FREQ=MINUTELY;INTERVAL=15", nil
+	case d == time.Hour:
+		return "FREQ=HOURLY", nil
+	case d == 6*time.Hour:
+		return "FREQ=HOURLY;INTERVAL=6", nil
+	case d == 24*time.Hour:
+		return "FREQ=DAILY", nil
+	case d == 7*24*time.Hour:
+		return "FREQ=WEEKLY", nil
+	case d == 30*24*time.Hour:
+		return "FREQ=MONTHLY", nil
+	default:
+		return "FREQ=DAILY", nil
+	}
+}
+
+// legacyToolsToConfig translates the legacy QuickCheckTools list into a
+// ToolConfig. In v1 we only seed the keys — downstream work (SCHED1.2)
+// will populate richer params from scan-time context.
+func legacyToolsToConfig(tools []string) model.ToolConfig {
+	if len(tools) == 0 {
+		return model.ToolConfig{}
+	}
+	tc := model.ToolConfig{}
+	for _, name := range tools {
+		name = strings.ToLower(strings.TrimSpace(name))
+		if _, known := model.RegisteredToolParams[name]; !known {
+			// Unknown tools in the legacy config would block ValidateToolConfig;
+			// skip them rather than fail the migration. The operator may
+			// reintroduce such params on a per-schedule basis later.
+			continue
+		}
+		tc[name] = []byte(`{}`)
+	}
+	return tc
+}
+
+// legacyWindowToMaintenance converts the legacy HH:MM window into a
+// nested RRULE-based MaintenanceWindow. A disabled window returns nil.
+func legacyWindowToMaintenance(w ScheduleConfigWindow) *model.MaintenanceWindow {
+	if !w.Enabled {
+		return nil
+	}
+	tz := w.Timezone
+	if tz == "" {
+		tz = "UTC"
+	}
+	start, err := ParseTimeOfDay(w.Start)
+	if err != nil {
+		return nil
+	}
+	end, err := ParseTimeOfDay(w.End)
+	if err != nil {
+		return nil
+	}
+	startMins := start.Hour*60 + start.Minute
+	endMins := end.Hour*60 + end.Minute
+	var durationSec int
+	if endMins > startMins {
+		durationSec = (endMins - startMins) * 60
+	} else {
+		// Crosses midnight: window is [start, 24h) ∪ [0, end)
+		durationSec = ((24*60 - startMins) + endMins) * 60
+	}
+	return &model.MaintenanceWindow{
+		RRule:       fmt.Sprintf("FREQ=DAILY;BYHOUR=%d;BYMINUTE=%d", start.Hour, start.Minute),
+		DurationSec: durationSec,
+		Timezone:    tz,
+	}
+}
+
+// computeInitialNextRun picks the schedule's next fire timestamp at
+// migration time. Honors RunOnStart: true → now, false → now + 1 tick
+// of full_scan_interval. The scheduler re-materializes this on its next
+// tick via the RRULE library anyway; this is just a reasonable seed.
+func computeInitialNextRun(cfg ScheduleConfig, now time.Time) *time.Time {
+	if cfg.RunOnStart {
+		t := now
+		return &t
+	}
+	d, err := time.ParseDuration(cfg.FullScanInterval)
+	if err != nil || d <= 0 {
+		t := now.Add(24 * time.Hour)
+		return &t
+	}
+	t := now.Add(d)
+	return &t
+}

--- a/internal/daemon/intervalsched/migrate_legacy_test.go
+++ b/internal/daemon/intervalsched/migrate_legacy_test.go
@@ -36,7 +36,7 @@ func newBackend(t *testing.T) *storage.SQLiteStore {
 	t.Helper()
 	s, err := storage.NewSQLiteStore(":memory:")
 	require.NoError(t, err)
-	t.Cleanup(func() { s.Close() })
+	t.Cleanup(func() { _ = s.Close() })
 	return s
 }
 

--- a/internal/daemon/intervalsched/migrate_legacy_test.go
+++ b/internal/daemon/intervalsched/migrate_legacy_test.go
@@ -1,0 +1,261 @@
+package intervalsched
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// stageFixture copies testdata/legacy_schedule_v1.json to a temp dir and
+// returns that dir. Tests mutate the dir freely.
+func stageFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src, err := os.ReadFile(filepath.Join("testdata", "legacy_schedule_v1.json"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "schedule.config.json"), src, 0o600))
+	return dir
+}
+
+func newBackend(t *testing.T) *storage.SQLiteStore {
+	t.Helper()
+	s, err := storage.NewSQLiteStore(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func seedTargets(t *testing.T, s *storage.SQLiteStore, values ...string) {
+	t.Helper()
+	for _, v := range values {
+		require.NoError(t, s.CreateTarget(context.Background(), &model.Target{Value: v}))
+	}
+}
+
+func TestMigrateLegacy_GoldenRoundTrip(t *testing.T) {
+	dir := stageFixture(t)
+	s := newBackend(t)
+	seedTargets(t, s, "a.example", "b.example")
+
+	ctx := context.Background()
+	report, err := MigrateLegacyScheduleConfig(ctx, dir, s, silentLogger())
+	require.NoError(t, err)
+	assert.NotEmpty(t, report.TemplateID)
+	assert.Equal(t, 2, report.TargetsMigrated)
+	assert.Equal(t, 2, report.SchedulesCreated)
+	assert.Empty(t, report.SkippedReason)
+
+	// Sentinel rename happened.
+	_, err = os.Stat(filepath.Join(dir, "schedule.config.json"))
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+	_, err = os.Stat(filepath.Join(dir, "schedule.config.json.migrated"))
+	assert.NoError(t, err)
+
+	// Template created with is_system=1.
+	tmpl, err := s.Templates().GetByName(ctx, "default")
+	require.NoError(t, err)
+	assert.True(t, tmpl.IsSystem)
+	assert.Equal(t, "FREQ=DAILY", tmpl.RRule)
+	require.NotNil(t, tmpl.MaintenanceWindow)
+	assert.Equal(t, 2*60*60, tmpl.MaintenanceWindow.DurationSec)
+
+	// Each enabled target has a "default" schedule.
+	tgts, err := s.ListTargets(ctx)
+	require.NoError(t, err)
+	for _, tgt := range tgts {
+		got, err := s.Schedules().GetByTargetAndName(ctx, tgt.ID, "default")
+		require.NoError(t, err, "target %s missing default schedule", tgt.ID)
+		require.NotNil(t, got.TemplateID)
+		assert.Equal(t, tmpl.ID, *got.TemplateID)
+		assert.True(t, got.Enabled)
+	}
+
+	// Defaults table links to the new template.
+	defaults, err := s.ScheduleDefaults().Get(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, defaults.DefaultTemplateID)
+	assert.Equal(t, tmpl.ID, *defaults.DefaultTemplateID)
+}
+
+func TestMigrateLegacy_Idempotent(t *testing.T) {
+	dir := stageFixture(t)
+	s := newBackend(t)
+	seedTargets(t, s, "a.example")
+	ctx := context.Background()
+
+	_, err := MigrateLegacyScheduleConfig(ctx, dir, s, silentLogger())
+	require.NoError(t, err)
+
+	report, err := MigrateLegacyScheduleConfig(ctx, dir, s, silentLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "already_migrated", report.SkippedReason)
+	assert.Empty(t, report.TemplateID)
+}
+
+func TestMigrateLegacy_NoLegacyFile(t *testing.T) {
+	dir := t.TempDir()
+	s := newBackend(t)
+	ctx := context.Background()
+
+	report, err := MigrateLegacyScheduleConfig(ctx, dir, s, silentLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "no_legacy_file", report.SkippedReason)
+
+	// DB untouched — no default template.
+	_, err = s.Templates().GetByName(ctx, "default")
+	assert.True(t, errors.Is(err, storage.ErrNotFound))
+}
+
+// faultyBackend wraps a real store but decorates TxStores.Schedules with
+// a fault-injecting ScheduleStore that fails the Nth Create call.
+type faultyBackend struct {
+	inner     *storage.SQLiteStore
+	failOnNth int // 1-indexed
+}
+
+func (f *faultyBackend) ListTargets(ctx context.Context) ([]model.Target, error) {
+	return f.inner.ListTargets(ctx)
+}
+
+func (f *faultyBackend) Transact(ctx context.Context, fn func(context.Context, storage.TxStores) error) error {
+	return f.inner.Transact(ctx, func(ctx context.Context, stores storage.TxStores) error {
+		stores.Schedules = &faultyScheduleStore{inner: stores.Schedules, failOnNth: f.failOnNth}
+		return fn(ctx, stores)
+	})
+}
+
+type faultyScheduleStore struct {
+	inner     storage.ScheduleStore
+	failOnNth int
+	calls     int
+}
+
+var errInjected = errors.New("injected failure")
+
+func (f *faultyScheduleStore) Create(ctx context.Context, s *model.Schedule) error {
+	f.calls++
+	if f.calls == f.failOnNth {
+		return errInjected
+	}
+	return f.inner.Create(ctx, s)
+}
+
+// Pass-throughs for the other interface methods.
+func (f *faultyScheduleStore) Get(ctx context.Context, id string) (*model.Schedule, error) {
+	return f.inner.Get(ctx, id)
+}
+func (f *faultyScheduleStore) GetByTargetAndName(ctx context.Context, t, n string) (*model.Schedule, error) {
+	return f.inner.GetByTargetAndName(ctx, t, n)
+}
+func (f *faultyScheduleStore) ListByTarget(ctx context.Context, t string) ([]model.Schedule, error) {
+	return f.inner.ListByTarget(ctx, t)
+}
+func (f *faultyScheduleStore) ListAll(ctx context.Context) ([]model.Schedule, error) {
+	return f.inner.ListAll(ctx)
+}
+func (f *faultyScheduleStore) ListDue(ctx context.Context, now time.Time, limit int) ([]model.Schedule, error) {
+	return f.inner.ListDue(ctx, now, limit)
+}
+func (f *faultyScheduleStore) ListByTemplate(ctx context.Context, id string) ([]model.Schedule, error) {
+	return f.inner.ListByTemplate(ctx, id)
+}
+func (f *faultyScheduleStore) Update(ctx context.Context, s *model.Schedule) error {
+	return f.inner.Update(ctx, s)
+}
+func (f *faultyScheduleStore) SetNextRunAt(ctx context.Context, id string, next *time.Time) error {
+	return f.inner.SetNextRunAt(ctx, id, next)
+}
+func (f *faultyScheduleStore) RecordRun(ctx context.Context, id string, status model.ScheduleRunStatus, scanID *string, at time.Time) error {
+	return f.inner.RecordRun(ctx, id, status, scanID, at)
+}
+func (f *faultyScheduleStore) Delete(ctx context.Context, id string) error {
+	return f.inner.Delete(ctx, id)
+}
+func (f *faultyScheduleStore) CountByTarget(ctx context.Context, t string) (int, error) {
+	return f.inner.CountByTarget(ctx, t)
+}
+
+func TestMigrateLegacy_RollbackOnMidStreamFailure(t *testing.T) {
+	dir := stageFixture(t)
+	s := newBackend(t)
+	seedTargets(t, s, "a.example", "b.example", "c.example")
+	ctx := context.Background()
+
+	backend := &faultyBackend{inner: s, failOnNth: 2}
+	_, err := MigrateLegacyScheduleConfig(ctx, dir, backend, silentLogger())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errInjected))
+
+	// DB rolled back — no template, no schedules for any target.
+	_, err = s.Templates().GetByName(ctx, "default")
+	assert.True(t, errors.Is(err, storage.ErrNotFound))
+	tgts, err := s.ListTargets(ctx)
+	require.NoError(t, err)
+	for _, tgt := range tgts {
+		count, err := s.Schedules().CountByTarget(ctx, tgt.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 0, count, "target %s should have zero schedules post-rollback", tgt.ID)
+	}
+
+	// File system: source is still there, sentinel is not — rollback is
+	// all-or-nothing.
+	_, err = os.Stat(filepath.Join(dir, "schedule.config.json"))
+	assert.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dir, "schedule.config.json.migrated"))
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+}
+
+func TestDurationToRRule(t *testing.T) {
+	cases := []struct {
+		d       time.Duration
+		want    string
+		wantErr error
+	}{
+		{15 * time.Minute, "FREQ=MINUTELY;INTERVAL=15", nil},
+		{time.Hour, "FREQ=HOURLY", nil},
+		{6 * time.Hour, "FREQ=HOURLY;INTERVAL=6", nil},
+		{24 * time.Hour, "FREQ=DAILY", nil},
+		{7 * 24 * time.Hour, "FREQ=WEEKLY", nil},
+		{30 * 24 * time.Hour, "FREQ=MONTHLY", nil},
+		{90 * time.Minute, "FREQ=DAILY", nil}, // pathological fallback
+		{time.Second, "", ErrInvalidLegacyInterval},
+		{0, "", ErrInvalidLegacyInterval},
+	}
+	for _, c := range cases {
+		t.Run(c.d.String(), func(t *testing.T) {
+			got, err := durationToRRule(c.d)
+			if c.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, c.wantErr))
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+// TestMigrateLegacy_NotCalledFromBoot is a grep invariant: the legacy
+// migration function must not be invoked anywhere in the daemon boot
+// path before PR SCHED1.2. This test pins the contract by asserting
+// scheduler.go has no reference to MigrateLegacyScheduleConfig.
+func TestMigrateLegacy_NotCalledFromBoot(t *testing.T) {
+	b, err := os.ReadFile("scheduler.go")
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "MigrateLegacyScheduleConfig")
+}

--- a/internal/daemon/intervalsched/testdata/legacy_schedule_v1.json
+++ b/internal/daemon/intervalsched/testdata/legacy_schedule_v1.json
@@ -1,0 +1,14 @@
+{
+  "enabled": true,
+  "full_scan_interval": "24h",
+  "quick_check_interval": "1h",
+  "jitter": "60s",
+  "run_on_start": false,
+  "quick_check_tools": ["nuclei", "httpx"],
+  "maintenance_window": {
+    "enabled": true,
+    "start": "02:00",
+    "end": "04:00",
+    "timezone": "UTC"
+  }
+}

--- a/internal/model/cascade.go
+++ b/internal/model/cascade.go
@@ -1,0 +1,166 @@
+package model
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ErrRequiredFieldUnresolved is returned by ResolveEffectiveConfig when
+// no layer (schedule, template, defaults) provides a value for a field
+// the scheduler needs. The error message names the offending field.
+var ErrRequiredFieldUnresolved = errors.New("required field unresolved")
+
+// EffectiveConfig is the fully-resolved scheduling configuration used at
+// dispatch time. All pointer/optional fields on Schedule / Template /
+// ScheduleDefaults have been walked to a concrete value.
+type EffectiveConfig struct {
+	RRule             string
+	Timezone          string
+	ToolConfig        ToolConfig
+	MaintenanceWindow *MaintenanceWindow
+}
+
+// ResolveEffectiveConfig walks schedule → template → defaults per
+// SPEC-SCHED1 R18 rules:
+//
+//   - rrule / timezone / maintenance_window use the schedule's value iff
+//     the field name is listed in Schedule.Overrides. Otherwise fall
+//     through to the template (if non-nil) then to defaults.
+//   - tool_config merges shallowly per tool name across layers: defaults
+//     → template → schedule. Keys present in schedule replace same-named
+//     keys in template, but tool params not mentioned at the schedule
+//     layer inherit from the template / defaults. Merging within a
+//     single tool's params is also shallow: schedule's "nuclei.severity"
+//     overrides, but schedule's missing "nuclei.rate_limit" inherits.
+//
+// Returns ErrRequiredFieldUnresolved (wrapped with the field name) when
+// rrule or timezone cannot be resolved.
+func ResolveEffectiveConfig(s Schedule, tmpl *Template, defaults ScheduleDefaults) (EffectiveConfig, error) {
+	overridden := overrideSet(s.Overrides)
+
+	rrule := pickString("rrule", overridden, s.RRule, tmplRRule(tmpl), defaults.DefaultRRule)
+	if rrule == "" {
+		return EffectiveConfig{}, fmt.Errorf("%w: rrule", ErrRequiredFieldUnresolved)
+	}
+	tz := pickString("timezone", overridden, s.Timezone, tmplTimezone(tmpl), defaults.DefaultTimezone)
+	if tz == "" {
+		return EffectiveConfig{}, fmt.Errorf("%w: timezone", ErrRequiredFieldUnresolved)
+	}
+
+	mw := resolveMaintenanceWindow(overridden, s, tmpl, defaults)
+	tc := resolveToolConfig(s, tmpl, defaults)
+
+	return EffectiveConfig{
+		RRule:             rrule,
+		Timezone:          tz,
+		ToolConfig:        tc,
+		MaintenanceWindow: mw,
+	}, nil
+}
+
+func overrideSet(overrides []string) map[string]bool {
+	set := make(map[string]bool, len(overrides))
+	for _, name := range overrides {
+		set[name] = true
+	}
+	return set
+}
+
+func pickString(field string, overridden map[string]bool, sched, tmpl, def string) string {
+	if overridden[field] && sched != "" {
+		return sched
+	}
+	if tmpl != "" {
+		return tmpl
+	}
+	if def != "" {
+		return def
+	}
+	// Final fallback: if the schedule supplied a value and the override
+	// flag is not set, still use it rather than erroring. This keeps
+	// standalone schedules (no template) working without requiring an
+	// explicit override list.
+	if sched != "" {
+		return sched
+	}
+	return ""
+}
+
+func tmplRRule(t *Template) string {
+	if t == nil {
+		return ""
+	}
+	return t.RRule
+}
+
+func tmplTimezone(t *Template) string {
+	if t == nil {
+		return ""
+	}
+	return t.Timezone
+}
+
+func resolveMaintenanceWindow(overridden map[string]bool, s Schedule, tmpl *Template, defaults ScheduleDefaults) *MaintenanceWindow {
+	if overridden["maintenance_window"] && s.MaintenanceWindow != nil {
+		return s.MaintenanceWindow
+	}
+	if tmpl != nil && tmpl.MaintenanceWindow != nil {
+		return tmpl.MaintenanceWindow
+	}
+	if defaults.DefaultMaintenanceWindow != nil {
+		return defaults.DefaultMaintenanceWindow
+	}
+	if s.MaintenanceWindow != nil {
+		return s.MaintenanceWindow
+	}
+	return nil
+}
+
+func resolveToolConfig(s Schedule, tmpl *Template, defaults ScheduleDefaults) ToolConfig {
+	out := ToolConfig{}
+
+	var layers []ToolConfig
+	if defaults.DefaultToolConfig != nil {
+		layers = append(layers, defaults.DefaultToolConfig)
+	}
+	if tmpl != nil && tmpl.ToolConfig != nil {
+		layers = append(layers, tmpl.ToolConfig)
+	}
+	if s.ToolConfig != nil {
+		layers = append(layers, s.ToolConfig)
+	}
+
+	for _, layer := range layers {
+		for name, raw := range layer {
+			existing, ok := out[name]
+			if !ok {
+				out[name] = raw
+				continue
+			}
+			out[name] = shallowMergeJSONObjects(existing, raw)
+		}
+	}
+	return out
+}
+
+// shallowMergeJSONObjects merges two JSON objects key-by-key, with
+// `overlay` winning. If either side fails to decode as an object the
+// overlay is returned unchanged — the schedule's intent is authoritative.
+func shallowMergeJSONObjects(base, overlay json.RawMessage) json.RawMessage {
+	var baseMap, overlayMap map[string]json.RawMessage
+	if err := json.Unmarshal(base, &baseMap); err != nil {
+		return overlay
+	}
+	if err := json.Unmarshal(overlay, &overlayMap); err != nil {
+		return overlay
+	}
+	for k, v := range overlayMap {
+		baseMap[k] = v
+	}
+	merged, err := json.Marshal(baseMap)
+	if err != nil {
+		return overlay
+	}
+	return merged
+}

--- a/internal/model/cascade_test.go
+++ b/internal/model/cascade_test.go
@@ -1,0 +1,215 @@
+package model
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveEffectiveConfig_SpecAcceptance pins the R20 example: schedule
+// overrides nuclei.severity; template supplies nuclei.rate_limit and
+// naabu entirely; effective config merges correctly.
+func TestResolveEffectiveConfig_SpecAcceptance(t *testing.T) {
+	tmpl := &Template{
+		ID:       "tmpl-01",
+		Name:     "prod-critical",
+		RRule:    "FREQ=DAILY",
+		Timezone: "UTC",
+		ToolConfig: ToolConfig{
+			"nuclei": json.RawMessage(`{"severity":["low","info"],"rate_limit":100}`),
+			"naabu":  json.RawMessage(`{"ports":"top-1000"}`),
+		},
+	}
+	tmplID := tmpl.ID
+	sched := Schedule{
+		ID:         "sched-01",
+		TemplateID: &tmplID,
+		ToolConfig: ToolConfig{
+			"nuclei": json.RawMessage(`{"severity":["critical","high"]}`),
+		},
+		// Note: Overrides left empty — tool_config merges without an
+		// explicit entry per SPEC-SCHED1 R20.
+	}
+	defaults := ScheduleDefaults{DefaultTimezone: "UTC"}
+
+	eff, err := ResolveEffectiveConfig(sched, tmpl, defaults)
+	require.NoError(t, err)
+	assert.Equal(t, "FREQ=DAILY", eff.RRule)
+	assert.Equal(t, "UTC", eff.Timezone)
+
+	var nuclei map[string]any
+	require.NoError(t, json.Unmarshal(eff.ToolConfig["nuclei"], &nuclei))
+	assert.Equal(t, []any{"critical", "high"}, nuclei["severity"])
+	assert.Equal(t, float64(100), nuclei["rate_limit"])
+
+	var naabu map[string]any
+	require.NoError(t, json.Unmarshal(eff.ToolConfig["naabu"], &naabu))
+	assert.Equal(t, "top-1000", naabu["ports"])
+}
+
+// TestResolveEffectiveConfig_TopLevelFields is the table-driven coverage
+// for the override × layer combinations of rrule, timezone, and
+// maintenance_window.
+func TestResolveEffectiveConfig_TopLevelFields(t *testing.T) {
+	schedMW := &MaintenanceWindow{RRule: "FREQ=DAILY;BYHOUR=0", DurationSec: 600, Timezone: "UTC"}
+	tmplMW := &MaintenanceWindow{RRule: "FREQ=DAILY;BYHOUR=1", DurationSec: 1200, Timezone: "UTC"}
+	defMW := &MaintenanceWindow{RRule: "FREQ=DAILY;BYHOUR=2", DurationSec: 1800, Timezone: "UTC"}
+
+	cases := []struct {
+		name       string
+		sched      Schedule
+		tmpl       *Template
+		defaults   ScheduleDefaults
+		wantRRule  string
+		wantTZ     string
+		wantMW     *MaintenanceWindow
+	}{
+		{
+			name:      "override wins: rrule",
+			sched:     Schedule{RRule: "FREQ=HOURLY", Timezone: "UTC", Overrides: []string{"rrule"}},
+			tmpl:      &Template{RRule: "FREQ=DAILY", Timezone: "UTC"},
+			defaults:  ScheduleDefaults{DefaultRRule: "FREQ=WEEKLY", DefaultTimezone: "UTC"},
+			wantRRule: "FREQ=HOURLY",
+			wantTZ:    "UTC",
+		},
+		{
+			name:      "template wins when no override",
+			sched:     Schedule{RRule: "FREQ=HOURLY", Timezone: "UTC"},
+			tmpl:      &Template{RRule: "FREQ=DAILY", Timezone: "UTC"},
+			defaults:  ScheduleDefaults{DefaultRRule: "FREQ=WEEKLY", DefaultTimezone: "UTC"},
+			wantRRule: "FREQ=DAILY",
+			wantTZ:    "UTC",
+		},
+		{
+			name:      "defaults win when no template and no override",
+			sched:     Schedule{},
+			tmpl:      nil,
+			defaults:  ScheduleDefaults{DefaultRRule: "FREQ=WEEKLY", DefaultTimezone: "UTC"},
+			wantRRule: "FREQ=WEEKLY",
+			wantTZ:    "UTC",
+		},
+		{
+			name:      "standalone schedule supplies rrule without override list",
+			sched:     Schedule{RRule: "FREQ=HOURLY", Timezone: "UTC"},
+			tmpl:      nil,
+			defaults:  ScheduleDefaults{},
+			wantRRule: "FREQ=HOURLY",
+			wantTZ:    "UTC",
+		},
+		{
+			name:      "timezone override wins",
+			sched:     Schedule{RRule: "FREQ=DAILY", Timezone: "Europe/Madrid", Overrides: []string{"timezone"}},
+			tmpl:      &Template{RRule: "FREQ=DAILY", Timezone: "UTC"},
+			defaults:  ScheduleDefaults{},
+			wantRRule: "FREQ=DAILY",
+			wantTZ:    "Europe/Madrid",
+		},
+		{
+			name:     "maintenance_window override",
+			sched:    Schedule{RRule: "FREQ=DAILY", Timezone: "UTC", Overrides: []string{"maintenance_window"}, MaintenanceWindow: schedMW},
+			tmpl:     &Template{RRule: "FREQ=DAILY", Timezone: "UTC", MaintenanceWindow: tmplMW},
+			defaults: ScheduleDefaults{DefaultMaintenanceWindow: defMW},
+			wantMW:   schedMW,
+		},
+		{
+			name:     "maintenance_window from template when not overridden",
+			sched:    Schedule{RRule: "FREQ=DAILY", Timezone: "UTC", MaintenanceWindow: schedMW},
+			tmpl:     &Template{RRule: "FREQ=DAILY", Timezone: "UTC", MaintenanceWindow: tmplMW},
+			defaults: ScheduleDefaults{DefaultMaintenanceWindow: defMW},
+			wantMW:   tmplMW,
+		},
+		{
+			name:     "maintenance_window from defaults when template empty",
+			sched:    Schedule{RRule: "FREQ=DAILY", Timezone: "UTC"},
+			tmpl:     &Template{RRule: "FREQ=DAILY", Timezone: "UTC"},
+			defaults: ScheduleDefaults{DefaultMaintenanceWindow: defMW},
+			wantMW:   defMW,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			eff, err := ResolveEffectiveConfig(c.sched, c.tmpl, c.defaults)
+			require.NoError(t, err)
+			if c.wantRRule != "" {
+				assert.Equal(t, c.wantRRule, eff.RRule)
+			}
+			if c.wantTZ != "" {
+				assert.Equal(t, c.wantTZ, eff.Timezone)
+			}
+			if c.wantMW != nil {
+				require.NotNil(t, eff.MaintenanceWindow)
+				assert.Equal(t, *c.wantMW, *eff.MaintenanceWindow)
+			}
+		})
+	}
+}
+
+func TestResolveEffectiveConfig_RequiredFieldError(t *testing.T) {
+	_, err := ResolveEffectiveConfig(Schedule{}, nil, ScheduleDefaults{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRequiredFieldUnresolved))
+	assert.Contains(t, err.Error(), "rrule")
+
+	_, err = ResolveEffectiveConfig(Schedule{RRule: "FREQ=DAILY"}, nil, ScheduleDefaults{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRequiredFieldUnresolved))
+	assert.Contains(t, err.Error(), "timezone")
+}
+
+func TestResolveEffectiveConfig_ToolConfigFallthrough(t *testing.T) {
+	// No schedule tool_config, no template → defaults supply everything.
+	defaults := ScheduleDefaults{
+		DefaultRRule:    "FREQ=DAILY",
+		DefaultTimezone: "UTC",
+		DefaultToolConfig: ToolConfig{
+			"nuclei": json.RawMessage(`{"rate_limit":50}`),
+		},
+	}
+	eff, err := ResolveEffectiveConfig(Schedule{}, nil, defaults)
+	require.NoError(t, err)
+	var n map[string]any
+	require.NoError(t, json.Unmarshal(eff.ToolConfig["nuclei"], &n))
+	assert.Equal(t, float64(50), n["rate_limit"])
+}
+
+func TestResolveEffectiveConfig_PerToolKeyMerge(t *testing.T) {
+	// defaults only supply naabu; template supplies nuclei; schedule
+	// overrides one sub-field of nuclei. Effective: all three present,
+	// schedule's nuclei fields win where specified.
+	defaults := ScheduleDefaults{
+		DefaultRRule:    "FREQ=DAILY",
+		DefaultTimezone: "UTC",
+		DefaultToolConfig: ToolConfig{
+			"naabu": json.RawMessage(`{"ports":"top-100"}`),
+		},
+	}
+	tmpl := &Template{
+		RRule:    "FREQ=DAILY",
+		Timezone: "UTC",
+		ToolConfig: ToolConfig{
+			"nuclei": json.RawMessage(`{"severity":["low"],"rate_limit":100}`),
+		},
+	}
+	sched := Schedule{
+		RRule:    "FREQ=DAILY",
+		Timezone: "UTC",
+		ToolConfig: ToolConfig{
+			"nuclei": json.RawMessage(`{"severity":["critical"]}`),
+		},
+	}
+	eff, err := ResolveEffectiveConfig(sched, tmpl, defaults)
+	require.NoError(t, err)
+
+	var nuclei map[string]any
+	require.NoError(t, json.Unmarshal(eff.ToolConfig["nuclei"], &nuclei))
+	assert.Equal(t, []any{"critical"}, nuclei["severity"])
+	assert.Equal(t, float64(100), nuclei["rate_limit"])
+
+	var naabu map[string]any
+	require.NoError(t, json.Unmarshal(eff.ToolConfig["naabu"], &naabu))
+	assert.Equal(t, "top-100", naabu["ports"])
+}

--- a/internal/model/cascade_test.go
+++ b/internal/model/cascade_test.go
@@ -59,13 +59,13 @@ func TestResolveEffectiveConfig_TopLevelFields(t *testing.T) {
 	defMW := &MaintenanceWindow{RRule: "FREQ=DAILY;BYHOUR=2", DurationSec: 1800, Timezone: "UTC"}
 
 	cases := []struct {
-		name       string
-		sched      Schedule
-		tmpl       *Template
-		defaults   ScheduleDefaults
-		wantRRule  string
-		wantTZ     string
-		wantMW     *MaintenanceWindow
+		name      string
+		sched     Schedule
+		tmpl      *Template
+		defaults  ScheduleDefaults
+		wantRRule string
+		wantTZ    string
+		wantMW    *MaintenanceWindow
 	}{
 		{
 			name:      "override wins: rrule",

--- a/internal/model/schedule.go
+++ b/internal/model/schedule.go
@@ -1,0 +1,174 @@
+package model
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Schedule is a per-target recurrence definition. A target may own zero
+// or more schedules, each with its own RRULE, tool config, and optional
+// maintenance window. Introduced by SPEC-SCHED1.
+type Schedule struct {
+	ID                string             `json:"id"`
+	TargetID          string             `json:"target_id"`
+	Name              string             `json:"name"`
+	RRule             string             `json:"rrule"`
+	DTStart           time.Time          `json:"dtstart"`
+	Timezone          string             `json:"timezone"`
+	TemplateID        *string            `json:"template_id,omitempty"`
+	ToolConfig        ToolConfig         `json:"tool_config"`
+	Overrides         []string           `json:"overrides"`
+	MaintenanceWindow *MaintenanceWindow `json:"maintenance_window,omitempty"`
+	Enabled           bool               `json:"enabled"`
+	NextRunAt         *time.Time         `json:"next_run_at,omitempty"`
+	LastRunAt         *time.Time         `json:"last_run_at,omitempty"`
+	LastRunStatus     *ScheduleRunStatus `json:"last_run_status,omitempty"`
+	LastScanID        *string            `json:"last_scan_id,omitempty"`
+	CreatedAt         time.Time          `json:"created_at"`
+	UpdatedAt         time.Time          `json:"updated_at"`
+}
+
+// ScheduleRunStatus is the outcome of the most recent attempt to fire a
+// schedule. The empty string is not a valid value — use nil on the
+// Schedule.LastRunStatus pointer when no run has happened yet.
+type ScheduleRunStatus string
+
+const (
+	ScheduleRunSuccess         ScheduleRunStatus = "success"
+	ScheduleRunFailed          ScheduleRunStatus = "failed"
+	ScheduleRunPausedBlackout  ScheduleRunStatus = "paused_blackout"
+	ScheduleRunSkippedOverlap  ScheduleRunStatus = "skipped_overlap"
+	ScheduleRunSkippedBlackout ScheduleRunStatus = "skipped_blackout"
+)
+
+// Template is a reusable, live-reference configuration that schedules may
+// point at. Editing a template cascades to every schedule referencing it,
+// except on fields listed in the schedule's `overrides`.
+type Template struct {
+	ID                string             `json:"id"`
+	Name              string             `json:"name"`
+	Description       string             `json:"description"`
+	RRule             string             `json:"rrule"`
+	Timezone          string             `json:"timezone"`
+	ToolConfig        ToolConfig         `json:"tool_config"`
+	MaintenanceWindow *MaintenanceWindow `json:"maintenance_window,omitempty"`
+	IsSystem          bool               `json:"is_system"`
+	CreatedAt         time.Time          `json:"created_at"`
+	UpdatedAt         time.Time          `json:"updated_at"`
+}
+
+// BlackoutScope distinguishes global vs. target-scoped blackout windows.
+type BlackoutScope string
+
+const (
+	BlackoutScopeGlobal BlackoutScope = "global"
+	BlackoutScopeTarget BlackoutScope = "target"
+)
+
+// BlackoutWindow defines when scans MUST NOT run. Active blackouts block
+// new dispatches and cooperatively cancel in-flight scans. Scope=global
+// affects every target; scope=target affects only the referenced target.
+type BlackoutWindow struct {
+	ID          string        `json:"id"`
+	Scope       BlackoutScope `json:"scope"`
+	TargetID    *string       `json:"target_id,omitempty"`
+	Name        string        `json:"name"`
+	RRule       string        `json:"rrule"`
+	DurationSec int           `json:"duration_seconds"`
+	Timezone    string        `json:"timezone"`
+	Enabled     bool          `json:"enabled"`
+	CreatedAt   time.Time     `json:"created_at"`
+	UpdatedAt   time.Time     `json:"updated_at"`
+}
+
+// MaintenanceWindow is a nested JSON value on Schedule, Template, and
+// ScheduleDefaults. It expresses recurring periods during which scans
+// should not be started. The shape matches SPEC-SCHED1 R1/R2/R4.
+//
+// This type is intentionally distinct from
+// internal/daemon/intervalsched.MaintenanceWindow, which is the legacy
+// HH:MM-based window of the singleton scheduler. The two will co-exist
+// until PR SCHED1.2 flips the runtime.
+type MaintenanceWindow struct {
+	RRule       string `json:"rrule"`
+	DurationSec int    `json:"duration_seconds"`
+	Timezone    string `json:"timezone"`
+}
+
+// ScheduleDefaults is the singleton row in schedule_defaults. It supplies
+// inherited values for schedules that don't override them at the template
+// or schedule layer.
+type ScheduleDefaults struct {
+	DefaultTemplateID        *string            `json:"default_template_id,omitempty"`
+	DefaultRRule             string             `json:"default_rrule"`
+	DefaultTimezone          string             `json:"default_timezone"`
+	DefaultToolConfig        ToolConfig         `json:"default_tool_config"`
+	DefaultMaintenanceWindow *MaintenanceWindow `json:"default_maintenance_window,omitempty"`
+	MaxConcurrentScans       int                `json:"max_concurrent_scans"`
+	RunOnStart               bool               `json:"run_on_start"`
+	JitterSeconds            int                `json:"jitter_seconds"`
+	UpdatedAt                time.Time          `json:"updated_at"`
+}
+
+// AdHocRunStatus is the lifecycle status of a single ad-hoc scan run.
+type AdHocRunStatus string
+
+const (
+	AdHocPending   AdHocRunStatus = "pending"
+	AdHocRunning   AdHocRunStatus = "running"
+	AdHocCompleted AdHocRunStatus = "completed"
+	AdHocFailed    AdHocRunStatus = "failed"
+	AdHocCancelled AdHocRunStatus = "cancelled"
+)
+
+// AdHocScanRun is a one-off scan invocation that is not tied to a
+// schedule's RRULE expansion. Sources include `cli`, `webui:<user>`,
+// `api:<token_id>`, and `schedule-runonce:<schedule_id>`.
+type AdHocScanRun struct {
+	ID          string         `json:"id"`
+	TargetID    string         `json:"target_id"`
+	TemplateID  *string        `json:"template_id,omitempty"`
+	ToolConfig  ToolConfig     `json:"tool_config"`
+	InitiatedBy string         `json:"initiated_by"`
+	Reason      string         `json:"reason"`
+	ScanID      *string        `json:"scan_id,omitempty"`
+	Status      AdHocRunStatus `json:"status"`
+	RequestedAt time.Time      `json:"requested_at"`
+	StartedAt   *time.Time     `json:"started_at,omitempty"`
+	CompletedAt *time.Time     `json:"completed_at,omitempty"`
+}
+
+// ToolConfig is the JSON-backed per-tool parameter map used by Schedule,
+// Template, ScheduleDefaults, and AdHocScanRun. Keys are tool names
+// (e.g. "nuclei", "naabu"); values are the serialized params struct for
+// that tool. Unknown tool names are rejected by ValidateToolConfig at
+// save time — see internal/model/tool_params.go.
+type ToolConfig map[string]json.RawMessage
+
+// GetTool decodes the params struct for a single tool out of a
+// ToolConfig. Returns false if the tool key is absent or the payload
+// does not decode into T. T is the tool's concrete *Params struct (e.g.
+// NucleiParams).
+func GetTool[T any](tc ToolConfig, toolName string) (T, bool) {
+	var zero T
+	raw, ok := tc[toolName]
+	if !ok {
+		return zero, false
+	}
+	var v T
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return zero, false
+	}
+	return v, true
+}
+
+// SetTool encodes and stores a tool's params struct into a ToolConfig.
+// Returns an error if params cannot be JSON-encoded.
+func SetTool[T any](tc ToolConfig, toolName string, params T) error {
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+	tc[toolName] = raw
+	return nil
+}

--- a/internal/model/schedule.go
+++ b/internal/model/schedule.go
@@ -118,7 +118,7 @@ const (
 	AdHocRunning   AdHocRunStatus = "running"
 	AdHocCompleted AdHocRunStatus = "completed"
 	AdHocFailed    AdHocRunStatus = "failed"
-	AdHocCancelled AdHocRunStatus = "cancelled"
+	AdHocCanceled  AdHocRunStatus = "canceled"
 )
 
 // AdHocScanRun is a one-off scan invocation that is not tied to a

--- a/internal/model/schedule_test.go
+++ b/internal/model/schedule_test.go
@@ -1,0 +1,182 @@
+package model
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func tsUTC(t *testing.T, s string) time.Time {
+	t.Helper()
+	tm, err := time.Parse(time.RFC3339, s)
+	require.NoError(t, err)
+	return tm.UTC()
+}
+
+func TestSchedule_JSONRoundTrip(t *testing.T) {
+	tmplID := "tmpl-01"
+	lastScanID := "scan-01"
+	status := ScheduleRunSuccess
+	nextRun := tsUTC(t, "2026-04-20T02:00:00Z")
+	lastRun := tsUTC(t, "2026-04-19T02:00:00Z")
+
+	orig := Schedule{
+		ID:       "sched-01",
+		TargetID: "tgt-01",
+		Name:     "weekly-full",
+		RRule:    "FREQ=WEEKLY;BYDAY=MO;BYHOUR=2",
+		DTStart:  tsUTC(t, "2026-04-01T02:00:00Z"),
+		Timezone: "UTC",
+		TemplateID: &tmplID,
+		ToolConfig: ToolConfig{
+			"nuclei": json.RawMessage(`{"severity":["critical","high"]}`),
+		},
+		Overrides: []string{"rrule"},
+		MaintenanceWindow: &MaintenanceWindow{
+			RRule:       "FREQ=DAILY;BYHOUR=2",
+			DurationSec: 7200,
+			Timezone:    "UTC",
+		},
+		Enabled:       true,
+		NextRunAt:     &nextRun,
+		LastRunAt:     &lastRun,
+		LastRunStatus: &status,
+		LastScanID:    &lastScanID,
+		CreatedAt:     tsUTC(t, "2026-04-01T00:00:00Z"),
+		UpdatedAt:     tsUTC(t, "2026-04-19T02:03:00Z"),
+	}
+
+	raw, err := json.Marshal(orig)
+	require.NoError(t, err)
+
+	var got Schedule
+	require.NoError(t, json.Unmarshal(raw, &got))
+
+	if !reflect.DeepEqual(orig, got) {
+		t.Fatalf("round-trip mismatch\norig: %#v\ngot:  %#v", orig, got)
+	}
+}
+
+func TestTemplate_JSONRoundTrip(t *testing.T) {
+	orig := Template{
+		ID:          "tmpl-01",
+		Name:        "prod-critical",
+		Description: "critical-severity probe, every 6h",
+		RRule:       "FREQ=HOURLY;INTERVAL=6",
+		Timezone:    "UTC",
+		ToolConfig: ToolConfig{
+			"nuclei": json.RawMessage(`{"severity":["critical"]}`),
+		},
+		IsSystem:  true,
+		CreatedAt: tsUTC(t, "2026-04-01T00:00:00Z"),
+		UpdatedAt: tsUTC(t, "2026-04-19T02:03:00Z"),
+	}
+
+	raw, err := json.Marshal(orig)
+	require.NoError(t, err)
+	var got Template
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, orig, got)
+}
+
+func TestBlackoutWindow_JSONRoundTrip(t *testing.T) {
+	targetID := "tgt-01"
+	orig := BlackoutWindow{
+		ID:          "bl-01",
+		Scope:       BlackoutScopeTarget,
+		TargetID:    &targetID,
+		Name:        "nightly-maintenance",
+		RRule:       "FREQ=DAILY;BYHOUR=2",
+		DurationSec: 7200,
+		Timezone:    "UTC",
+		Enabled:     true,
+		CreatedAt:   tsUTC(t, "2026-04-01T00:00:00Z"),
+		UpdatedAt:   tsUTC(t, "2026-04-19T00:00:00Z"),
+	}
+
+	raw, err := json.Marshal(orig)
+	require.NoError(t, err)
+	var got BlackoutWindow
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, orig, got)
+}
+
+func TestScheduleDefaults_JSONRoundTrip(t *testing.T) {
+	tmplID := "tmpl-default"
+	orig := ScheduleDefaults{
+		DefaultTemplateID: &tmplID,
+		DefaultRRule:      "FREQ=DAILY;BYHOUR=2",
+		DefaultTimezone:   "UTC",
+		DefaultToolConfig: ToolConfig{
+			"naabu": json.RawMessage(`{"ports":"top-1000"}`),
+		},
+		DefaultMaintenanceWindow: &MaintenanceWindow{
+			RRule:       "FREQ=DAILY;BYHOUR=2",
+			DurationSec: 3600,
+			Timezone:    "UTC",
+		},
+		MaxConcurrentScans: 4,
+		RunOnStart:         false,
+		JitterSeconds:      60,
+		UpdatedAt:          tsUTC(t, "2026-04-19T00:00:00Z"),
+	}
+	raw, err := json.Marshal(orig)
+	require.NoError(t, err)
+	var got ScheduleDefaults
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, orig, got)
+}
+
+func TestAdHocScanRun_JSONRoundTrip(t *testing.T) {
+	tmplID := "tmpl-01"
+	scanID := "scan-01"
+	started := tsUTC(t, "2026-04-19T02:00:00Z")
+	completed := tsUTC(t, "2026-04-19T02:03:00Z")
+	orig := AdHocScanRun{
+		ID:       "ah-01",
+		TargetID: "tgt-01",
+		TemplateID: &tmplID,
+		ToolConfig: ToolConfig{
+			"nuclei": json.RawMessage(`{"tags":["cve-2025"]}`),
+		},
+		InitiatedBy: "cli",
+		Reason:      "zero-day verification",
+		ScanID:      &scanID,
+		Status:      AdHocCompleted,
+		RequestedAt: tsUTC(t, "2026-04-19T01:59:00Z"),
+		StartedAt:   &started,
+		CompletedAt: &completed,
+	}
+	raw, err := json.Marshal(orig)
+	require.NoError(t, err)
+	var got AdHocScanRun
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, orig, got)
+}
+
+func TestToolConfig_GetSetTool(t *testing.T) {
+	type dummyParams struct {
+		Threads int      `json:"threads,omitempty"`
+		Tags    []string `json:"tags,omitempty"`
+	}
+
+	tc := ToolConfig{}
+	require.NoError(t, SetTool(tc, "nuclei", dummyParams{Threads: 10, Tags: []string{"cve"}}))
+
+	got, ok := GetTool[dummyParams](tc, "nuclei")
+	require.True(t, ok)
+	assert.Equal(t, 10, got.Threads)
+	assert.Equal(t, []string{"cve"}, got.Tags)
+
+	_, ok = GetTool[dummyParams](tc, "unknown")
+	assert.False(t, ok)
+
+	// Malformed payload: GetTool returns false without panicking.
+	tc["broken"] = json.RawMessage(`"not an object"`)
+	_, ok = GetTool[dummyParams](tc, "broken")
+	assert.False(t, ok)
+}

--- a/internal/model/schedule_test.go
+++ b/internal/model/schedule_test.go
@@ -25,12 +25,12 @@ func TestSchedule_JSONRoundTrip(t *testing.T) {
 	lastRun := tsUTC(t, "2026-04-19T02:00:00Z")
 
 	orig := Schedule{
-		ID:       "sched-01",
-		TargetID: "tgt-01",
-		Name:     "weekly-full",
-		RRule:    "FREQ=WEEKLY;BYDAY=MO;BYHOUR=2",
-		DTStart:  tsUTC(t, "2026-04-01T02:00:00Z"),
-		Timezone: "UTC",
+		ID:         "sched-01",
+		TargetID:   "tgt-01",
+		Name:       "weekly-full",
+		RRule:      "FREQ=WEEKLY;BYDAY=MO;BYHOUR=2",
+		DTStart:    tsUTC(t, "2026-04-01T02:00:00Z"),
+		Timezone:   "UTC",
 		TemplateID: &tmplID,
 		ToolConfig: ToolConfig{
 			"nuclei": json.RawMessage(`{"severity":["critical","high"]}`),
@@ -137,8 +137,8 @@ func TestAdHocScanRun_JSONRoundTrip(t *testing.T) {
 	started := tsUTC(t, "2026-04-19T02:00:00Z")
 	completed := tsUTC(t, "2026-04-19T02:03:00Z")
 	orig := AdHocScanRun{
-		ID:       "ah-01",
-		TargetID: "tgt-01",
+		ID:         "ah-01",
+		TargetID:   "tgt-01",
 		TemplateID: &tmplID,
 		ToolConfig: ToolConfig{
 			"nuclei": json.RawMessage(`{"tags":["cve-2025"]}`),

--- a/internal/model/tool_params.go
+++ b/internal/model/tool_params.go
@@ -1,0 +1,90 @@
+package model
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+)
+
+// ErrUnknownTool is returned by ValidateToolConfig when the ToolConfig
+// contains a tool key that is not registered in RegisteredToolParams.
+var ErrUnknownTool = errors.New("unknown tool")
+
+// ErrInvalidToolParams is returned when a tool key's payload does not
+// decode into its registered params struct.
+var ErrInvalidToolParams = errors.New("invalid tool params")
+
+// NucleiParams mirrors the subset of nuclei CLI knobs the scheduler
+// exposes via tool_config. Field names match SPEC-SCHED1 R20.
+type NucleiParams struct {
+	Templates   []string      `json:"templates,omitempty"`
+	Severity    []string      `json:"severity,omitempty"`
+	Tags        []string      `json:"tags,omitempty"`
+	ExcludeTags []string      `json:"exclude_tags,omitempty"`
+	RateLimit   int           `json:"rate_limit,omitempty"`
+	Timeout     time.Duration `json:"timeout,omitempty"`
+}
+
+// NaabuParams mirrors naabu CLI knobs.
+type NaabuParams struct {
+	Ports      string `json:"ports,omitempty"`
+	Rate       int    `json:"rate,omitempty"`
+	Retries    int    `json:"retries,omitempty"`
+	ScanType   string `json:"scan_type,omitempty"`
+	BannerGrab bool   `json:"banner_grab,omitempty"`
+}
+
+// HttpxParams mirrors httpx CLI knobs.
+type HttpxParams struct {
+	Threads         int           `json:"threads,omitempty"`
+	Probes          []string      `json:"probes,omitempty"`
+	FollowRedirects bool          `json:"follow_redirects,omitempty"`
+	Timeout         time.Duration `json:"timeout,omitempty"`
+}
+
+// SubfinderParams mirrors subfinder knobs.
+type SubfinderParams struct {
+	Sources    []string `json:"sources,omitempty"`
+	AllSources bool     `json:"all_sources,omitempty"`
+	Recursive  bool     `json:"recursive,omitempty"`
+	Resolvers  []string `json:"resolvers,omitempty"`
+}
+
+// DnsxParams mirrors dnsx knobs.
+type DnsxParams struct {
+	RecordTypes []string `json:"record_types,omitempty"`
+	Resolvers   []string `json:"resolvers,omitempty"`
+	Retries     int      `json:"retries,omitempty"`
+}
+
+// RegisteredToolParams is the authoritative set of tool names whose
+// params structs are recognized by ValidateToolConfig. Adding a new
+// detection tool to the scheduler means adding a *Params struct and
+// registering it here.
+var RegisteredToolParams = map[string]reflect.Type{
+	"nuclei":    reflect.TypeOf(NucleiParams{}),
+	"naabu":     reflect.TypeOf(NaabuParams{}),
+	"httpx":     reflect.TypeOf(HttpxParams{}),
+	"subfinder": reflect.TypeOf(SubfinderParams{}),
+	"dnsx":      reflect.TypeOf(DnsxParams{}),
+}
+
+// ValidateToolConfig returns ErrUnknownTool (wrapped with the offending
+// tool name) when the ToolConfig contains a key that is not in
+// RegisteredToolParams, and ErrInvalidToolParams when a payload fails to
+// decode into its registered struct. A nil or empty ToolConfig is valid.
+func ValidateToolConfig(tc ToolConfig) error {
+	for name, raw := range tc {
+		typ, ok := RegisteredToolParams[name]
+		if !ok {
+			return fmt.Errorf("%w: %q", ErrUnknownTool, name)
+		}
+		instance := reflect.New(typ).Interface()
+		if err := json.Unmarshal(raw, instance); err != nil {
+			return fmt.Errorf("%w: %q: %v", ErrInvalidToolParams, name, err)
+		}
+	}
+	return nil
+}

--- a/internal/model/tool_params_test.go
+++ b/internal/model/tool_params_test.go
@@ -1,0 +1,134 @@
+package model
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateToolConfig_UnknownTool(t *testing.T) {
+	tc := ToolConfig{
+		"amass": json.RawMessage(`{"brute": true}`),
+	}
+	err := ValidateToolConfig(tc)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnknownTool), "expected ErrUnknownTool, got %v", err)
+	assert.Contains(t, err.Error(), "amass")
+}
+
+func TestValidateToolConfig_InvalidPayload(t *testing.T) {
+	tc := ToolConfig{
+		"nuclei": json.RawMessage(`"not an object"`),
+	}
+	err := ValidateToolConfig(tc)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidToolParams), "expected ErrInvalidToolParams, got %v", err)
+}
+
+func TestValidateToolConfig_AllKnownTools(t *testing.T) {
+	tc := ToolConfig{}
+	require.NoError(t, SetTool(tc, "nuclei", NucleiParams{Severity: []string{"critical"}}))
+	require.NoError(t, SetTool(tc, "naabu", NaabuParams{Ports: "top-1000"}))
+	require.NoError(t, SetTool(tc, "httpx", HttpxParams{Threads: 50}))
+	require.NoError(t, SetTool(tc, "subfinder", SubfinderParams{AllSources: true}))
+	require.NoError(t, SetTool(tc, "dnsx", DnsxParams{RecordTypes: []string{"A", "AAAA"}}))
+	assert.NoError(t, ValidateToolConfig(tc))
+}
+
+func TestValidateToolConfig_Empty(t *testing.T) {
+	assert.NoError(t, ValidateToolConfig(nil))
+	assert.NoError(t, ValidateToolConfig(ToolConfig{}))
+}
+
+func TestNucleiParams_JSONRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		v    NucleiParams
+	}{
+		{"zero", NucleiParams{}},
+		{"populated", NucleiParams{
+			Templates:   []string{"cves/", "exposed-panels/"},
+			Severity:    []string{"critical", "high"},
+			Tags:        []string{"cve"},
+			ExcludeTags: []string{"intrusive"},
+			RateLimit:   150,
+			Timeout:     30 * time.Second,
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			raw, err := json.Marshal(c.v)
+			require.NoError(t, err)
+			var got NucleiParams
+			require.NoError(t, json.Unmarshal(raw, &got))
+			assert.Equal(t, c.v, got)
+		})
+	}
+}
+
+func TestNucleiParams_OmitEmpty(t *testing.T) {
+	raw, err := json.Marshal(NucleiParams{})
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(raw), "zero-valued params must marshal to {} with omitempty tags")
+}
+
+func TestNaabuParams_JSONRoundTrip(t *testing.T) {
+	orig := NaabuParams{Ports: "top-1000", Rate: 1000, Retries: 3, ScanType: "syn", BannerGrab: true}
+	raw, err := json.Marshal(orig)
+	require.NoError(t, err)
+	var got NaabuParams
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, orig, got)
+}
+
+func TestHttpxParams_JSONRoundTrip(t *testing.T) {
+	orig := HttpxParams{
+		Threads:         25,
+		Probes:          []string{"status", "title", "tech"},
+		FollowRedirects: true,
+		Timeout:         5 * time.Second,
+	}
+	raw, err := json.Marshal(orig)
+	require.NoError(t, err)
+	var got HttpxParams
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, orig, got)
+}
+
+func TestSubfinderParams_JSONRoundTrip(t *testing.T) {
+	orig := SubfinderParams{
+		Sources:    []string{"crtsh", "virustotal"},
+		AllSources: false,
+		Recursive:  true,
+		Resolvers:  []string{"1.1.1.1"},
+	}
+	raw, err := json.Marshal(orig)
+	require.NoError(t, err)
+	var got SubfinderParams
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, orig, got)
+}
+
+func TestDnsxParams_JSONRoundTrip(t *testing.T) {
+	orig := DnsxParams{RecordTypes: []string{"A", "AAAA", "CNAME"}, Resolvers: []string{"1.1.1.1"}, Retries: 2}
+	raw, err := json.Marshal(orig)
+	require.NoError(t, err)
+	var got DnsxParams
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, orig, got)
+}
+
+func TestRegisteredToolParams_Covers5Tools(t *testing.T) {
+	want := []string{"nuclei", "naabu", "httpx", "subfinder", "dnsx"}
+	for _, name := range want {
+		typ, ok := RegisteredToolParams[name]
+		require.True(t, ok, "missing registration for %q", name)
+		// Confirm the type is a struct (reflect.Type of the Params value).
+		assert.Equal(t, reflect.Struct, typ.Kind())
+	}
+}

--- a/internal/rrule/validator.go
+++ b/internal/rrule/validator.go
@@ -1,0 +1,121 @@
+// Package rrule validates RFC-5545 RRULE strings for use by the schedule
+// storage layer and the CLI. It is its own package so internal/storage
+// can call the validator without creating an import cycle with
+// internal/cli.
+package rrule
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	extrrule "github.com/teambition/rrule-go"
+)
+
+// ErrInvalidRRule wraps every failure returned by ValidateRRule. Callers
+// that want to distinguish semantic causes should errors.Is against the
+// sentinels below.
+var (
+	ErrInvalidRRule        = errors.New("invalid rrule")
+	ErrRRuleUnsupportedFreq = errors.New("unsupported FREQ")
+	ErrRRuleCountZero       = errors.New("COUNT=0")
+	ErrRRuleMissingFreq     = errors.New("missing FREQ")
+)
+
+// Warnings is a non-blocking result returned alongside a valid RRULE.
+// Callers persist the raw rrule string regardless of warnings; the
+// warnings are surfaced in the UI / CLI for operator awareness.
+type Warnings struct {
+	Messages []string
+}
+
+// Empty reports whether the warning set is empty.
+func (w *Warnings) Empty() bool {
+	return w == nil || len(w.Messages) == 0
+}
+
+// ValidateRRule parses an RFC-5545 RRULE string and enforces
+// SPEC-SCHED1 R13 acceptance rules:
+//
+//   - Reject: SECONDLY, COUNT=0, missing FREQ, syntactically invalid.
+//   - Warn:   MINUTELY with INTERVAL<5; UNTIL in the past.
+//
+// On success the returned Warnings value may be nil (no warnings) or
+// non-nil with one or more messages. The caller persists the raw
+// rfcString unchanged — we never rewrite it.
+func ValidateRRule(rfcString string) (*Warnings, error) {
+	if strings.TrimSpace(rfcString) == "" {
+		return nil, fmt.Errorf("%w: empty string", ErrInvalidRRule)
+	}
+
+	// Check FREQ presence before parsing so we can surface the precise
+	// ErrRRuleMissingFreq sentinel rather than wrapping the library's
+	// generic "RRULE property FREQ is required" inside ErrInvalidRRule.
+	if !strings.Contains(strings.ToUpper(rfcString), "FREQ=") {
+		return nil, fmt.Errorf("%w", ErrRRuleMissingFreq)
+	}
+
+	opt, err := extrrule.StrToROption(rfcString)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidRRule, err)
+	}
+
+	if opt.Freq == extrrule.SECONDLY {
+		return nil, fmt.Errorf("%w: SECONDLY is not supported (security noise)", ErrRRuleUnsupportedFreq)
+	}
+
+	// extrrule.StrToROption parses COUNT as int; COUNT=0 is meaningless
+	// (schedule can never fire) and the library does not reject it.
+	// We also reject a literal "COUNT=0" token to be explicit for
+	// operators — opt.Count can be 0 when the token is absent, so we
+	// check the string.
+	if containsToken(rfcString, "COUNT=0") {
+		return nil, fmt.Errorf("%w", ErrRRuleCountZero)
+	}
+
+	// Confirm the rule is constructible — this surfaces invalid BYDAY
+	// tokens like "XX" that StrToROption may accept but NewRRule
+	// rejects.
+	if _, err := extrrule.NewRRule(*opt); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidRRule, err)
+	}
+
+	var w *Warnings
+	addWarning := func(msg string) {
+		if w == nil {
+			w = &Warnings{}
+		}
+		w.Messages = append(w.Messages, msg)
+	}
+
+	if opt.Freq == extrrule.MINUTELY {
+		interval := opt.Interval
+		if interval == 0 {
+			interval = 1
+		}
+		if interval < 5 {
+			addWarning("sub-5-minute cadence will likely trigger WAFs")
+		}
+	}
+
+	if !opt.Until.IsZero() && opt.Until.Before(time.Now()) {
+		addWarning("UNTIL is in the past; schedule will never fire")
+	}
+
+	return w, nil
+}
+
+// containsToken does a case-insensitive scan for `token` as a ;-delimited
+// element of the RRULE body. It avoids matching substrings inside, e.g.,
+// "COUNT=0" appearing as a value in a later key/value pair.
+func containsToken(rfc, token string) bool {
+	upper := strings.ToUpper(rfc)
+	token = strings.ToUpper(token)
+	for _, part := range strings.Split(upper, ";") {
+		if strings.TrimSpace(part) == token {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rrule/validator.go
+++ b/internal/rrule/validator.go
@@ -17,7 +17,7 @@ import (
 // that want to distinguish semantic causes should errors.Is against the
 // sentinels below.
 var (
-	ErrInvalidRRule        = errors.New("invalid rrule")
+	ErrInvalidRRule         = errors.New("invalid rrule")
 	ErrRRuleUnsupportedFreq = errors.New("unsupported FREQ")
 	ErrRRuleCountZero       = errors.New("COUNT=0")
 	ErrRRuleMissingFreq     = errors.New("missing FREQ")

--- a/internal/rrule/validator_test.go
+++ b/internal/rrule/validator_test.go
@@ -1,0 +1,105 @@
+package rrule
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateRRule_TableDriven covers ≥30 RRULE strings drawn from:
+//   - Tenable's public API/docs examples (daily, weekly, monthly, yearly).
+//   - Acunetix's scheduler docs (weekday/weekend, specific day, BYSETPOS).
+//   - Edge cases: leap year, DST boundaries, BYSETPOS=-1, unsupported FREQ.
+//
+// Citations live inline on each case. SPEC-SCHED1 R13 acceptance.
+func TestValidateRRule_TableDriven(t *testing.T) {
+	cases := []struct {
+		name       string
+		rrule      string
+		wantErr    error
+		wantWarn   bool
+		warnMatch  string
+	}{
+		// --- Tenable-style RRULEs ---------------------------------------
+		{name: "tenable/daily-at-2am", rrule: "FREQ=DAILY;BYHOUR=2"},
+		{name: "tenable/weekly-monday", rrule: "FREQ=WEEKLY;BYDAY=MO"},
+		{name: "tenable/weekly-mon-fri", rrule: "FREQ=WEEKLY;BYDAY=MO,FR;BYHOUR=2"},
+		{name: "tenable/monthly-first", rrule: "FREQ=MONTHLY;BYMONTHDAY=1"},
+		{name: "tenable/monthly-15th-9am", rrule: "FREQ=MONTHLY;BYMONTHDAY=15;BYHOUR=9"},
+		{name: "tenable/yearly-jan-1", rrule: "FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1"},
+		{name: "tenable/every-3-hours", rrule: "FREQ=HOURLY;INTERVAL=3"},
+		{name: "tenable/every-6-hours", rrule: "FREQ=HOURLY;INTERVAL=6"},
+		{name: "tenable/every-other-day", rrule: "FREQ=DAILY;INTERVAL=2"},
+		{name: "tenable/count-limited", rrule: "FREQ=DAILY;COUNT=10"},
+		{name: "tenable/until-future", rrule: "FREQ=DAILY;UNTIL=20991231T000000Z"},
+		{name: "tenable/bysetpos-last-friday", rrule: "FREQ=MONTHLY;BYDAY=FR;BYSETPOS=-1"},
+		{name: "tenable/weekend-scan", rrule: "FREQ=WEEKLY;BYDAY=SA,SU;BYHOUR=3"},
+
+		// --- Acunetix-style RRULEs --------------------------------------
+		{name: "acunetix/daily-midnight", rrule: "FREQ=DAILY;BYHOUR=0"},
+		{name: "acunetix/weekly-weekdays", rrule: "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"},
+		{name: "acunetix/weekly-single-day", rrule: "FREQ=WEEKLY;BYDAY=WE;BYHOUR=1;BYMINUTE=30"},
+		{name: "acunetix/monthly-day-of-month", rrule: "FREQ=MONTHLY;BYMONTHDAY=5;BYHOUR=0"},
+		{name: "acunetix/monthly-first-weekday", rrule: "FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=1"},
+		{name: "acunetix/yearly-quarter", rrule: "FREQ=YEARLY;BYMONTH=1,4,7,10;BYMONTHDAY=1"},
+		{name: "acunetix/weekly-interval-2", rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO"},
+		{name: "acunetix/monthly-last-day", rrule: "FREQ=MONTHLY;BYMONTHDAY=-1"},
+
+		// --- Calendar edge cases ----------------------------------------
+		{name: "leap-year-feb-29", rrule: "FREQ=YEARLY;BYMONTH=2;BYMONTHDAY=29"},
+		{name: "dst-forward-new-york", rrule: "FREQ=DAILY;BYHOUR=2;BYMINUTE=30"},
+		{name: "bysetpos-first-mon", rrule: "FREQ=MONTHLY;BYDAY=MO;BYSETPOS=1"},
+		{name: "bysetpos-second-to-last", rrule: "FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-2"},
+
+		// --- Rejections -------------------------------------------------
+		{name: "reject/secondly", rrule: "FREQ=SECONDLY", wantErr: ErrRRuleUnsupportedFreq},
+		{name: "reject/count-zero", rrule: "FREQ=DAILY;COUNT=0", wantErr: ErrRRuleCountZero},
+		{name: "reject/byday-invalid", rrule: "FREQ=WEEKLY;BYDAY=XX", wantErr: ErrInvalidRRule},
+		{name: "reject/missing-freq", rrule: "INTERVAL=1;BYDAY=MO", wantErr: ErrRRuleMissingFreq},
+		{name: "reject/empty", rrule: "", wantErr: ErrInvalidRRule},
+		{name: "reject/bad-freq-token", rrule: "FREQ=NONSENSE;BYHOUR=9", wantErr: ErrInvalidRRule},
+		{name: "reject/malformed-pair", rrule: "FREQ=DAILY;NOEQUALS", wantErr: ErrInvalidRRule},
+
+		// --- Warnings (non-blocking) ------------------------------------
+		{name: "warn/minutely-interval-2", rrule: "FREQ=MINUTELY;INTERVAL=2", wantWarn: true, warnMatch: "WAF"},
+		{name: "warn/minutely-default-interval", rrule: "FREQ=MINUTELY", wantWarn: true, warnMatch: "WAF"},
+		{name: "warn/until-past", rrule: "FREQ=DAILY;UNTIL=20200101T000000Z", wantWarn: true, warnMatch: "past"},
+
+		// --- No warning at interval=5 (just above threshold) ------------
+		{name: "minutely-interval-5-ok", rrule: "FREQ=MINUTELY;INTERVAL=5"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w, err := ValidateRRule(c.rrule)
+			if c.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, c.wantErr),
+					"expected error to wrap %v, got %v", c.wantErr, err)
+				return
+			}
+			require.NoError(t, err)
+			if c.wantWarn {
+				require.NotNil(t, w)
+				assert.False(t, w.Empty())
+				joined := strings.Join(w.Messages, " | ")
+				assert.Contains(t, joined, c.warnMatch,
+					"expected warning to mention %q, got %q", c.warnMatch, joined)
+			} else {
+				assert.True(t, w.Empty(), "expected no warnings, got %+v", w)
+			}
+		})
+	}
+}
+
+func TestValidateRRule_PreservesInput(t *testing.T) {
+	// Spec: the validator returns the original rrule string unchanged on
+	// success — the caller persists the raw RFC-5545 form. This is
+	// implicit (we don't return a mutated string) but pin it: the call
+	// does not error on a well-formed rule regardless of whitespace.
+	_, err := ValidateRRule("FREQ=DAILY;BYHOUR=2")
+	require.NoError(t, err)
+}

--- a/internal/rrule/validator_test.go
+++ b/internal/rrule/validator_test.go
@@ -17,11 +17,11 @@ import (
 // Citations live inline on each case. SPEC-SCHED1 R13 acceptance.
 func TestValidateRRule_TableDriven(t *testing.T) {
 	cases := []struct {
-		name       string
-		rrule      string
-		wantErr    error
-		wantWarn   bool
-		warnMatch  string
+		name      string
+		rrule     string
+		wantErr   error
+		wantWarn  bool
+		warnMatch string
 	}{
 		// --- Tenable-style RRULEs ---------------------------------------
 		{name: "tenable/daily-at-2am", rrule: "FREQ=DAILY;BYHOUR=2"},

--- a/internal/storage/adhoc_scan_runs.go
+++ b/internal/storage/adhoc_scan_runs.go
@@ -99,13 +99,13 @@ func (st *sqliteAdHocScanRunStore) ListByStatus(ctx context.Context, status mode
 func (st *sqliteAdHocScanRunStore) UpdateStatus(ctx context.Context, id string, status model.AdHocRunStatus, at time.Time) error {
 	// Mirror the status onto started_at / completed_at where the
 	// transition warrants it. A `running` transition pins started_at;
-	// `completed`, `failed`, `cancelled` pin completed_at.
+	// `completed`, `failed`, `canceled` pin completed_at.
 	var startedCol, completedCol any
 	stamp := at.UTC().Format(timeFormat)
 	switch status {
 	case model.AdHocRunning:
 		startedCol = stamp
-	case model.AdHocCompleted, model.AdHocFailed, model.AdHocCancelled:
+	case model.AdHocCompleted, model.AdHocFailed, model.AdHocCanceled:
 		completedCol = stamp
 	}
 
@@ -171,7 +171,7 @@ func validateAdHocInput(r *model.AdHocScanRun) error {
 	switch r.Status {
 	case "":
 		r.Status = model.AdHocPending
-	case model.AdHocPending, model.AdHocRunning, model.AdHocCompleted, model.AdHocFailed, model.AdHocCancelled:
+	case model.AdHocPending, model.AdHocRunning, model.AdHocCompleted, model.AdHocFailed, model.AdHocCanceled:
 	default:
 		return fmt.Errorf("invalid ad_hoc.status %q", r.Status)
 	}
@@ -183,14 +183,14 @@ func validateAdHocInput(r *model.AdHocScanRun) error {
 
 func scanAdHoc(r rowScanner) (*model.AdHocScanRun, error) {
 	var (
-		ah           model.AdHocScanRun
-		templateID   sql.NullString
-		toolJSON     string
-		scanID       sql.NullString
-		status       string
-		requestedAt  sql.NullString
-		startedAt    sql.NullString
-		completedAt  sql.NullString
+		ah          model.AdHocScanRun
+		templateID  sql.NullString
+		toolJSON    string
+		scanID      sql.NullString
+		status      string
+		requestedAt sql.NullString
+		startedAt   sql.NullString
+		completedAt sql.NullString
 	)
 	if err := r.Scan(
 		&ah.ID, &ah.TargetID, &templateID, &toolJSON, &ah.InitiatedBy, &ah.Reason,
@@ -228,7 +228,7 @@ func queryManyAdHoc(ctx context.Context, db dbtx, query string, args ...any) ([]
 	if err != nil {
 		return nil, fmt.Errorf("querying ad_hoc_scan_runs: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	out := make([]model.AdHocScanRun, 0)
 	for rows.Next() {
 		r, err := scanAdHoc(rows)

--- a/internal/storage/adhoc_scan_runs.go
+++ b/internal/storage/adhoc_scan_runs.go
@@ -34,7 +34,7 @@ func (s *SQLiteStore) AdHocScanRuns() AdHocScanRunStore {
 }
 
 type sqliteAdHocScanRunStore struct {
-	db *sql.DB
+	db dbtx
 }
 
 const adhocColumns = `id, target_id, template_id, tool_config, initiated_by, reason,
@@ -223,7 +223,7 @@ func scanAdHoc(r rowScanner) (*model.AdHocScanRun, error) {
 	return &ah, nil
 }
 
-func queryManyAdHoc(ctx context.Context, db *sql.DB, query string, args ...any) ([]model.AdHocScanRun, error) {
+func queryManyAdHoc(ctx context.Context, db dbtx, query string, args ...any) ([]model.AdHocScanRun, error) {
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying ad_hoc_scan_runs: %w", err)

--- a/internal/storage/adhoc_scan_runs.go
+++ b/internal/storage/adhoc_scan_runs.go
@@ -1,0 +1,241 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// AdHocScanRunStore persists one-off scan invocations (CLI, web UI, API,
+// run-once). Distinct from schedule dispatches — ad-hoc runs have no
+// RRULE, a required `initiated_by` attribution, and flow through
+// independently of the ticker.
+type AdHocScanRunStore interface {
+	Create(ctx context.Context, r *model.AdHocScanRun) error
+	Get(ctx context.Context, id string) (*model.AdHocScanRun, error)
+	ListByTarget(ctx context.Context, targetID string, limit int) ([]model.AdHocScanRun, error)
+	ListByStatus(ctx context.Context, status model.AdHocRunStatus) ([]model.AdHocScanRun, error)
+	UpdateStatus(ctx context.Context, id string, status model.AdHocRunStatus, at time.Time) error
+	AttachScan(ctx context.Context, id, scanID string) error
+	Delete(ctx context.Context, id string) error
+}
+
+// AdHocScanRuns returns an AdHocScanRunStore backed by this SQLiteStore.
+func (s *SQLiteStore) AdHocScanRuns() AdHocScanRunStore {
+	return &sqliteAdHocScanRunStore{db: s.db}
+}
+
+type sqliteAdHocScanRunStore struct {
+	db *sql.DB
+}
+
+const adhocColumns = `id, target_id, template_id, tool_config, initiated_by, reason,
+  scan_id, status, requested_at, started_at, completed_at`
+
+func (st *sqliteAdHocScanRunStore) Create(ctx context.Context, r *model.AdHocScanRun) error {
+	if err := validateAdHocInput(r); err != nil {
+		return err
+	}
+	if r.ID == "" {
+		r.ID = uuid.New().String()
+	}
+	if r.RequestedAt.IsZero() {
+		r.RequestedAt = time.Now().UTC()
+	}
+	if r.ToolConfig == nil {
+		r.ToolConfig = model.ToolConfig{}
+	}
+
+	toolJSON, err := json.Marshal(r.ToolConfig)
+	if err != nil {
+		return fmt.Errorf("marshaling tool_config: %w", err)
+	}
+
+	_, err = st.db.ExecContext(ctx,
+		`INSERT INTO ad_hoc_scan_runs (`+adhocColumns+`)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.ID, r.TargetID, nullableString(r.TemplateID), string(toolJSON),
+		r.InitiatedBy, r.Reason, nullableString(r.ScanID), string(r.Status),
+		r.RequestedAt.UTC().Format(timeFormat),
+		timePtrUTC(r.StartedAt), timePtrUTC(r.CompletedAt),
+	)
+	if err != nil {
+		return fmt.Errorf("store.adhoc.Create: %w", err)
+	}
+	return nil
+}
+
+func (st *sqliteAdHocScanRunStore) Get(ctx context.Context, id string) (*model.AdHocScanRun, error) {
+	row := st.db.QueryRowContext(ctx,
+		`SELECT `+adhocColumns+` FROM ad_hoc_scan_runs WHERE id = ?`, id)
+	return scanAdHoc(row)
+}
+
+func (st *sqliteAdHocScanRunStore) ListByTarget(ctx context.Context, targetID string, limit int) ([]model.AdHocScanRun, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	return queryManyAdHoc(ctx, st.db,
+		`SELECT `+adhocColumns+` FROM ad_hoc_scan_runs
+		 WHERE target_id = ? ORDER BY requested_at DESC LIMIT ?`,
+		targetID, limit)
+}
+
+func (st *sqliteAdHocScanRunStore) ListByStatus(ctx context.Context, status model.AdHocRunStatus) ([]model.AdHocScanRun, error) {
+	return queryManyAdHoc(ctx, st.db,
+		`SELECT `+adhocColumns+` FROM ad_hoc_scan_runs
+		 WHERE status = ? ORDER BY requested_at ASC`,
+		string(status))
+}
+
+func (st *sqliteAdHocScanRunStore) UpdateStatus(ctx context.Context, id string, status model.AdHocRunStatus, at time.Time) error {
+	// Mirror the status onto started_at / completed_at where the
+	// transition warrants it. A `running` transition pins started_at;
+	// `completed`, `failed`, `cancelled` pin completed_at.
+	var startedCol, completedCol any
+	stamp := at.UTC().Format(timeFormat)
+	switch status {
+	case model.AdHocRunning:
+		startedCol = stamp
+	case model.AdHocCompleted, model.AdHocFailed, model.AdHocCancelled:
+		completedCol = stamp
+	}
+
+	query := `UPDATE ad_hoc_scan_runs SET status = ?`
+	args := []any{string(status)}
+	if startedCol != nil {
+		query += `, started_at = COALESCE(started_at, ?)`
+		args = append(args, startedCol)
+	}
+	if completedCol != nil {
+		query += `, completed_at = ?`
+		args = append(args, completedCol)
+	}
+	query += ` WHERE id = ?`
+	args = append(args, id)
+
+	res, err := st.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("store.adhoc.UpdateStatus: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (st *sqliteAdHocScanRunStore) AttachScan(ctx context.Context, id, scanID string) error {
+	res, err := st.db.ExecContext(ctx,
+		`UPDATE ad_hoc_scan_runs SET scan_id = ? WHERE id = ?`, scanID, id)
+	if err != nil {
+		return fmt.Errorf("store.adhoc.AttachScan: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (st *sqliteAdHocScanRunStore) Delete(ctx context.Context, id string) error {
+	res, err := st.db.ExecContext(ctx, `DELETE FROM ad_hoc_scan_runs WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("store.adhoc.Delete: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func validateAdHocInput(r *model.AdHocScanRun) error {
+	if r == nil {
+		return fmt.Errorf("ad-hoc run is nil")
+	}
+	if strings.TrimSpace(r.TargetID) == "" {
+		return fmt.Errorf("ad_hoc.target_id is required")
+	}
+	if strings.TrimSpace(r.InitiatedBy) == "" {
+		return fmt.Errorf("ad_hoc.initiated_by is required")
+	}
+	switch r.Status {
+	case "":
+		r.Status = model.AdHocPending
+	case model.AdHocPending, model.AdHocRunning, model.AdHocCompleted, model.AdHocFailed, model.AdHocCancelled:
+	default:
+		return fmt.Errorf("invalid ad_hoc.status %q", r.Status)
+	}
+	if err := model.ValidateToolConfig(r.ToolConfig); err != nil {
+		return err
+	}
+	return nil
+}
+
+func scanAdHoc(r rowScanner) (*model.AdHocScanRun, error) {
+	var (
+		ah           model.AdHocScanRun
+		templateID   sql.NullString
+		toolJSON     string
+		scanID       sql.NullString
+		status       string
+		requestedAt  sql.NullString
+		startedAt    sql.NullString
+		completedAt  sql.NullString
+	)
+	if err := r.Scan(
+		&ah.ID, &ah.TargetID, &templateID, &toolJSON, &ah.InitiatedBy, &ah.Reason,
+		&scanID, &status, &requestedAt, &startedAt, &completedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("scanning ad_hoc_scan_run: %w", err)
+	}
+	ah.Status = model.AdHocRunStatus(status)
+	ah.RequestedAt = parseTime(requestedAt)
+	ah.StartedAt = parseTimePtr(startedAt)
+	ah.CompletedAt = parseTimePtr(completedAt)
+	if templateID.Valid && templateID.String != "" {
+		v := templateID.String
+		ah.TemplateID = &v
+	}
+	if scanID.Valid && scanID.String != "" {
+		v := scanID.String
+		ah.ScanID = &v
+	}
+	if toolJSON == "" {
+		ah.ToolConfig = model.ToolConfig{}
+	} else {
+		if err := json.Unmarshal([]byte(toolJSON), &ah.ToolConfig); err != nil {
+			return nil, fmt.Errorf("unmarshaling ad_hoc.tool_config: %w", err)
+		}
+	}
+	return &ah, nil
+}
+
+func queryManyAdHoc(ctx context.Context, db *sql.DB, query string, args ...any) ([]model.AdHocScanRun, error) {
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying ad_hoc_scan_runs: %w", err)
+	}
+	defer rows.Close()
+	out := make([]model.AdHocScanRun, 0)
+	for rows.Next() {
+		r, err := scanAdHoc(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *r)
+	}
+	return out, rows.Err()
+}

--- a/internal/storage/adhoc_scan_runs_test.go
+++ b/internal/storage/adhoc_scan_runs_test.go
@@ -1,0 +1,141 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+func TestAdHocScanRunStore_CRUDRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	store := s.AdHocScanRuns()
+	ctx := context.Background()
+	tgt := seedTarget(t, s, "example.com")
+
+	r := &model.AdHocScanRun{
+		TargetID:    tgt.ID,
+		InitiatedBy: "cli",
+		Reason:      "zero-day verification",
+		ToolConfig: model.ToolConfig{
+			"nuclei": json.RawMessage(`{"tags":["cve-2025"]}`),
+		},
+		Status: model.AdHocPending,
+	}
+	require.NoError(t, store.Create(ctx, r))
+	assert.NotEmpty(t, r.ID)
+
+	got, err := store.Get(ctx, r.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "cli", got.InitiatedBy)
+	assert.Equal(t, model.AdHocPending, got.Status)
+	assert.Equal(t, "zero-day verification", got.Reason)
+
+	list, err := store.ListByTarget(ctx, tgt.ID, 10)
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+
+	require.NoError(t, store.Delete(ctx, r.ID))
+	_, err = store.Get(ctx, r.ID)
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+func TestAdHocScanRunStore_StatusLifecycle(t *testing.T) {
+	s := newTestStore(t)
+	store := s.AdHocScanRuns()
+	ctx := context.Background()
+	tgt := seedTarget(t, s, "example.com")
+
+	r := &model.AdHocScanRun{TargetID: tgt.ID, InitiatedBy: "api:token-1"}
+	require.NoError(t, store.Create(ctx, r))
+
+	started := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, store.UpdateStatus(ctx, r.ID, model.AdHocRunning, started))
+	got, err := store.Get(ctx, r.ID)
+	require.NoError(t, err)
+	assert.Equal(t, model.AdHocRunning, got.Status)
+	require.NotNil(t, got.StartedAt)
+	assert.WithinDuration(t, started, *got.StartedAt, time.Second)
+
+	completed := started.Add(5 * time.Minute)
+	require.NoError(t, store.UpdateStatus(ctx, r.ID, model.AdHocCompleted, completed))
+	got, err = store.Get(ctx, r.ID)
+	require.NoError(t, err)
+	assert.Equal(t, model.AdHocCompleted, got.Status)
+	require.NotNil(t, got.CompletedAt)
+	assert.WithinDuration(t, completed, *got.CompletedAt, time.Second)
+}
+
+func TestAdHocScanRunStore_AttachScan(t *testing.T) {
+	s := newTestStore(t)
+	store := s.AdHocScanRuns()
+	ctx := context.Background()
+	tgt := seedTarget(t, s, "example.com")
+
+	r := &model.AdHocScanRun{TargetID: tgt.ID, InitiatedBy: "cli"}
+	require.NoError(t, store.Create(ctx, r))
+
+	scan := &model.Scan{TargetID: tgt.ID, Type: model.ScanTypeFull, Status: model.ScanStatusQueued}
+	require.NoError(t, s.CreateScan(ctx, scan))
+
+	require.NoError(t, store.AttachScan(ctx, r.ID, scan.ID))
+
+	got, err := store.Get(ctx, r.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.ScanID)
+	assert.Equal(t, scan.ID, *got.ScanID)
+}
+
+func TestAdHocScanRunStore_ListByStatus(t *testing.T) {
+	s := newTestStore(t)
+	store := s.AdHocScanRuns()
+	ctx := context.Background()
+	tgt := seedTarget(t, s, "example.com")
+
+	make := func(status model.AdHocRunStatus, initiator string) {
+		r := &model.AdHocScanRun{TargetID: tgt.ID, InitiatedBy: initiator, Status: status}
+		require.NoError(t, store.Create(ctx, r))
+	}
+	make(model.AdHocPending, "cli")
+	make(model.AdHocRunning, "api:1")
+	make(model.AdHocPending, "webui:alice")
+
+	pending, err := store.ListByStatus(ctx, model.AdHocPending)
+	require.NoError(t, err)
+	assert.Len(t, pending, 2)
+}
+
+func TestAdHocScanRunStore_CascadeOnTargetDelete(t *testing.T) {
+	s := newTestStore(t)
+	store := s.AdHocScanRuns()
+	ctx := context.Background()
+	tgt := seedTarget(t, s, "example.com")
+
+	r := &model.AdHocScanRun{TargetID: tgt.ID, InitiatedBy: "cli"}
+	require.NoError(t, store.Create(ctx, r))
+	require.NoError(t, s.DeleteTarget(ctx, tgt.ID))
+
+	_, err := store.Get(ctx, r.ID)
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+func TestAdHocScanRunStore_ValidatesUnknownTool(t *testing.T) {
+	s := newTestStore(t)
+	store := s.AdHocScanRuns()
+	ctx := context.Background()
+	tgt := seedTarget(t, s, "example.com")
+
+	r := &model.AdHocScanRun{
+		TargetID: tgt.ID, InitiatedBy: "cli",
+		ToolConfig: model.ToolConfig{"amass": json.RawMessage(`{}`)},
+	}
+	err := store.Create(ctx, r)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, model.ErrUnknownTool))
+}

--- a/internal/storage/blackouts.go
+++ b/internal/storage/blackouts.go
@@ -1,0 +1,213 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/rrule"
+)
+
+// BlackoutStore persists blackout windows (global or per-target). Used by
+// the daemon's active-window evaluator, the HTTP handlers, and the CLI.
+type BlackoutStore interface {
+	Create(ctx context.Context, b *model.BlackoutWindow) error
+	Get(ctx context.Context, id string) (*model.BlackoutWindow, error)
+	List(ctx context.Context) ([]model.BlackoutWindow, error)
+	ListByScope(ctx context.Context, scope model.BlackoutScope) ([]model.BlackoutWindow, error)
+	ListByTarget(ctx context.Context, targetID string) ([]model.BlackoutWindow, error)
+	ListActive(ctx context.Context, targetID string) ([]model.BlackoutWindow, error)
+	Update(ctx context.Context, b *model.BlackoutWindow) error
+	Delete(ctx context.Context, id string) error
+}
+
+// Blackouts returns a BlackoutStore backed by this SQLiteStore.
+func (s *SQLiteStore) Blackouts() BlackoutStore {
+	return &sqliteBlackoutStore{db: s.db}
+}
+
+type sqliteBlackoutStore struct {
+	db *sql.DB
+}
+
+const blackoutColumns = `id, scope, target_id, name, rrule, duration_sec, timezone,
+  enabled, created_at, updated_at`
+
+func (st *sqliteBlackoutStore) Create(ctx context.Context, b *model.BlackoutWindow) error {
+	if err := validateBlackoutInput(b); err != nil {
+		return err
+	}
+	if b.ID == "" {
+		b.ID = uuid.New().String()
+	}
+	now := time.Now().UTC()
+	b.CreatedAt = now
+	b.UpdatedAt = now
+
+	_, err := st.db.ExecContext(ctx,
+		`INSERT INTO blackout_windows (`+blackoutColumns+`)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		b.ID, string(b.Scope), nullableString(b.TargetID), b.Name, b.RRule,
+		b.DurationSec, b.Timezone, boolToInt(b.Enabled),
+		b.CreatedAt.Format(timeFormat), b.UpdatedAt.Format(timeFormat),
+	)
+	if err != nil {
+		return fmt.Errorf("store.blackouts.Create: %w", err)
+	}
+	return nil
+}
+
+func (st *sqliteBlackoutStore) Get(ctx context.Context, id string) (*model.BlackoutWindow, error) {
+	row := st.db.QueryRowContext(ctx,
+		`SELECT `+blackoutColumns+` FROM blackout_windows WHERE id = ?`, id)
+	return scanBlackout(row)
+}
+
+func (st *sqliteBlackoutStore) List(ctx context.Context) ([]model.BlackoutWindow, error) {
+	return queryManyBlackouts(ctx, st.db,
+		`SELECT `+blackoutColumns+` FROM blackout_windows ORDER BY created_at ASC`)
+}
+
+func (st *sqliteBlackoutStore) ListByScope(ctx context.Context, scope model.BlackoutScope) ([]model.BlackoutWindow, error) {
+	return queryManyBlackouts(ctx, st.db,
+		`SELECT `+blackoutColumns+` FROM blackout_windows WHERE scope = ? ORDER BY created_at ASC`,
+		string(scope))
+}
+
+func (st *sqliteBlackoutStore) ListByTarget(ctx context.Context, targetID string) ([]model.BlackoutWindow, error) {
+	return queryManyBlackouts(ctx, st.db,
+		`SELECT `+blackoutColumns+` FROM blackout_windows WHERE target_id = ? ORDER BY created_at ASC`,
+		targetID)
+}
+
+// ListActive returns the enabled global blackouts plus the enabled
+// target-scoped blackouts for the given target. Actual "is this window
+// live now?" evaluation is performed by the scheduler from the RRULE —
+// this store just hands over the candidate set.
+func (st *sqliteBlackoutStore) ListActive(ctx context.Context, targetID string) ([]model.BlackoutWindow, error) {
+	return queryManyBlackouts(ctx, st.db,
+		`SELECT `+blackoutColumns+` FROM blackout_windows
+		 WHERE enabled = 1 AND (scope = 'global' OR target_id = ?)
+		 ORDER BY created_at ASC`,
+		targetID)
+}
+
+func (st *sqliteBlackoutStore) Update(ctx context.Context, b *model.BlackoutWindow) error {
+	if err := validateBlackoutInput(b); err != nil {
+		return err
+	}
+	b.UpdatedAt = time.Now().UTC()
+
+	res, err := st.db.ExecContext(ctx,
+		`UPDATE blackout_windows SET
+		   scope = ?, target_id = ?, name = ?, rrule = ?, duration_sec = ?,
+		   timezone = ?, enabled = ?, updated_at = ?
+		 WHERE id = ?`,
+		string(b.Scope), nullableString(b.TargetID), b.Name, b.RRule,
+		b.DurationSec, b.Timezone, boolToInt(b.Enabled),
+		b.UpdatedAt.Format(timeFormat), b.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("store.blackouts.Update: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (st *sqliteBlackoutStore) Delete(ctx context.Context, id string) error {
+	res, err := st.db.ExecContext(ctx, `DELETE FROM blackout_windows WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("store.blackouts.Delete: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func validateBlackoutInput(b *model.BlackoutWindow) error {
+	if b == nil {
+		return fmt.Errorf("blackout is nil")
+	}
+	if strings.TrimSpace(b.Name) == "" {
+		return fmt.Errorf("blackout.name is required")
+	}
+	if b.DurationSec <= 0 {
+		return fmt.Errorf("blackout.duration_seconds must be > 0")
+	}
+	if strings.TrimSpace(b.Timezone) == "" {
+		return fmt.Errorf("blackout.timezone is required")
+	}
+	switch b.Scope {
+	case model.BlackoutScopeGlobal:
+		if b.TargetID != nil && *b.TargetID != "" {
+			return fmt.Errorf("global blackout must not have target_id")
+		}
+	case model.BlackoutScopeTarget:
+		if b.TargetID == nil || *b.TargetID == "" {
+			return fmt.Errorf("target blackout must have target_id")
+		}
+	default:
+		return fmt.Errorf("invalid blackout scope %q", b.Scope)
+	}
+	if _, err := rrule.ValidateRRule(b.RRule); err != nil {
+		return err
+	}
+	return nil
+}
+
+func scanBlackout(r rowScanner) (*model.BlackoutWindow, error) {
+	var (
+		b         model.BlackoutWindow
+		scope     string
+		targetID  sql.NullString
+		enabled   int
+		createdAt sql.NullString
+		updatedAt sql.NullString
+	)
+	if err := r.Scan(
+		&b.ID, &scope, &targetID, &b.Name, &b.RRule, &b.DurationSec, &b.Timezone,
+		&enabled, &createdAt, &updatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("scanning blackout: %w", err)
+	}
+	b.Scope = model.BlackoutScope(scope)
+	b.Enabled = enabled != 0
+	b.CreatedAt = parseTime(createdAt)
+	b.UpdatedAt = parseTime(updatedAt)
+	if targetID.Valid && targetID.String != "" {
+		v := targetID.String
+		b.TargetID = &v
+	}
+	return &b, nil
+}
+
+func queryManyBlackouts(ctx context.Context, db *sql.DB, query string, args ...any) ([]model.BlackoutWindow, error) {
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying blackouts: %w", err)
+	}
+	defer rows.Close()
+	out := make([]model.BlackoutWindow, 0)
+	for rows.Next() {
+		b, err := scanBlackout(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *b)
+	}
+	return out, rows.Err()
+}

--- a/internal/storage/blackouts.go
+++ b/internal/storage/blackouts.go
@@ -200,7 +200,7 @@ func queryManyBlackouts(ctx context.Context, db dbtx, query string, args ...any)
 	if err != nil {
 		return nil, fmt.Errorf("querying blackouts: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	out := make([]model.BlackoutWindow, 0)
 	for rows.Next() {
 		b, err := scanBlackout(rows)

--- a/internal/storage/blackouts.go
+++ b/internal/storage/blackouts.go
@@ -33,7 +33,7 @@ func (s *SQLiteStore) Blackouts() BlackoutStore {
 }
 
 type sqliteBlackoutStore struct {
-	db *sql.DB
+	db dbtx
 }
 
 const blackoutColumns = `id, scope, target_id, name, rrule, duration_sec, timezone,
@@ -195,7 +195,7 @@ func scanBlackout(r rowScanner) (*model.BlackoutWindow, error) {
 	return &b, nil
 }
 
-func queryManyBlackouts(ctx context.Context, db *sql.DB, query string, args ...any) ([]model.BlackoutWindow, error) {
+func queryManyBlackouts(ctx context.Context, db dbtx, query string, args ...any) ([]model.BlackoutWindow, error) {
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying blackouts: %w", err)

--- a/internal/storage/blackouts_test.go
+++ b/internal/storage/blackouts_test.go
@@ -1,0 +1,134 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+func TestBlackoutStore_CRUDRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Blackouts()
+	ctx := context.Background()
+
+	b := &model.BlackoutWindow{
+		Scope:       model.BlackoutScopeGlobal,
+		Name:        "nightly-freeze",
+		RRule:       "FREQ=DAILY;BYHOUR=2",
+		DurationSec: 7200,
+		Timezone:    "UTC",
+		Enabled:     true,
+	}
+	require.NoError(t, store.Create(ctx, b))
+	assert.NotEmpty(t, b.ID)
+
+	got, err := store.Get(ctx, b.ID)
+	require.NoError(t, err)
+	assert.Equal(t, model.BlackoutScopeGlobal, got.Scope)
+	assert.Equal(t, 7200, got.DurationSec)
+
+	got.Enabled = false
+	got.DurationSec = 3600
+	require.NoError(t, store.Update(ctx, got))
+
+	reread, err := store.Get(ctx, b.ID)
+	require.NoError(t, err)
+	assert.False(t, reread.Enabled)
+	assert.Equal(t, 3600, reread.DurationSec)
+
+	require.NoError(t, store.Delete(ctx, b.ID))
+	_, err = store.Get(ctx, b.ID)
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+func TestBlackoutStore_ScopeConstraints(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Blackouts()
+	ctx := context.Background()
+	tgt := seedTarget(t, s, "example.com")
+
+	// Global with target_id must fail validation.
+	badGlobal := &model.BlackoutWindow{
+		Scope:       model.BlackoutScopeGlobal,
+		TargetID:    &tgt.ID,
+		Name:        "bad",
+		RRule:       "FREQ=DAILY",
+		DurationSec: 60,
+		Timezone:    "UTC",
+		Enabled:     true,
+	}
+	require.Error(t, store.Create(ctx, badGlobal))
+
+	// Target without target_id must fail validation.
+	badTarget := &model.BlackoutWindow{
+		Scope:       model.BlackoutScopeTarget,
+		Name:        "bad",
+		RRule:       "FREQ=DAILY",
+		DurationSec: 60,
+		Timezone:    "UTC",
+		Enabled:     true,
+	}
+	require.Error(t, store.Create(ctx, badTarget))
+}
+
+func TestBlackoutStore_ListActive(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Blackouts()
+	ctx := context.Background()
+	tgtA := seedTarget(t, s, "a.example")
+	tgtB := seedTarget(t, s, "b.example")
+
+	mk := func(scope model.BlackoutScope, targetID *string, enabled bool, name string) *model.BlackoutWindow {
+		return &model.BlackoutWindow{
+			Scope: scope, TargetID: targetID, Name: name,
+			RRule: "FREQ=DAILY;BYHOUR=2", DurationSec: 3600, Timezone: "UTC",
+			Enabled: enabled,
+		}
+	}
+	require.NoError(t, store.Create(ctx, mk(model.BlackoutScopeGlobal, nil, true, "global-on")))
+	require.NoError(t, store.Create(ctx, mk(model.BlackoutScopeGlobal, nil, false, "global-off")))
+	require.NoError(t, store.Create(ctx, mk(model.BlackoutScopeTarget, &tgtA.ID, true, "a-on")))
+	require.NoError(t, store.Create(ctx, mk(model.BlackoutScopeTarget, &tgtB.ID, true, "b-on")))
+
+	active, err := store.ListActive(ctx, tgtA.ID)
+	require.NoError(t, err)
+	names := make([]string, 0, len(active))
+	for _, bl := range active {
+		names = append(names, bl.Name)
+	}
+	assert.ElementsMatch(t, []string{"global-on", "a-on"}, names)
+}
+
+func TestBlackoutStore_CascadeOnTargetDelete(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Blackouts()
+	ctx := context.Background()
+	tgt := seedTarget(t, s, "example.com")
+
+	b := &model.BlackoutWindow{
+		Scope: model.BlackoutScopeTarget, TargetID: &tgt.ID, Name: "x",
+		RRule: "FREQ=DAILY", DurationSec: 60, Timezone: "UTC", Enabled: true,
+	}
+	require.NoError(t, store.Create(ctx, b))
+	require.NoError(t, s.DeleteTarget(ctx, tgt.ID))
+	_, err := store.Get(ctx, b.ID)
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+func TestBlackoutStore_ValidatesRRule(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Blackouts()
+	ctx := context.Background()
+
+	bad := &model.BlackoutWindow{
+		Scope: model.BlackoutScopeGlobal, Name: "x",
+		RRule: "FREQ=SECONDLY", DurationSec: 60, Timezone: "UTC", Enabled: true,
+	}
+	err := store.Create(ctx, bad)
+	require.Error(t, err)
+}

--- a/internal/storage/dbtx.go
+++ b/internal/storage/dbtx.go
@@ -1,0 +1,57 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// dbtx is the common read/write surface satisfied by both *sql.DB and
+// *sql.Tx. Store implementations depend on this so a single concrete
+// store can execute either against the outer connection pool or inside
+// a caller-supplied transaction.
+type dbtx interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// TxStores bundles the schedule-adjacent stores rebound against a single
+// transaction. MigrateLegacyScheduleConfig (and future multi-store
+// operations) receive one of these from SQLiteStore.Transact so every
+// write lands atomically.
+type TxStores struct {
+	Schedules        ScheduleStore
+	Templates        TemplateStore
+	Blackouts        BlackoutStore
+	ScheduleDefaults ScheduleDefaultsStore
+	AdHocScanRuns    AdHocScanRunStore
+}
+
+// Transact runs fn inside a database transaction. If fn returns an
+// error, the transaction is rolled back; otherwise it is committed. The
+// TxStores argument exposes every schedule-adjacent store rebound to
+// the tx so the fn body can perform multi-store writes atomically.
+func (s *SQLiteStore) Transact(ctx context.Context, fn func(context.Context, TxStores) error) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("storage.Transact: begin: %w", err)
+	}
+	stores := TxStores{
+		Schedules:        &sqliteScheduleStore{db: tx},
+		Templates:        &sqliteTemplateStore{db: tx},
+		Blackouts:        &sqliteBlackoutStore{db: tx},
+		ScheduleDefaults: &sqliteScheduleDefaultsStore{db: tx},
+		AdHocScanRuns:    &sqliteAdHocScanRunStore{db: tx},
+	}
+	if err := fn(ctx, stores); err != nil {
+		if rbErr := tx.Rollback(); rbErr != nil {
+			return fmt.Errorf("storage.Transact: %v; rollback: %v", err, rbErr)
+		}
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("storage.Transact: commit: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/migrations/0004_first_class_schedules.sql
+++ b/internal/storage/migrations/0004_first_class_schedules.sql
@@ -86,7 +86,7 @@ CREATE TABLE IF NOT EXISTS ad_hoc_scan_runs (
     initiated_by     TEXT NOT NULL,
     reason           TEXT NOT NULL DEFAULT '',
     scan_id          TEXT REFERENCES scans(id) ON DELETE SET NULL,
-    status           TEXT NOT NULL CHECK (status IN ('pending', 'running', 'completed', 'failed', 'cancelled')),
+    status           TEXT NOT NULL CHECK (status IN ('pending', 'running', 'completed', 'failed', 'canceled')),
     requested_at     TEXT NOT NULL,
     started_at       TEXT,
     completed_at     TEXT

--- a/internal/storage/migrations/0004_first_class_schedules.sql
+++ b/internal/storage/migrations/0004_first_class_schedules.sql
@@ -1,0 +1,110 @@
+-- Migration 0004: first-class schedules (SPEC-SCHED1.1)
+--
+-- Promotes schedules from a singleton schedule.config.json to first-class
+-- resources. Creates five new tables: scan_schedules, scan_templates,
+-- blackout_windows, schedule_defaults, ad_hoc_scan_runs.
+--
+-- This migration is purely additive — existing scans, targets, assets, and
+-- findings tables are untouched. The new tables sit dormant until PR
+-- SCHED1.2 wires the master ticker to them.
+
+CREATE TABLE IF NOT EXISTS scan_templates (
+    id                 TEXT PRIMARY KEY,
+    name               TEXT NOT NULL UNIQUE,
+    description        TEXT NOT NULL DEFAULT '',
+    rrule              TEXT NOT NULL,
+    timezone           TEXT NOT NULL DEFAULT 'UTC',
+    tool_config        TEXT NOT NULL DEFAULT '{}',
+    maintenance_window TEXT,
+    is_system          INTEGER NOT NULL DEFAULT 0,
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_scan_templates_updated ON scan_templates(updated_at);
+
+CREATE TABLE IF NOT EXISTS scan_schedules (
+    id                 TEXT PRIMARY KEY,
+    target_id          TEXT NOT NULL REFERENCES targets(id) ON DELETE CASCADE,
+    name               TEXT NOT NULL,
+    rrule              TEXT NOT NULL,
+    dtstart            TEXT NOT NULL,
+    timezone           TEXT NOT NULL,
+    template_id        TEXT REFERENCES scan_templates(id) ON DELETE SET NULL,
+    tool_config        TEXT NOT NULL DEFAULT '{}',
+    overrides          TEXT NOT NULL DEFAULT '[]',
+    maintenance_window TEXT,
+    enabled            INTEGER NOT NULL DEFAULT 1,
+    next_run_at        TEXT,
+    last_run_at        TEXT,
+    last_run_status    TEXT,
+    last_scan_id       TEXT REFERENCES scans(id) ON DELETE SET NULL,
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL,
+    UNIQUE(target_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_scan_schedules_next_run ON scan_schedules(next_run_at) WHERE enabled = 1;
+CREATE INDEX IF NOT EXISTS idx_scan_schedules_target ON scan_schedules(target_id);
+CREATE INDEX IF NOT EXISTS idx_scan_schedules_template ON scan_schedules(template_id);
+
+CREATE TABLE IF NOT EXISTS blackout_windows (
+    id            TEXT PRIMARY KEY,
+    scope         TEXT NOT NULL CHECK (scope IN ('global', 'target')),
+    target_id     TEXT REFERENCES targets(id) ON DELETE CASCADE,
+    name          TEXT NOT NULL,
+    rrule         TEXT NOT NULL,
+    duration_sec  INTEGER NOT NULL,
+    timezone      TEXT NOT NULL DEFAULT 'UTC',
+    enabled       INTEGER NOT NULL DEFAULT 1,
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL,
+    CHECK ((scope = 'global' AND target_id IS NULL) OR (scope = 'target' AND target_id IS NOT NULL))
+);
+
+CREATE INDEX IF NOT EXISTS idx_blackout_scope ON blackout_windows(scope, enabled);
+CREATE INDEX IF NOT EXISTS idx_blackout_target ON blackout_windows(target_id) WHERE target_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS schedule_defaults (
+    id                          INTEGER PRIMARY KEY CHECK (id = 1),
+    default_template_id         TEXT REFERENCES scan_templates(id) ON DELETE SET NULL,
+    default_rrule               TEXT NOT NULL,
+    default_timezone            TEXT NOT NULL DEFAULT 'UTC',
+    default_tool_config         TEXT NOT NULL DEFAULT '{}',
+    default_maintenance_window  TEXT,
+    max_concurrent_scans        INTEGER NOT NULL DEFAULT 4,
+    run_on_start                INTEGER NOT NULL DEFAULT 0,
+    jitter_seconds              INTEGER NOT NULL DEFAULT 60,
+    updated_at                  TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS ad_hoc_scan_runs (
+    id               TEXT PRIMARY KEY,
+    target_id        TEXT NOT NULL REFERENCES targets(id) ON DELETE CASCADE,
+    template_id      TEXT REFERENCES scan_templates(id) ON DELETE SET NULL,
+    tool_config      TEXT NOT NULL DEFAULT '{}',
+    initiated_by     TEXT NOT NULL,
+    reason           TEXT NOT NULL DEFAULT '',
+    scan_id          TEXT REFERENCES scans(id) ON DELETE SET NULL,
+    status           TEXT NOT NULL CHECK (status IN ('pending', 'running', 'completed', 'failed', 'cancelled')),
+    requested_at     TEXT NOT NULL,
+    started_at       TEXT,
+    completed_at     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_adhoc_target ON ad_hoc_scan_runs(target_id, requested_at DESC);
+CREATE INDEX IF NOT EXISTS idx_adhoc_status ON ad_hoc_scan_runs(status);
+
+-- Seed the singleton schedule_defaults row. Values here are placeholders;
+-- the legacy migration function (PR SCHED1.2) overwrites them with data
+-- derived from schedule.config.json on first boot post-upgrade.
+INSERT OR IGNORE INTO schedule_defaults (
+    id, default_rrule, default_timezone, default_tool_config,
+    max_concurrent_scans, run_on_start, jitter_seconds, updated_at
+) VALUES (
+    1, 'FREQ=DAILY;BYHOUR=2', 'UTC', '{}', 4, 0, 60, CURRENT_TIMESTAMP
+);
+
+PRAGMA user_version = 4;
+
+UPDATE agent_meta SET value = '4' WHERE key = 'schema_version';

--- a/internal/storage/migrations_0004_test.go
+++ b/internal/storage/migrations_0004_test.go
@@ -1,0 +1,238 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// TestMigration0004_FreshDB verifies that migration 0004 creates all five
+// schedule tables and all seven indexes from the spec on a fresh database.
+func TestMigration0004_FreshDB(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	wantTables := []string{
+		"scan_schedules",
+		"scan_templates",
+		"blackout_windows",
+		"schedule_defaults",
+		"ad_hoc_scan_runs",
+	}
+	for _, table := range wantTables {
+		var name string
+		err := s.db.QueryRowContext(ctx,
+			`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, table).Scan(&name)
+		require.NoError(t, err, "table %s should exist", table)
+		assert.Equal(t, table, name)
+	}
+
+	wantIndexes := []string{
+		"idx_scan_schedules_next_run",
+		"idx_scan_schedules_target",
+		"idx_scan_schedules_template",
+		"idx_scan_templates_updated",
+		"idx_blackout_scope",
+		"idx_blackout_target",
+		"idx_adhoc_target",
+		"idx_adhoc_status",
+	}
+	for _, idx := range wantIndexes {
+		var name string
+		err := s.db.QueryRowContext(ctx,
+			`SELECT name FROM sqlite_master WHERE type='index' AND name=?`, idx).Scan(&name)
+		require.NoError(t, err, "index %s should exist", idx)
+	}
+
+	v, err := s.GetMeta(ctx, "schema_version")
+	require.NoError(t, err)
+	assert.Equal(t, "4", v)
+
+	var userVersion int
+	err = s.db.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&userVersion)
+	require.NoError(t, err)
+	assert.Equal(t, 4, userVersion)
+
+	var defaultsCount int
+	err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM schedule_defaults`).Scan(&defaultsCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, defaultsCount, "schedule_defaults must seed exactly one row")
+}
+
+// TestMigration0004_WithExistingData verifies that migration 0004 does not
+// touch populated scans/targets/assets/findings tables when it runs.
+func TestMigration0004_WithExistingData(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	target := &model.Target{Value: "example.com"}
+	require.NoError(t, s.CreateTarget(ctx, target))
+
+	scan := &model.Scan{TargetID: target.ID, Type: model.ScanTypeFull, Status: model.ScanStatusRunning}
+	require.NoError(t, s.CreateScan(ctx, scan))
+
+	assertRowCount := func(t *testing.T, table string, want int) {
+		t.Helper()
+		var n int
+		err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+table).Scan(&n)
+		require.NoError(t, err)
+		assert.Equal(t, want, n, "table %s row count", table)
+	}
+
+	assertRowCount(t, "targets", 1)
+	assertRowCount(t, "scans", 1)
+	assertRowCount(t, "scan_schedules", 0)
+	assertRowCount(t, "scan_templates", 0)
+	assertRowCount(t, "blackout_windows", 0)
+	assertRowCount(t, "ad_hoc_scan_runs", 0)
+	assertRowCount(t, "schedule_defaults", 1)
+}
+
+// TestMigration0004_ForwardOnly documents that no down migration exists —
+// the repo policy is forward-only. This test pins the policy so a future
+// change intending to add a down migration has to make it explicit.
+func TestMigration0004_ForwardOnly(t *testing.T) {
+	entries, err := migrationsFS.ReadDir("migrations")
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), "_down_", "no down migrations allowed in %s", e.Name())
+		assert.NotContains(t, e.Name(), ".down.", "no down migrations allowed in %s", e.Name())
+	}
+}
+
+// TestMigration0004_ForeignKeys enforces the FK constraints declared in the
+// migration: deleting a target cascades to its schedules, blackouts, and
+// ad-hoc runs; deleting a template nulls template_id on schedules and
+// ad-hoc runs.
+func TestMigration0004_ForeignKeys(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	target := &model.Target{Value: "example.com"}
+	require.NoError(t, s.CreateTarget(ctx, target))
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	tmplID := "tmpl-01"
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO scan_templates (id, name, description, rrule, timezone, tool_config, is_system, created_at, updated_at)
+		 VALUES (?, 'default', '', 'FREQ=DAILY', 'UTC', '{}', 1, ?, ?)`,
+		tmplID, now, now)
+	require.NoError(t, err)
+
+	schedID := "sched-01"
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO scan_schedules (id, target_id, name, rrule, dtstart, timezone, template_id, created_at, updated_at)
+		 VALUES (?, ?, 'default', 'FREQ=DAILY', ?, 'UTC', ?, ?, ?)`,
+		schedID, target.ID, now, tmplID, now, now)
+	require.NoError(t, err)
+
+	blID := "bl-01"
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO blackout_windows (id, scope, target_id, name, rrule, duration_sec, timezone, created_at, updated_at)
+		 VALUES (?, 'target', ?, 'night', 'FREQ=DAILY;BYHOUR=2', 3600, 'UTC', ?, ?)`,
+		blID, target.ID, now, now)
+	require.NoError(t, err)
+
+	ahID := "ah-01"
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO ad_hoc_scan_runs (id, target_id, template_id, initiated_by, status, requested_at)
+		 VALUES (?, ?, ?, 'cli', 'pending', ?)`,
+		ahID, target.ID, tmplID, now)
+	require.NoError(t, err)
+
+	// Delete the template: schedules and ad-hoc runs should have template_id NULL.
+	_, err = s.db.ExecContext(ctx, `DELETE FROM scan_templates WHERE id = ?`, tmplID)
+	require.NoError(t, err)
+
+	var tmplRef sql.NullString
+	err = s.db.QueryRowContext(ctx,
+		`SELECT template_id FROM scan_schedules WHERE id = ?`, schedID).Scan(&tmplRef)
+	require.NoError(t, err)
+	assert.False(t, tmplRef.Valid, "template_id should be NULL after template delete")
+
+	err = s.db.QueryRowContext(ctx,
+		`SELECT template_id FROM ad_hoc_scan_runs WHERE id = ?`, ahID).Scan(&tmplRef)
+	require.NoError(t, err)
+	assert.False(t, tmplRef.Valid)
+
+	// Delete the target: schedules, target-scoped blackouts, and ad-hoc runs cascade.
+	_, err = s.db.ExecContext(ctx, `DELETE FROM targets WHERE id = ?`, target.ID)
+	require.NoError(t, err)
+
+	var n int
+	require.NoError(t, s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM scan_schedules WHERE id = ?`, schedID).Scan(&n))
+	assert.Equal(t, 0, n)
+	require.NoError(t, s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM blackout_windows WHERE id = ?`, blID).Scan(&n))
+	assert.Equal(t, 0, n)
+	require.NoError(t, s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM ad_hoc_scan_runs WHERE id = ?`, ahID).Scan(&n))
+	assert.Equal(t, 0, n)
+}
+
+// TestMigration0004_Constraints exercises the CHECK and UNIQUE constraints.
+func TestMigration0004_Constraints(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// schedule_defaults is a singleton.
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO schedule_defaults (id, default_rrule, updated_at) VALUES (2, 'FREQ=DAILY', ?)`, now)
+	assert.Error(t, err, "id != 1 must fail CHECK")
+
+	// Global blackout with non-null target_id must fail.
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO blackout_windows (id, scope, target_id, name, rrule, duration_sec, timezone, created_at, updated_at)
+		 VALUES ('x', 'global', 'some-target', 'bad', 'FREQ=DAILY', 60, 'UTC', ?, ?)`, now, now)
+	assert.Error(t, err, "global scope with non-null target_id must fail CHECK")
+
+	// Target blackout with null target_id must fail.
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO blackout_windows (id, scope, target_id, name, rrule, duration_sec, timezone, created_at, updated_at)
+		 VALUES ('y', 'target', NULL, 'bad', 'FREQ=DAILY', 60, 'UTC', ?, ?)`, now, now)
+	assert.Error(t, err, "target scope with null target_id must fail CHECK")
+
+	// (target_id, name) uniqueness.
+	target := &model.Target{Value: "example.com"}
+	require.NoError(t, s.CreateTarget(ctx, target))
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO scan_schedules (id, target_id, name, rrule, dtstart, timezone, created_at, updated_at)
+		 VALUES ('s1', ?, 'default', 'FREQ=DAILY', ?, 'UTC', ?, ?)`, target.ID, now, now, now)
+	require.NoError(t, err)
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO scan_schedules (id, target_id, name, rrule, dtstart, timezone, created_at, updated_at)
+		 VALUES ('s2', ?, 'default', 'FREQ=DAILY', ?, 'UTC', ?, ?)`, target.ID, now, now, now)
+	assert.Error(t, err, "two schedules with same (target_id, name) must fail UNIQUE")
+}
+
+// TestMigration0004_PartialIndex verifies the partial next_run_at index is
+// used for the hot ticker query.
+func TestMigration0004_PartialIndex(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	rows, err := s.db.QueryContext(ctx,
+		`EXPLAIN QUERY PLAN SELECT id FROM scan_schedules WHERE enabled = 1 AND next_run_at <= ?`,
+		time.Now().UTC().Format(time.RFC3339))
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var plan string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		plan += detail + "\n"
+	}
+	assert.Contains(t, plan, "idx_scan_schedules_next_run",
+		"query must use partial next_run_at index")
+}

--- a/internal/storage/migrations_0004_test.go
+++ b/internal/storage/migrations_0004_test.go
@@ -224,7 +224,7 @@ func TestMigration0004_PartialIndex(t *testing.T) {
 		`EXPLAIN QUERY PLAN SELECT id FROM scan_schedules WHERE enabled = 1 AND next_run_at <= ?`,
 		time.Now().UTC().Format(time.RFC3339))
 	require.NoError(t, err)
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var plan string
 	for rows.Next() {

--- a/internal/storage/schedule_defaults.go
+++ b/internal/storage/schedule_defaults.go
@@ -25,7 +25,7 @@ func (s *SQLiteStore) ScheduleDefaults() ScheduleDefaultsStore {
 }
 
 type sqliteScheduleDefaultsStore struct {
-	db *sql.DB
+	db dbtx
 }
 
 func (st *sqliteScheduleDefaultsStore) Get(ctx context.Context) (*model.ScheduleDefaults, error) {

--- a/internal/storage/schedule_defaults.go
+++ b/internal/storage/schedule_defaults.go
@@ -35,12 +35,12 @@ func (st *sqliteScheduleDefaultsStore) Get(ctx context.Context) (*model.Schedule
 		        jitter_seconds, updated_at
 		 FROM schedule_defaults WHERE id = 1`)
 	var (
-		d         model.ScheduleDefaults
-		tmplID    sql.NullString
-		toolJSON  string
-		mwJSON    sql.NullString
+		d          model.ScheduleDefaults
+		tmplID     sql.NullString
+		toolJSON   string
+		mwJSON     sql.NullString
 		runOnStart int
-		updatedAt sql.NullString
+		updatedAt  sql.NullString
 	)
 	if err := row.Scan(
 		&tmplID, &d.DefaultRRule, &d.DefaultTimezone, &toolJSON, &mwJSON,

--- a/internal/storage/schedule_defaults.go
+++ b/internal/storage/schedule_defaults.go
@@ -1,0 +1,120 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// ScheduleDefaultsStore persists the singleton schedule_defaults row that
+// supplies inherited values for schedules without explicit overrides.
+// The row id is always 1 (enforced by CHECK constraint in the schema).
+type ScheduleDefaultsStore interface {
+	Get(ctx context.Context) (*model.ScheduleDefaults, error)
+	Update(ctx context.Context, d *model.ScheduleDefaults) error
+}
+
+// ScheduleDefaults returns a ScheduleDefaultsStore backed by this SQLiteStore.
+func (s *SQLiteStore) ScheduleDefaults() ScheduleDefaultsStore {
+	return &sqliteScheduleDefaultsStore{db: s.db}
+}
+
+type sqliteScheduleDefaultsStore struct {
+	db *sql.DB
+}
+
+func (st *sqliteScheduleDefaultsStore) Get(ctx context.Context) (*model.ScheduleDefaults, error) {
+	row := st.db.QueryRowContext(ctx,
+		`SELECT default_template_id, default_rrule, default_timezone, default_tool_config,
+		        default_maintenance_window, max_concurrent_scans, run_on_start,
+		        jitter_seconds, updated_at
+		 FROM schedule_defaults WHERE id = 1`)
+	var (
+		d         model.ScheduleDefaults
+		tmplID    sql.NullString
+		toolJSON  string
+		mwJSON    sql.NullString
+		runOnStart int
+		updatedAt sql.NullString
+	)
+	if err := row.Scan(
+		&tmplID, &d.DefaultRRule, &d.DefaultTimezone, &toolJSON, &mwJSON,
+		&d.MaxConcurrentScans, &runOnStart, &d.JitterSeconds, &updatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("store.schedule_defaults.Get: %w", err)
+	}
+	d.RunOnStart = runOnStart != 0
+	d.UpdatedAt = parseTime(updatedAt)
+	if tmplID.Valid && tmplID.String != "" {
+		v := tmplID.String
+		d.DefaultTemplateID = &v
+	}
+	if toolJSON == "" {
+		d.DefaultToolConfig = model.ToolConfig{}
+	} else {
+		if err := json.Unmarshal([]byte(toolJSON), &d.DefaultToolConfig); err != nil {
+			return nil, fmt.Errorf("unmarshaling default_tool_config: %w", err)
+		}
+	}
+	if mwJSON.Valid && mwJSON.String != "" {
+		var mw model.MaintenanceWindow
+		if err := json.Unmarshal([]byte(mwJSON.String), &mw); err != nil {
+			return nil, fmt.Errorf("unmarshaling default_maintenance_window: %w", err)
+		}
+		d.DefaultMaintenanceWindow = &mw
+	}
+	return &d, nil
+}
+
+func (st *sqliteScheduleDefaultsStore) Update(ctx context.Context, d *model.ScheduleDefaults) error {
+	if d == nil {
+		return fmt.Errorf("defaults is nil")
+	}
+	if err := model.ValidateToolConfig(d.DefaultToolConfig); err != nil {
+		return err
+	}
+	d.UpdatedAt = time.Now().UTC()
+
+	toolJSON, err := json.Marshal(d.DefaultToolConfig)
+	if err != nil {
+		return fmt.Errorf("marshaling default_tool_config: %w", err)
+	}
+	var mwJSON any
+	if d.DefaultMaintenanceWindow != nil {
+		b, err := json.Marshal(d.DefaultMaintenanceWindow)
+		if err != nil {
+			return fmt.Errorf("marshaling default_maintenance_window: %w", err)
+		}
+		mwJSON = string(b)
+	}
+
+	res, err := st.db.ExecContext(ctx,
+		`UPDATE schedule_defaults SET
+		   default_template_id = ?, default_rrule = ?, default_timezone = ?,
+		   default_tool_config = ?, default_maintenance_window = ?,
+		   max_concurrent_scans = ?, run_on_start = ?, jitter_seconds = ?,
+		   updated_at = ?
+		 WHERE id = 1`,
+		nullableString(d.DefaultTemplateID), d.DefaultRRule, d.DefaultTimezone,
+		string(toolJSON), mwJSON, d.MaxConcurrentScans,
+		boolToInt(d.RunOnStart), d.JitterSeconds,
+		d.UpdatedAt.Format(timeFormat),
+	)
+	if err != nil {
+		return fmt.Errorf("store.schedule_defaults.Update: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		// Should never happen — the migration seeds the row.
+		return ErrNotFound
+	}
+	return nil
+}

--- a/internal/storage/schedule_defaults_test.go
+++ b/internal/storage/schedule_defaults_test.go
@@ -1,0 +1,88 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+func TestScheduleDefaultsStore_SeededOnMigration(t *testing.T) {
+	s := newTestStore(t)
+	store := s.ScheduleDefaults()
+	ctx := context.Background()
+
+	got, err := store.Get(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "FREQ=DAILY;BYHOUR=2", got.DefaultRRule)
+	assert.Equal(t, "UTC", got.DefaultTimezone)
+	assert.Equal(t, 4, got.MaxConcurrentScans)
+	assert.Equal(t, 60, got.JitterSeconds)
+	assert.False(t, got.RunOnStart)
+}
+
+func TestScheduleDefaultsStore_Update(t *testing.T) {
+	s := newTestStore(t)
+	store := s.ScheduleDefaults()
+	ctx := context.Background()
+
+	tmplID := "tmpl-01"
+	seedRawTemplate(t, s, tmplID, "system-default")
+
+	got, err := store.Get(ctx)
+	require.NoError(t, err)
+
+	got.DefaultTemplateID = &tmplID
+	got.DefaultRRule = "FREQ=HOURLY"
+	got.MaxConcurrentScans = 8
+	got.RunOnStart = true
+	got.JitterSeconds = 30
+	got.DefaultToolConfig = model.ToolConfig{
+		"nuclei": json.RawMessage(`{"severity":["critical"]}`),
+	}
+	got.DefaultMaintenanceWindow = &model.MaintenanceWindow{
+		RRule: "FREQ=DAILY;BYHOUR=2", DurationSec: 7200, Timezone: "UTC",
+	}
+	require.NoError(t, store.Update(ctx, got))
+
+	reread, err := store.Get(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, reread.DefaultTemplateID)
+	assert.Equal(t, tmplID, *reread.DefaultTemplateID)
+	assert.Equal(t, "FREQ=HOURLY", reread.DefaultRRule)
+	assert.Equal(t, 8, reread.MaxConcurrentScans)
+	assert.True(t, reread.RunOnStart)
+	assert.Equal(t, 30, reread.JitterSeconds)
+	assert.Contains(t, reread.DefaultToolConfig, "nuclei")
+	require.NotNil(t, reread.DefaultMaintenanceWindow)
+	assert.Equal(t, 7200, reread.DefaultMaintenanceWindow.DurationSec)
+}
+
+func TestScheduleDefaultsStore_RejectsUnknownTool(t *testing.T) {
+	s := newTestStore(t)
+	store := s.ScheduleDefaults()
+	ctx := context.Background()
+
+	got, err := store.Get(ctx)
+	require.NoError(t, err)
+	got.DefaultToolConfig = model.ToolConfig{"amass": json.RawMessage(`{}`)}
+	err = store.Update(ctx, got)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, model.ErrUnknownTool))
+}
+
+func TestScheduleDefaultsStore_SingletonCheck(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO schedule_defaults (id, default_rrule, default_timezone, default_tool_config,
+		                                max_concurrent_scans, run_on_start, jitter_seconds, updated_at)
+		 VALUES (2, 'FREQ=DAILY', 'UTC', '{}', 4, 0, 60, '2026-01-01T00:00:00Z')`)
+	require.Error(t, err, "CHECK (id = 1) must reject inserts with other ids")
+}

--- a/internal/storage/schedules.go
+++ b/internal/storage/schedules.go
@@ -41,7 +41,7 @@ func (s *SQLiteStore) Schedules() ScheduleStore {
 }
 
 type sqliteScheduleStore struct {
-	db *sql.DB
+	db dbtx
 }
 
 const scheduleColumns = `id, target_id, name, rrule, dtstart, timezone, template_id, tool_config,
@@ -343,7 +343,7 @@ func scanSchedule(r rowScanner) (*model.Schedule, error) {
 	return &s, nil
 }
 
-func queryManySchedules(ctx context.Context, db *sql.DB, query string, args ...any) ([]model.Schedule, error) {
+func queryManySchedules(ctx context.Context, db dbtx, query string, args ...any) ([]model.Schedule, error) {
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying schedules: %w", err)

--- a/internal/storage/schedules.go
+++ b/internal/storage/schedules.go
@@ -276,19 +276,19 @@ type rowScanner interface {
 
 func scanSchedule(r rowScanner) (*model.Schedule, error) {
 	var (
-		s              model.Schedule
-		dtstart        sql.NullString
-		templateID     sql.NullString
-		toolJSON       string
-		overridesJSON  string
-		mwJSON         sql.NullString
-		enabled        int
-		nextRunAt      sql.NullString
-		lastRunAt      sql.NullString
-		lastRunStatus  sql.NullString
-		lastScanID     sql.NullString
-		createdAt      sql.NullString
-		updatedAt      sql.NullString
+		s             model.Schedule
+		dtstart       sql.NullString
+		templateID    sql.NullString
+		toolJSON      string
+		overridesJSON string
+		mwJSON        sql.NullString
+		enabled       int
+		nextRunAt     sql.NullString
+		lastRunAt     sql.NullString
+		lastRunStatus sql.NullString
+		lastScanID    sql.NullString
+		createdAt     sql.NullString
+		updatedAt     sql.NullString
 	)
 	if err := r.Scan(
 		&s.ID, &s.TargetID, &s.Name, &s.RRule, &dtstart, &s.Timezone,
@@ -348,7 +348,7 @@ func queryManySchedules(ctx context.Context, db dbtx, query string, args ...any)
 	if err != nil {
 		return nil, fmt.Errorf("querying schedules: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	out := make([]model.Schedule, 0)
 	for rows.Next() {

--- a/internal/storage/schedules.go
+++ b/internal/storage/schedules.go
@@ -1,0 +1,390 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/rrule"
+)
+
+// ScheduleStore is the persistence interface for per-target scan
+// schedules. All implementations must validate the RRULE and ToolConfig
+// on Create and Update (SPEC-SCHED1 R6). The interface is consumed by
+// the daemon (master ticker), the HTTP handlers, and the CLI, so it
+// lives at a package boundary.
+type ScheduleStore interface {
+	Create(ctx context.Context, s *model.Schedule) error
+	Get(ctx context.Context, id string) (*model.Schedule, error)
+	GetByTargetAndName(ctx context.Context, targetID, name string) (*model.Schedule, error)
+	ListByTarget(ctx context.Context, targetID string) ([]model.Schedule, error)
+	ListAll(ctx context.Context) ([]model.Schedule, error)
+	ListDue(ctx context.Context, now time.Time, limit int) ([]model.Schedule, error)
+	ListByTemplate(ctx context.Context, templateID string) ([]model.Schedule, error)
+	Update(ctx context.Context, s *model.Schedule) error
+	SetNextRunAt(ctx context.Context, id string, next *time.Time) error
+	RecordRun(ctx context.Context, id string, status model.ScheduleRunStatus, scanID *string, at time.Time) error
+	Delete(ctx context.Context, id string) error
+	CountByTarget(ctx context.Context, targetID string) (int, error)
+}
+
+// Schedules returns a ScheduleStore backed by this SQLiteStore.
+func (s *SQLiteStore) Schedules() ScheduleStore {
+	return &sqliteScheduleStore{db: s.db}
+}
+
+type sqliteScheduleStore struct {
+	db *sql.DB
+}
+
+const scheduleColumns = `id, target_id, name, rrule, dtstart, timezone, template_id, tool_config,
+  overrides, maintenance_window, enabled, next_run_at, last_run_at, last_run_status, last_scan_id,
+  created_at, updated_at`
+
+func (st *sqliteScheduleStore) Create(ctx context.Context, s *model.Schedule) error {
+	if err := validateScheduleInput(s); err != nil {
+		return err
+	}
+	if s.ID == "" {
+		s.ID = uuid.New().String()
+	}
+	now := time.Now().UTC()
+	s.CreatedAt = now
+	s.UpdatedAt = now
+	if s.Overrides == nil {
+		s.Overrides = []string{}
+	}
+	if s.ToolConfig == nil {
+		s.ToolConfig = model.ToolConfig{}
+	}
+
+	toolJSON, overridesJSON, mwJSON, err := marshalScheduleFields(s)
+	if err != nil {
+		return err
+	}
+
+	_, err = st.db.ExecContext(ctx,
+		`INSERT INTO scan_schedules (`+scheduleColumns+`)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.ID, s.TargetID, s.Name, s.RRule, s.DTStart.Format(timeFormat), s.Timezone,
+		nullableString(s.TemplateID), toolJSON, overridesJSON, mwJSON, boolToInt(s.Enabled),
+		timePtrUTC(s.NextRunAt), timePtrUTC(s.LastRunAt), nullableRunStatus(s.LastRunStatus),
+		nullableString(s.LastScanID),
+		s.CreatedAt.Format(timeFormat), s.UpdatedAt.Format(timeFormat),
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return fmt.Errorf("%w: schedule (target=%s, name=%s)", ErrAlreadyExists, s.TargetID, s.Name)
+		}
+		return fmt.Errorf("store.schedules.Create: %w", err)
+	}
+	return nil
+}
+
+func (st *sqliteScheduleStore) Get(ctx context.Context, id string) (*model.Schedule, error) {
+	row := st.db.QueryRowContext(ctx,
+		`SELECT `+scheduleColumns+` FROM scan_schedules WHERE id = ?`, id)
+	return scanSchedule(row)
+}
+
+func (st *sqliteScheduleStore) GetByTargetAndName(ctx context.Context, targetID, name string) (*model.Schedule, error) {
+	row := st.db.QueryRowContext(ctx,
+		`SELECT `+scheduleColumns+` FROM scan_schedules WHERE target_id = ? AND name = ?`, targetID, name)
+	return scanSchedule(row)
+}
+
+func (st *sqliteScheduleStore) ListByTarget(ctx context.Context, targetID string) ([]model.Schedule, error) {
+	return queryManySchedules(ctx, st.db,
+		`SELECT `+scheduleColumns+` FROM scan_schedules WHERE target_id = ? ORDER BY name ASC`,
+		targetID)
+}
+
+func (st *sqliteScheduleStore) ListAll(ctx context.Context) ([]model.Schedule, error) {
+	return queryManySchedules(ctx, st.db,
+		`SELECT `+scheduleColumns+` FROM scan_schedules ORDER BY created_at ASC`)
+}
+
+func (st *sqliteScheduleStore) ListDue(ctx context.Context, now time.Time, limit int) ([]model.Schedule, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	return queryManySchedules(ctx, st.db,
+		`SELECT `+scheduleColumns+` FROM scan_schedules
+		 WHERE enabled = 1 AND next_run_at IS NOT NULL AND next_run_at <= ?
+		 ORDER BY next_run_at ASC
+		 LIMIT ?`,
+		now.UTC().Format(timeFormat), limit)
+}
+
+func (st *sqliteScheduleStore) ListByTemplate(ctx context.Context, templateID string) ([]model.Schedule, error) {
+	return queryManySchedules(ctx, st.db,
+		`SELECT `+scheduleColumns+` FROM scan_schedules WHERE template_id = ? ORDER BY created_at ASC`,
+		templateID)
+}
+
+func (st *sqliteScheduleStore) Update(ctx context.Context, s *model.Schedule) error {
+	if err := validateScheduleInput(s); err != nil {
+		return err
+	}
+	s.UpdatedAt = time.Now().UTC()
+	if s.Overrides == nil {
+		s.Overrides = []string{}
+	}
+	if s.ToolConfig == nil {
+		s.ToolConfig = model.ToolConfig{}
+	}
+
+	toolJSON, overridesJSON, mwJSON, err := marshalScheduleFields(s)
+	if err != nil {
+		return err
+	}
+
+	res, err := st.db.ExecContext(ctx,
+		`UPDATE scan_schedules SET
+		   target_id = ?, name = ?, rrule = ?, dtstart = ?, timezone = ?,
+		   template_id = ?, tool_config = ?, overrides = ?, maintenance_window = ?,
+		   enabled = ?, next_run_at = ?, last_run_at = ?, last_run_status = ?,
+		   last_scan_id = ?, updated_at = ?
+		 WHERE id = ?`,
+		s.TargetID, s.Name, s.RRule, s.DTStart.Format(timeFormat), s.Timezone,
+		nullableString(s.TemplateID), toolJSON, overridesJSON, mwJSON, boolToInt(s.Enabled),
+		timePtrUTC(s.NextRunAt), timePtrUTC(s.LastRunAt), nullableRunStatus(s.LastRunStatus),
+		nullableString(s.LastScanID), s.UpdatedAt.Format(timeFormat), s.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("store.schedules.Update: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (st *sqliteScheduleStore) SetNextRunAt(ctx context.Context, id string, next *time.Time) error {
+	res, err := st.db.ExecContext(ctx,
+		`UPDATE scan_schedules SET next_run_at = ?, updated_at = ? WHERE id = ?`,
+		timePtrUTC(next), time.Now().UTC().Format(timeFormat), id)
+	if err != nil {
+		return fmt.Errorf("store.schedules.SetNextRunAt: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (st *sqliteScheduleStore) RecordRun(ctx context.Context, id string, status model.ScheduleRunStatus, scanID *string, at time.Time) error {
+	res, err := st.db.ExecContext(ctx,
+		`UPDATE scan_schedules SET last_run_at = ?, last_run_status = ?, last_scan_id = ?, updated_at = ?
+		 WHERE id = ?`,
+		at.UTC().Format(timeFormat), string(status), nullableString(scanID),
+		time.Now().UTC().Format(timeFormat), id)
+	if err != nil {
+		return fmt.Errorf("store.schedules.RecordRun: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (st *sqliteScheduleStore) Delete(ctx context.Context, id string) error {
+	res, err := st.db.ExecContext(ctx, `DELETE FROM scan_schedules WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("store.schedules.Delete: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (st *sqliteScheduleStore) CountByTarget(ctx context.Context, targetID string) (int, error) {
+	var n int
+	err := st.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM scan_schedules WHERE target_id = ?`, targetID).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("store.schedules.CountByTarget: %w", err)
+	}
+	return n, nil
+}
+
+// validateScheduleInput runs the declarative guards shared by Create and
+// Update: non-empty target+name, valid rrule, known tool names, non-zero
+// DTStart. Returns a typed error for each failure class so HTTP handlers
+// can surface specific status codes later (SCHED1.3).
+func validateScheduleInput(s *model.Schedule) error {
+	if s == nil {
+		return fmt.Errorf("schedule is nil")
+	}
+	if strings.TrimSpace(s.TargetID) == "" {
+		return fmt.Errorf("schedule.target_id is required")
+	}
+	if strings.TrimSpace(s.Name) == "" {
+		return fmt.Errorf("schedule.name is required")
+	}
+	if strings.TrimSpace(s.Timezone) == "" {
+		return fmt.Errorf("schedule.timezone is required")
+	}
+	if _, err := rrule.ValidateRRule(s.RRule); err != nil {
+		return err
+	}
+	if err := model.ValidateToolConfig(s.ToolConfig); err != nil {
+		return err
+	}
+	return nil
+}
+
+// marshalScheduleFields serializes the JSON columns (tool_config,
+// overrides, maintenance_window) for INSERT / UPDATE.
+func marshalScheduleFields(s *model.Schedule) (string, string, any, error) {
+	toolJSON, err := json.Marshal(s.ToolConfig)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("marshaling tool_config: %w", err)
+	}
+	overridesJSON, err := json.Marshal(s.Overrides)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("marshaling overrides: %w", err)
+	}
+	var mwJSON any
+	if s.MaintenanceWindow != nil {
+		b, err := json.Marshal(s.MaintenanceWindow)
+		if err != nil {
+			return "", "", nil, fmt.Errorf("marshaling maintenance_window: %w", err)
+		}
+		mwJSON = string(b)
+	}
+	return string(toolJSON), string(overridesJSON), mwJSON, nil
+}
+
+// rowScanner is satisfied by both *sql.Row and *sql.Rows — lets us share
+// the column-mapping logic between Get* and List*.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanSchedule(r rowScanner) (*model.Schedule, error) {
+	var (
+		s              model.Schedule
+		dtstart        sql.NullString
+		templateID     sql.NullString
+		toolJSON       string
+		overridesJSON  string
+		mwJSON         sql.NullString
+		enabled        int
+		nextRunAt      sql.NullString
+		lastRunAt      sql.NullString
+		lastRunStatus  sql.NullString
+		lastScanID     sql.NullString
+		createdAt      sql.NullString
+		updatedAt      sql.NullString
+	)
+	if err := r.Scan(
+		&s.ID, &s.TargetID, &s.Name, &s.RRule, &dtstart, &s.Timezone,
+		&templateID, &toolJSON, &overridesJSON, &mwJSON, &enabled,
+		&nextRunAt, &lastRunAt, &lastRunStatus, &lastScanID,
+		&createdAt, &updatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("scanning schedule: %w", err)
+	}
+	s.DTStart = parseTime(dtstart)
+	s.CreatedAt = parseTime(createdAt)
+	s.UpdatedAt = parseTime(updatedAt)
+	s.Enabled = enabled != 0
+	s.NextRunAt = parseTimePtr(nextRunAt)
+	s.LastRunAt = parseTimePtr(lastRunAt)
+	if templateID.Valid && templateID.String != "" {
+		v := templateID.String
+		s.TemplateID = &v
+	}
+	if lastScanID.Valid && lastScanID.String != "" {
+		v := lastScanID.String
+		s.LastScanID = &v
+	}
+	if lastRunStatus.Valid && lastRunStatus.String != "" {
+		v := model.ScheduleRunStatus(lastRunStatus.String)
+		s.LastRunStatus = &v
+	}
+	if toolJSON == "" {
+		s.ToolConfig = model.ToolConfig{}
+	} else {
+		if err := json.Unmarshal([]byte(toolJSON), &s.ToolConfig); err != nil {
+			return nil, fmt.Errorf("unmarshaling tool_config: %w", err)
+		}
+	}
+	if overridesJSON == "" {
+		s.Overrides = []string{}
+	} else {
+		if err := json.Unmarshal([]byte(overridesJSON), &s.Overrides); err != nil {
+			return nil, fmt.Errorf("unmarshaling overrides: %w", err)
+		}
+	}
+	if mwJSON.Valid && mwJSON.String != "" {
+		var mw model.MaintenanceWindow
+		if err := json.Unmarshal([]byte(mwJSON.String), &mw); err != nil {
+			return nil, fmt.Errorf("unmarshaling maintenance_window: %w", err)
+		}
+		s.MaintenanceWindow = &mw
+	}
+	return &s, nil
+}
+
+func queryManySchedules(ctx context.Context, db *sql.DB, query string, args ...any) ([]model.Schedule, error) {
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying schedules: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]model.Schedule, 0)
+	for rows.Next() {
+		s, err := scanSchedule(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *s)
+	}
+	return out, rows.Err()
+}
+
+// nullableString turns a *string into a driver argument that round-trips
+// as SQL NULL when nil or empty.
+func nullableString(v *string) any {
+	if v == nil || *v == "" {
+		return nil
+	}
+	return *v
+}
+
+func nullableRunStatus(v *model.ScheduleRunStatus) any {
+	if v == nil || *v == "" {
+		return nil
+	}
+	return string(*v)
+}
+
+// timePtrUTC serializes a *time.Time as a UTC-normalized RFC3339 string,
+// or SQL NULL when nil. Schedule-adjacent columns must use this rather
+// than timePtr so partial-index lookups (e.g. next_run_at ≤ now.UTC())
+// do not fall over on lexicographic comparisons between local-offset
+// and UTC ("Z") forms.
+func timePtrUTC(t *time.Time) any {
+	if t == nil {
+		return nil
+	}
+	return t.UTC().Format(timeFormat)
+}

--- a/internal/storage/schedules_test.go
+++ b/internal/storage/schedules_test.go
@@ -1,0 +1,237 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+func seedTarget(t *testing.T, s *SQLiteStore, value string) *model.Target {
+	t.Helper()
+	tgt := &model.Target{Value: value}
+	require.NoError(t, s.CreateTarget(context.Background(), tgt))
+	return tgt
+}
+
+func newSchedule(target *model.Target, name string) *model.Schedule {
+	return &model.Schedule{
+		TargetID: target.ID,
+		Name:     name,
+		RRule:    "FREQ=DAILY;BYHOUR=2",
+		DTStart:  time.Now().UTC(),
+		Timezone: "UTC",
+		ToolConfig: model.ToolConfig{
+			"nuclei": json.RawMessage(`{"severity":["critical"]}`),
+		},
+		Enabled: true,
+	}
+}
+
+func TestScheduleStore_CRUDRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Schedules()
+	ctx := context.Background()
+
+	tgt := seedTarget(t, s, "example.com")
+	sched := newSchedule(tgt, "default")
+
+	require.NoError(t, store.Create(ctx, sched))
+	assert.NotEmpty(t, sched.ID)
+
+	got, err := store.Get(ctx, sched.ID)
+	require.NoError(t, err)
+	assert.Equal(t, sched.TargetID, got.TargetID)
+	assert.Equal(t, "default", got.Name)
+	assert.Equal(t, "FREQ=DAILY;BYHOUR=2", got.RRule)
+	assert.True(t, got.Enabled)
+	assert.NotNil(t, got.ToolConfig["nuclei"])
+
+	got.RRule = "FREQ=HOURLY"
+	got.Overrides = []string{"rrule"}
+	require.NoError(t, store.Update(ctx, got))
+
+	reread, err := store.Get(ctx, sched.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "FREQ=HOURLY", reread.RRule)
+	assert.Equal(t, []string{"rrule"}, reread.Overrides)
+
+	byName, err := store.GetByTargetAndName(ctx, tgt.ID, "default")
+	require.NoError(t, err)
+	assert.Equal(t, sched.ID, byName.ID)
+
+	require.NoError(t, store.Delete(ctx, sched.ID))
+	_, err = store.Get(ctx, sched.ID)
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+func TestScheduleStore_UniqueTargetName(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Schedules()
+	ctx := context.Background()
+	tgt := seedTarget(t, s, "example.com")
+
+	require.NoError(t, store.Create(ctx, newSchedule(tgt, "default")))
+	err := store.Create(ctx, newSchedule(tgt, "default"))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAlreadyExists))
+}
+
+// seedRawTemplate inserts a minimal scan_templates row via raw SQL so
+// schedule tests can exercise template_id joins without depending on
+// the TemplateStore (which lands in the next commit).
+func seedRawTemplate(t *testing.T, s *SQLiteStore, id, name string) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.Exec(
+		`INSERT INTO scan_templates (id, name, description, rrule, timezone, tool_config, is_system, created_at, updated_at)
+		 VALUES (?, ?, '', 'FREQ=DAILY', 'UTC', '{}', 0, ?, ?)`,
+		id, name, now, now)
+	require.NoError(t, err)
+}
+
+func TestScheduleStore_ListByTargetAndTemplate(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Schedules()
+	ctx := context.Background()
+
+	tgt := seedTarget(t, s, "example.com")
+	tmplID := "tmpl-01"
+	seedRawTemplate(t, s, tmplID, "daily")
+
+	s1 := newSchedule(tgt, "a")
+	s1.TemplateID = &tmplID
+	require.NoError(t, store.Create(ctx, s1))
+
+	s2 := newSchedule(tgt, "b")
+	require.NoError(t, store.Create(ctx, s2))
+
+	byTarget, err := store.ListByTarget(ctx, tgt.ID)
+	require.NoError(t, err)
+	assert.Len(t, byTarget, 2)
+
+	byTemplate, err := store.ListByTemplate(ctx, tmplID)
+	require.NoError(t, err)
+	assert.Len(t, byTemplate, 1)
+	assert.Equal(t, "a", byTemplate[0].Name)
+
+	count, err := store.CountByTarget(ctx, tgt.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestScheduleStore_ListDue(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Schedules()
+	ctx := context.Background()
+	tgt := seedTarget(t, s, "example.com")
+
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+
+	duePast := newSchedule(tgt, "due-past")
+	duePast.NextRunAt = &past
+	require.NoError(t, store.Create(ctx, duePast))
+
+	notYet := newSchedule(tgt, "not-yet")
+	notYet.NextRunAt = &future
+	require.NoError(t, store.Create(ctx, notYet))
+
+	disabled := newSchedule(tgt, "disabled")
+	disabled.Enabled = false
+	disabled.NextRunAt = &past
+	require.NoError(t, store.Create(ctx, disabled))
+
+	due, err := store.ListDue(ctx, time.Now(), 10)
+	require.NoError(t, err)
+	require.Len(t, due, 1)
+	assert.Equal(t, "due-past", due[0].Name)
+}
+
+func TestScheduleStore_SetNextRunAtAndRecordRun(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Schedules()
+	ctx := context.Background()
+	tgt := seedTarget(t, s, "example.com")
+	sched := newSchedule(tgt, "default")
+	require.NoError(t, store.Create(ctx, sched))
+
+	next := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
+	require.NoError(t, store.SetNextRunAt(ctx, sched.ID, &next))
+
+	got, err := store.Get(ctx, sched.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.NextRunAt)
+	assert.WithinDuration(t, next, *got.NextRunAt, time.Second)
+
+	// RecordRun sets last_scan_id which has an FK → scans(id). Create a
+	// real scan row so the FK resolves.
+	scan := &model.Scan{TargetID: tgt.ID, Type: model.ScanTypeFull, Status: model.ScanStatusCompleted}
+	require.NoError(t, s.CreateScan(ctx, scan))
+
+	require.NoError(t, store.RecordRun(ctx, sched.ID, model.ScheduleRunSuccess, &scan.ID, time.Now()))
+	got, err = store.Get(ctx, sched.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.LastRunStatus)
+	assert.Equal(t, model.ScheduleRunSuccess, *got.LastRunStatus)
+	assert.Equal(t, scan.ID, *got.LastScanID)
+}
+
+func TestScheduleStore_ValidatesOnCreate(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Schedules()
+	ctx := context.Background()
+	tgt := seedTarget(t, s, "example.com")
+
+	bad := newSchedule(tgt, "bad")
+	bad.RRule = "FREQ=SECONDLY"
+	err := store.Create(ctx, bad)
+	require.Error(t, err)
+
+	unknownTool := newSchedule(tgt, "amass-schedule")
+	unknownTool.ToolConfig = model.ToolConfig{"amass": json.RawMessage(`{}`)}
+	err = store.Create(ctx, unknownTool)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, model.ErrUnknownTool))
+}
+
+func TestScheduleStore_CascadeOnTargetDelete(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Schedules()
+	ctx := context.Background()
+	tgt := seedTarget(t, s, "example.com")
+	require.NoError(t, store.Create(ctx, newSchedule(tgt, "default")))
+
+	require.NoError(t, s.DeleteTarget(ctx, tgt.ID))
+
+	schedules, err := store.ListByTarget(ctx, tgt.ID)
+	require.NoError(t, err)
+	assert.Empty(t, schedules)
+}
+
+func TestScheduleStore_NullsTemplateOnTemplateDelete(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Schedules()
+	ctx := context.Background()
+	tgt := seedTarget(t, s, "example.com")
+
+	tmplID := "tmpl-01"
+	seedRawTemplate(t, s, tmplID, "daily")
+
+	sched := newSchedule(tgt, "default")
+	sched.TemplateID = &tmplID
+	require.NoError(t, store.Create(ctx, sched))
+
+	_, err := s.db.ExecContext(ctx, `DELETE FROM scan_templates WHERE id = ?`, tmplID)
+	require.NoError(t, err)
+
+	got, err := store.Get(ctx, sched.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got.TemplateID)
+}

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -32,10 +32,10 @@ func TestNewSQLiteStore(t *testing.T) {
 	}
 
 	// Verify agent_meta seeded. schema_version tracks the latest applied
-	// migration: 003 bumps it to "3".
+	// migration: 0004 bumps it to "4".
 	v, err := s.GetMeta(ctx, "schema_version")
 	require.NoError(t, err)
-	assert.Equal(t, "3", v)
+	assert.Equal(t, "4", v)
 }
 
 func TestTargetCRUD(t *testing.T) {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -202,6 +202,17 @@ func (s *SQLiteStore) runMigrations() error {
 		}
 	}
 
+	schemaVersion, _ = s.getSchemaVersion()
+	if schemaVersion < 4 {
+		m004, err := migrationsFS.ReadFile("migrations/0004_first_class_schedules.sql")
+		if err != nil {
+			return fmt.Errorf("reading migration 0004: %w", err)
+		}
+		if _, err = s.db.Exec(string(m004)); err != nil {
+			return fmt.Errorf("executing migration 0004: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/storage/templates.go
+++ b/internal/storage/templates.go
@@ -1,0 +1,223 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/rrule"
+)
+
+// TemplateStore is the persistence interface for reusable scan
+// templates. Consumed by the daemon (cascade resolver), handlers, and
+// the CLI, so it lives at a package boundary.
+type TemplateStore interface {
+	Create(ctx context.Context, t *model.Template) error
+	Get(ctx context.Context, id string) (*model.Template, error)
+	GetByName(ctx context.Context, name string) (*model.Template, error)
+	List(ctx context.Context) ([]model.Template, error)
+	Update(ctx context.Context, t *model.Template) error
+	Delete(ctx context.Context, id string) error
+}
+
+// Templates returns a TemplateStore backed by this SQLiteStore.
+func (s *SQLiteStore) Templates() TemplateStore {
+	return &sqliteTemplateStore{db: s.db}
+}
+
+type sqliteTemplateStore struct {
+	db *sql.DB
+}
+
+const templateColumns = `id, name, description, rrule, timezone, tool_config,
+  maintenance_window, is_system, created_at, updated_at`
+
+func (st *sqliteTemplateStore) Create(ctx context.Context, t *model.Template) error {
+	if err := validateTemplateInput(t); err != nil {
+		return err
+	}
+	if t.ID == "" {
+		t.ID = uuid.New().String()
+	}
+	now := time.Now().UTC()
+	t.CreatedAt = now
+	t.UpdatedAt = now
+	if t.ToolConfig == nil {
+		t.ToolConfig = model.ToolConfig{}
+	}
+
+	toolJSON, mwJSON, err := marshalTemplateFields(t)
+	if err != nil {
+		return err
+	}
+
+	_, err = st.db.ExecContext(ctx,
+		`INSERT INTO scan_templates (`+templateColumns+`)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		t.ID, t.Name, t.Description, t.RRule, t.Timezone, toolJSON, mwJSON,
+		boolToInt(t.IsSystem),
+		t.CreatedAt.Format(timeFormat), t.UpdatedAt.Format(timeFormat),
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return fmt.Errorf("%w: template %q", ErrAlreadyExists, t.Name)
+		}
+		return fmt.Errorf("store.templates.Create: %w", err)
+	}
+	return nil
+}
+
+func (st *sqliteTemplateStore) Get(ctx context.Context, id string) (*model.Template, error) {
+	row := st.db.QueryRowContext(ctx,
+		`SELECT `+templateColumns+` FROM scan_templates WHERE id = ?`, id)
+	return scanTemplate(row)
+}
+
+func (st *sqliteTemplateStore) GetByName(ctx context.Context, name string) (*model.Template, error) {
+	row := st.db.QueryRowContext(ctx,
+		`SELECT `+templateColumns+` FROM scan_templates WHERE name = ?`, name)
+	return scanTemplate(row)
+}
+
+func (st *sqliteTemplateStore) List(ctx context.Context) ([]model.Template, error) {
+	rows, err := st.db.QueryContext(ctx,
+		`SELECT `+templateColumns+` FROM scan_templates ORDER BY name ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("store.templates.List: %w", err)
+	}
+	defer rows.Close()
+	out := make([]model.Template, 0)
+	for rows.Next() {
+		t, err := scanTemplate(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *t)
+	}
+	return out, rows.Err()
+}
+
+func (st *sqliteTemplateStore) Update(ctx context.Context, t *model.Template) error {
+	if err := validateTemplateInput(t); err != nil {
+		return err
+	}
+	t.UpdatedAt = time.Now().UTC()
+	if t.ToolConfig == nil {
+		t.ToolConfig = model.ToolConfig{}
+	}
+
+	toolJSON, mwJSON, err := marshalTemplateFields(t)
+	if err != nil {
+		return err
+	}
+
+	res, err := st.db.ExecContext(ctx,
+		`UPDATE scan_templates SET
+		   name = ?, description = ?, rrule = ?, timezone = ?,
+		   tool_config = ?, maintenance_window = ?, is_system = ?,
+		   updated_at = ?
+		 WHERE id = ?`,
+		t.Name, t.Description, t.RRule, t.Timezone, toolJSON, mwJSON,
+		boolToInt(t.IsSystem), t.UpdatedAt.Format(timeFormat), t.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("store.templates.Update: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (st *sqliteTemplateStore) Delete(ctx context.Context, id string) error {
+	res, err := st.db.ExecContext(ctx, `DELETE FROM scan_templates WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("store.templates.Delete: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func validateTemplateInput(t *model.Template) error {
+	if t == nil {
+		return fmt.Errorf("template is nil")
+	}
+	if strings.TrimSpace(t.Name) == "" {
+		return fmt.Errorf("template.name is required")
+	}
+	if strings.TrimSpace(t.Timezone) == "" {
+		return fmt.Errorf("template.timezone is required")
+	}
+	if _, err := rrule.ValidateRRule(t.RRule); err != nil {
+		return err
+	}
+	if err := model.ValidateToolConfig(t.ToolConfig); err != nil {
+		return err
+	}
+	return nil
+}
+
+func marshalTemplateFields(t *model.Template) (string, any, error) {
+	toolJSON, err := json.Marshal(t.ToolConfig)
+	if err != nil {
+		return "", nil, fmt.Errorf("marshaling tool_config: %w", err)
+	}
+	var mwJSON any
+	if t.MaintenanceWindow != nil {
+		b, err := json.Marshal(t.MaintenanceWindow)
+		if err != nil {
+			return "", nil, fmt.Errorf("marshaling maintenance_window: %w", err)
+		}
+		mwJSON = string(b)
+	}
+	return string(toolJSON), mwJSON, nil
+}
+
+func scanTemplate(r rowScanner) (*model.Template, error) {
+	var (
+		t         model.Template
+		toolJSON  string
+		mwJSON    sql.NullString
+		isSystem  int
+		createdAt sql.NullString
+		updatedAt sql.NullString
+	)
+	if err := r.Scan(
+		&t.ID, &t.Name, &t.Description, &t.RRule, &t.Timezone, &toolJSON, &mwJSON,
+		&isSystem, &createdAt, &updatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("scanning template: %w", err)
+	}
+	t.IsSystem = isSystem != 0
+	t.CreatedAt = parseTime(createdAt)
+	t.UpdatedAt = parseTime(updatedAt)
+	if toolJSON == "" {
+		t.ToolConfig = model.ToolConfig{}
+	} else {
+		if err := json.Unmarshal([]byte(toolJSON), &t.ToolConfig); err != nil {
+			return nil, fmt.Errorf("unmarshaling tool_config: %w", err)
+		}
+	}
+	if mwJSON.Valid && mwJSON.String != "" {
+		var mw model.MaintenanceWindow
+		if err := json.Unmarshal([]byte(mwJSON.String), &mw); err != nil {
+			return nil, fmt.Errorf("unmarshaling maintenance_window: %w", err)
+		}
+		t.MaintenanceWindow = &mw
+	}
+	return &t, nil
+}

--- a/internal/storage/templates.go
+++ b/internal/storage/templates.go
@@ -92,7 +92,7 @@ func (st *sqliteTemplateStore) List(ctx context.Context) ([]model.Template, erro
 	if err != nil {
 		return nil, fmt.Errorf("store.templates.List: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	out := make([]model.Template, 0)
 	for rows.Next() {
 		t, err := scanTemplate(rows)

--- a/internal/storage/templates.go
+++ b/internal/storage/templates.go
@@ -33,7 +33,7 @@ func (s *SQLiteStore) Templates() TemplateStore {
 }
 
 type sqliteTemplateStore struct {
-	db *sql.DB
+	db dbtx
 }
 
 const templateColumns = `id, name, description, rrule, timezone, tool_config,

--- a/internal/storage/templates_test.go
+++ b/internal/storage/templates_test.go
@@ -1,0 +1,97 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+func newTemplate(name string) *model.Template {
+	return &model.Template{
+		Name:        name,
+		Description: "desc",
+		RRule:       "FREQ=DAILY;BYHOUR=2",
+		Timezone:    "UTC",
+		ToolConfig: model.ToolConfig{
+			"nuclei": json.RawMessage(`{"severity":["critical","high"]}`),
+		},
+		MaintenanceWindow: &model.MaintenanceWindow{
+			RRule:       "FREQ=DAILY;BYHOUR=2",
+			DurationSec: 3600,
+			Timezone:    "UTC",
+		},
+	}
+}
+
+func TestTemplateStore_CRUDRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Templates()
+	ctx := context.Background()
+
+	tmpl := newTemplate("prod-critical")
+	require.NoError(t, store.Create(ctx, tmpl))
+	assert.NotEmpty(t, tmpl.ID)
+
+	got, err := store.Get(ctx, tmpl.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-critical", got.Name)
+	assert.Equal(t, "FREQ=DAILY;BYHOUR=2", got.RRule)
+	require.NotNil(t, got.MaintenanceWindow)
+	assert.Equal(t, 3600, got.MaintenanceWindow.DurationSec)
+	assert.Contains(t, got.ToolConfig, "nuclei")
+
+	byName, err := store.GetByName(ctx, "prod-critical")
+	require.NoError(t, err)
+	assert.Equal(t, tmpl.ID, byName.ID)
+
+	got.Description = "updated"
+	got.RRule = "FREQ=HOURLY"
+	require.NoError(t, store.Update(ctx, got))
+
+	reread, err := store.Get(ctx, tmpl.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "updated", reread.Description)
+	assert.Equal(t, "FREQ=HOURLY", reread.RRule)
+
+	list, err := store.List(ctx)
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+
+	require.NoError(t, store.Delete(ctx, tmpl.ID))
+	_, err = store.Get(ctx, tmpl.ID)
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+func TestTemplateStore_UniqueName(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Templates()
+	ctx := context.Background()
+
+	require.NoError(t, store.Create(ctx, newTemplate("prod-critical")))
+	err := store.Create(ctx, newTemplate("prod-critical"))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAlreadyExists))
+}
+
+func TestTemplateStore_ValidatesOnCreate(t *testing.T) {
+	s := newTestStore(t)
+	store := s.Templates()
+	ctx := context.Background()
+
+	bad := newTemplate("bad")
+	bad.RRule = "FREQ=SECONDLY"
+	err := store.Create(ctx, bad)
+	require.Error(t, err)
+
+	unknown := newTemplate("unknown-tool")
+	unknown.ToolConfig = model.ToolConfig{"amass": json.RawMessage(`{}`)}
+	err = store.Create(ctx, unknown)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, model.ErrUnknownTool))
+}


### PR DESCRIPTION
## Review Checklist (reviewer: paste into PR)

- [ ] Migration runs green on fresh DB.
- [ ] Migration runs green on a DB with populated scans/targets/assets/findings.
- [ ] All 5 stores have CRUD round-trip tests.
- [ ] FK cascade + null tests present.
- [ ] CHECK + UNIQUE constraints tested.
- [ ] Cascade resolver tests cover the SPEC-SCHED1 R20 acceptance example.
- [ ] RRULE validator covers Tenable + Acunetix example sets.
- [ ] Legacy migration function has golden + idempotency + rollback tests.
- [ ] Legacy migration function is NOT called from daemon boot (grep confirms).
- [ ] `go vet`, lint, race tests green.
- [ ] No changes to `scheduler.go`, `webui/*`, or `cli/schedule.go`.
- [ ] Binary size delta ≤ 2%.

---

### Deviations from the spec file manifest

- **RRULE validator location.** Spec R5 lists `internal/cli/rrule_validator.go`. The validator moved to a new `internal/rrule/` package because `internal/storage` needs to call it (spec R6 acceptance: "All Create and Update methods call ValidateRRule"), and the existing import graph already has `internal/cli` depending on `internal/storage` — locating the validator under `cli` creates a cycle. The package surface is functionally identical.
- **IDs are `string`, not `ulid.ULID`.** Matches the existing model convention (Target, Scan, Asset, etc. all use `string`). SQLite TEXT columns accept either scheme; ULID generation can be layered on top without a type change.