### PR TITLE
sched1.2a: scheduler primitives (library only)

### DIFF
--- a/internal/daemon/intervalsched/blackout.go
+++ b/internal/daemon/intervalsched/blackout.go
@@ -1,0 +1,250 @@
+package intervalsched
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	extrrule "github.com/teambition/rrule-go"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// cacheTTL controls how stale a BlackoutEvaluator's snapshot may be
+// before IsActive triggers an implicit Refresh. Callers on hot paths
+// should Refresh explicitly rather than relying on the implicit TTL.
+const cacheTTL = 30 * time.Second
+
+// blackoutHorizonPast is how far back IsActive scans for occurrences
+// whose duration still covers `at`. A blackout that started N seconds
+// ago is active at `at` only if N < duration; scanning back 7 days
+// accommodates multi-day weekend windows.
+const blackoutHorizonPast = 7 * 24 * time.Hour
+
+// BlackoutEvaluator answers "is target T subject to an active blackout
+// at time at?". It caches the current set of enabled windows (global +
+// per-target) plus the parsed RRule for each. Refresh rebuilds the
+// cache from the store.
+//
+// The evaluator is safe for concurrent use. When IsActive observes a
+// stale or never-populated cache it does an implicit Refresh behind the
+// lock — callers on hot paths should Refresh explicitly before heavy
+// batches to keep that work off the evaluation path.
+type BlackoutEvaluator struct {
+	store storage.BlackoutStore
+
+	mu           sync.Mutex
+	global       []cachedWindow
+	perTarget    map[string][]cachedWindow
+	lastRefresh  time.Time
+	refreshErr   error
+	populatedOK  bool
+}
+
+type cachedWindow struct {
+	window model.BlackoutWindow
+	rule   *extrrule.RRule
+	loc    *time.Location
+}
+
+// NewBlackoutEvaluator constructs an evaluator backed by the given
+// store. Callers must Refresh at least once; IsActive / NextWindowEnd
+// will do so lazily if needed.
+func NewBlackoutEvaluator(store storage.BlackoutStore) *BlackoutEvaluator {
+	return &BlackoutEvaluator{
+		store:     store,
+		perTarget: map[string][]cachedWindow{},
+	}
+}
+
+// Refresh reloads all enabled blackout windows from the store and
+// re-parses their RRULEs. Safe to call concurrently with IsActive /
+// NextWindowEnd.
+func (e *BlackoutEvaluator) Refresh(ctx context.Context) error {
+	windows, err := e.store.List(ctx)
+	if err != nil {
+		e.mu.Lock()
+		e.refreshErr = err
+		e.mu.Unlock()
+		return fmt.Errorf("listing blackouts: %w", err)
+	}
+
+	global := make([]cachedWindow, 0)
+	perTarget := map[string][]cachedWindow{}
+
+	for _, w := range windows {
+		if !w.Enabled {
+			continue
+		}
+		cached, err := buildCachedWindow(w)
+		if err != nil {
+			// Skip broken windows rather than poisoning the cache. In
+			// production they can't land — the store validates on
+			// Create/Update — but defensive skip keeps us honest.
+			continue
+		}
+		switch w.Scope {
+		case model.BlackoutScopeGlobal:
+			global = append(global, cached)
+		case model.BlackoutScopeTarget:
+			if w.TargetID == nil || *w.TargetID == "" {
+				continue
+			}
+			perTarget[*w.TargetID] = append(perTarget[*w.TargetID], cached)
+		}
+	}
+
+	e.mu.Lock()
+	e.global = global
+	e.perTarget = perTarget
+	e.lastRefresh = time.Now()
+	e.refreshErr = nil
+	e.populatedOK = true
+	e.mu.Unlock()
+	return nil
+}
+
+func buildCachedWindow(w model.BlackoutWindow) (cachedWindow, error) {
+	loc, err := time.LoadLocation(w.Timezone)
+	if err != nil {
+		return cachedWindow{}, fmt.Errorf("loading timezone %q: %w", w.Timezone, err)
+	}
+	opt, err := extrrule.StrToROption(w.RRule)
+	if err != nil {
+		return cachedWindow{}, fmt.Errorf("parsing rrule: %w", err)
+	}
+	if opt.Dtstart.IsZero() {
+		opt.Dtstart = w.CreatedAt.In(loc)
+	} else {
+		opt.Dtstart = opt.Dtstart.In(loc)
+	}
+	rule, err := extrrule.NewRRule(*opt)
+	if err != nil {
+		return cachedWindow{}, fmt.Errorf("building rrule: %w", err)
+	}
+	return cachedWindow{window: w, rule: rule, loc: loc}, nil
+}
+
+// IsActive reports whether targetID is inside a blackout window at
+// time `at`. Global windows are evaluated first; the first hit wins.
+// Returns (false, nil) otherwise.
+//
+// Window boundaries are [start, start+duration): a window starting at
+// 12:00 with duration 1h is active at 12:00:00 but not at 13:00:00.
+func (e *BlackoutEvaluator) IsActive(targetID string, at time.Time) (bool, *model.BlackoutWindow) {
+	e.ensureFreshLocked()
+
+	e.mu.Lock()
+	globals := e.global
+	targetWindows := append([]cachedWindow(nil), e.perTarget[targetID]...)
+	e.mu.Unlock()
+
+	if w := firstActive(globals, at); w != nil {
+		return true, w
+	}
+	if w := firstActive(targetWindows, at); w != nil {
+		return true, w
+	}
+	return false, nil
+}
+
+// NextWindowEnd returns the end time of the currently-active blackout
+// window for targetID at `at`. Returns nil when no window is active.
+func (e *BlackoutEvaluator) NextWindowEnd(targetID string, at time.Time) *time.Time {
+	active, w := e.IsActive(targetID, at)
+	if !active || w == nil {
+		return nil
+	}
+	end := findActiveEnd(e, targetID, *w, at)
+	return &end
+}
+
+func (e *BlackoutEvaluator) ensureFreshLocked() {
+	e.mu.Lock()
+	stale := !e.populatedOK || time.Since(e.lastRefresh) > cacheTTL
+	e.mu.Unlock()
+	if !stale {
+		return
+	}
+	_ = e.Refresh(context.Background())
+}
+
+// firstActive returns the first window in `windows` that covers `at`,
+// or nil. The returned pointer references a copy of the stored
+// model.BlackoutWindow.
+func firstActive(windows []cachedWindow, at time.Time) *model.BlackoutWindow {
+	for i := range windows {
+		if occurrenceCovers(windows[i], at) {
+			w := windows[i].window
+			return &w
+		}
+	}
+	return nil
+}
+
+// occurrenceCovers reports whether any occurrence of cw covers `at`.
+func occurrenceCovers(cw cachedWindow, at time.Time) bool {
+	dur := time.Duration(cw.window.DurationSec) * time.Second
+	if dur <= 0 {
+		return false
+	}
+	atInTZ := at.In(cw.loc)
+	lower := atInTZ.Add(-blackoutHorizonPast)
+	// Between(lower, atInTZ+1ns, true) returns every occurrence whose
+	// start is inside the inclusive range. Any such occurrence whose
+	// start+duration covers `at` makes the window active.
+	upper := atInTZ.Add(time.Nanosecond)
+	for _, t := range cw.rule.Between(lower, upper, true) {
+		end := t.Add(dur)
+		if (atInTZ.Equal(t) || atInTZ.After(t)) && atInTZ.Before(end) {
+			return true
+		}
+	}
+	return false
+}
+
+// findActiveEnd scans cached windows for `targetID` (and globals) to
+// locate the currently-active occurrence of `w` and return its end
+// time. If no occurrence is found (unexpected — caller just confirmed
+// one), it falls back to at + 1s to avoid infinite loops upstream.
+func findActiveEnd(e *BlackoutEvaluator, targetID string, w model.BlackoutWindow, at time.Time) time.Time {
+	e.mu.Lock()
+	var candidates []cachedWindow
+	for i := range e.global {
+		if e.global[i].window.ID == w.ID {
+			candidates = append(candidates, e.global[i])
+		}
+	}
+	for i := range e.perTarget[targetID] {
+		if e.perTarget[targetID][i].window.ID == w.ID {
+			candidates = append(candidates, e.perTarget[targetID][i])
+		}
+	}
+	e.mu.Unlock()
+
+	for _, cw := range candidates {
+		if end, ok := activeOccurrenceEnd(cw, at); ok {
+			return end
+		}
+	}
+	return at.Add(time.Second)
+}
+
+func activeOccurrenceEnd(cw cachedWindow, at time.Time) (time.Time, bool) {
+	dur := time.Duration(cw.window.DurationSec) * time.Second
+	if dur <= 0 {
+		return time.Time{}, false
+	}
+	atInTZ := at.In(cw.loc)
+	lower := atInTZ.Add(-blackoutHorizonPast)
+	upper := atInTZ.Add(time.Nanosecond)
+	for _, t := range cw.rule.Between(lower, upper, true) {
+		end := t.Add(dur)
+		if (atInTZ.Equal(t) || atInTZ.After(t)) && atInTZ.Before(end) {
+			return end, true
+		}
+	}
+	return time.Time{}, false
+}

--- a/internal/daemon/intervalsched/blackout.go
+++ b/internal/daemon/intervalsched/blackout.go
@@ -35,12 +35,12 @@ const blackoutHorizonPast = 7 * 24 * time.Hour
 type BlackoutEvaluator struct {
 	store storage.BlackoutStore
 
-	mu           sync.Mutex
-	global       []cachedWindow
-	perTarget    map[string][]cachedWindow
-	lastRefresh  time.Time
-	refreshErr   error
-	populatedOK  bool
+	mu          sync.Mutex
+	global      []cachedWindow
+	perTarget   map[string][]cachedWindow
+	lastRefresh time.Time
+	refreshErr  error
+	populatedOK bool
 }
 
 type cachedWindow struct {

--- a/internal/daemon/intervalsched/blackout_test.go
+++ b/internal/daemon/intervalsched/blackout_test.go
@@ -1,0 +1,305 @@
+package intervalsched
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// fakeBlackoutStore is an in-memory implementation of
+// storage.BlackoutStore sufficient for the evaluator tests. Only the
+// methods the evaluator consumes are real; the rest return errors.
+type fakeBlackoutStore struct {
+	mu      sync.Mutex
+	windows []model.BlackoutWindow
+}
+
+func newFakeStore() *fakeBlackoutStore { return &fakeBlackoutStore{} }
+
+func (f *fakeBlackoutStore) set(ws []model.BlackoutWindow) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.windows = append([]model.BlackoutWindow(nil), ws...)
+}
+
+func (f *fakeBlackoutStore) Create(ctx context.Context, b *model.BlackoutWindow) error {
+	return errors.New("not implemented")
+}
+func (f *fakeBlackoutStore) Get(ctx context.Context, id string) (*model.BlackoutWindow, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeBlackoutStore) List(ctx context.Context) ([]model.BlackoutWindow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]model.BlackoutWindow(nil), f.windows...), nil
+}
+func (f *fakeBlackoutStore) ListByScope(ctx context.Context, scope model.BlackoutScope) ([]model.BlackoutWindow, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeBlackoutStore) ListByTarget(ctx context.Context, targetID string) ([]model.BlackoutWindow, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeBlackoutStore) ListActive(ctx context.Context, targetID string) ([]model.BlackoutWindow, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeBlackoutStore) Update(ctx context.Context, b *model.BlackoutWindow) error {
+	return errors.New("not implemented")
+}
+func (f *fakeBlackoutStore) Delete(ctx context.Context, id string) error {
+	return errors.New("not implemented")
+}
+
+// ensure fakeBlackoutStore satisfies the interface at compile time.
+var _ storage.BlackoutStore = (*fakeBlackoutStore)(nil)
+
+func mustRefresh(t *testing.T, e *BlackoutEvaluator) {
+	t.Helper()
+	if err := e.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+}
+
+// mkWindow builds a BlackoutWindow with sensible defaults. Caller
+// supplies scope/target/rrule/duration/tz.
+func mkWindow(id string, scope model.BlackoutScope, targetID *string, rrule string, dur time.Duration, tz string, dtstart time.Time) model.BlackoutWindow {
+	return model.BlackoutWindow{
+		ID:          id,
+		Scope:       scope,
+		TargetID:    targetID,
+		Name:        "w-" + id,
+		RRule:       rrule,
+		DurationSec: int(dur / time.Second),
+		Timezone:    tz,
+		Enabled:     true,
+		CreatedAt:   dtstart,
+		UpdatedAt:   dtstart,
+	}
+}
+
+func TestBlackoutEvaluator_NoWindows(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	e := NewBlackoutEvaluator(store)
+	mustRefresh(t, e)
+
+	if active, w := e.IsActive("t1", time.Now()); active || w != nil {
+		t.Fatalf("expected inactive, got active=%v w=%v", active, w)
+	}
+}
+
+func TestBlackoutEvaluator_GlobalActive(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	// DAILY BYHOUR=0 window with 24h duration → always active.
+	dtstart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	store.set([]model.BlackoutWindow{
+		mkWindow("g1", model.BlackoutScopeGlobal, nil,
+			fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=DAILY;BYHOUR=0;BYMINUTE=0;BYSECOND=0", dtstart.Format("20060102T150405Z")),
+			24*time.Hour, "UTC", dtstart),
+	})
+	e := NewBlackoutEvaluator(store)
+	mustRefresh(t, e)
+
+	now := time.Date(2026, 4, 19, 12, 30, 0, 0, time.UTC)
+	for _, targetID := range []string{"t1", "t2", "whatever"} {
+		if active, w := e.IsActive(targetID, now); !active || w == nil {
+			t.Fatalf("target %s: expected active, got active=%v w=%v", targetID, active, w)
+		}
+	}
+}
+
+func TestBlackoutEvaluator_TargetScoped(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	dtstart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	targetID := "T"
+	store.set([]model.BlackoutWindow{
+		mkWindow("t1", model.BlackoutScopeTarget, &targetID,
+			fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=DAILY;BYHOUR=0", dtstart.Format("20060102T150405Z")),
+			24*time.Hour, "UTC", dtstart),
+	})
+	e := NewBlackoutEvaluator(store)
+	mustRefresh(t, e)
+
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	if active, _ := e.IsActive("T", now); !active {
+		t.Fatalf("T should be active")
+	}
+	if active, _ := e.IsActive("U", now); active {
+		t.Fatalf("U should not be active")
+	}
+}
+
+func TestBlackoutEvaluator_BothActive(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	dtstart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	targetID := "T"
+	store.set([]model.BlackoutWindow{
+		mkWindow("g", model.BlackoutScopeGlobal, nil,
+			fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=DAILY;BYHOUR=0", dtstart.Format("20060102T150405Z")),
+			24*time.Hour, "UTC", dtstart),
+		mkWindow("tt", model.BlackoutScopeTarget, &targetID,
+			fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=DAILY;BYHOUR=0", dtstart.Format("20060102T150405Z")),
+			24*time.Hour, "UTC", dtstart),
+	})
+	e := NewBlackoutEvaluator(store)
+	mustRefresh(t, e)
+
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	active, w := e.IsActive("T", now)
+	if !active || w == nil {
+		t.Fatalf("expected active")
+	}
+	if w.ID != "g" {
+		t.Fatalf("expected global to win tiebreak; got %s", w.ID)
+	}
+}
+
+func TestBlackoutEvaluator_Boundary(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	// DTSTART at 12:00, duration 1h.
+	dtstart := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	store.set([]model.BlackoutWindow{
+		mkWindow("g", model.BlackoutScopeGlobal, nil,
+			fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=DAILY;BYHOUR=12;BYMINUTE=0;BYSECOND=0", dtstart.Format("20060102T150405Z")),
+			time.Hour, "UTC", dtstart),
+	})
+	e := NewBlackoutEvaluator(store)
+	mustRefresh(t, e)
+
+	at12 := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	at1255 := time.Date(2026, 4, 19, 12, 55, 0, 0, time.UTC)
+	at13 := time.Date(2026, 4, 19, 13, 0, 0, 0, time.UTC)
+
+	if active, _ := e.IsActive("t", at12); !active {
+		t.Fatalf("12:00 should be active (inclusive start)")
+	}
+	if active, _ := e.IsActive("t", at1255); !active {
+		t.Fatalf("12:55 should be active")
+	}
+	if active, _ := e.IsActive("t", at13); active {
+		t.Fatalf("13:00 should NOT be active (exclusive end)")
+	}
+}
+
+func TestBlackoutEvaluator_WeeklyRRULE(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	// Saturday 00:00 UTC, 48h = covers Sat + Sun.
+	dtstart := time.Date(2026, 4, 4, 0, 0, 0, 0, time.UTC) // saturday
+	store.set([]model.BlackoutWindow{
+		mkWindow("g", model.BlackoutScopeGlobal, nil,
+			fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=WEEKLY;BYDAY=SA", dtstart.Format("20060102T150405Z")),
+			48*time.Hour, "UTC", dtstart),
+	})
+	e := NewBlackoutEvaluator(store)
+	mustRefresh(t, e)
+
+	// Saturday mid-day → active.
+	sat := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	sun := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	mon := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	fri := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	for _, tc := range []struct {
+		name string
+		at   time.Time
+		want bool
+	}{
+		{"sat", sat, true},
+		{"sun", sun, true},
+		{"mon", mon, false},
+		{"fri", fri, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			active, _ := e.IsActive("t", tc.at)
+			if active != tc.want {
+				t.Fatalf("%s: want active=%v got %v", tc.name, tc.want, active)
+			}
+		})
+	}
+}
+
+func TestBlackoutEvaluator_RefreshInvalidates(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	e := NewBlackoutEvaluator(store)
+	mustRefresh(t, e)
+
+	dtstart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	if active, _ := e.IsActive("t", now); active {
+		t.Fatalf("unexpected active on empty store")
+	}
+
+	// Populate after refresh — should not yet be visible.
+	store.set([]model.BlackoutWindow{
+		mkWindow("g", model.BlackoutScopeGlobal, nil,
+			fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=DAILY;BYHOUR=0", dtstart.Format("20060102T150405Z")),
+			24*time.Hour, "UTC", dtstart),
+	})
+
+	// Immediately after populating, the cache is still fresh (populatedOK=true, <30s).
+	if active, _ := e.IsActive("t", now); active {
+		t.Fatalf("store change should not be visible without Refresh")
+	}
+
+	mustRefresh(t, e)
+	if active, _ := e.IsActive("t", now); !active {
+		t.Fatalf("after Refresh, new window should be visible")
+	}
+}
+
+func TestBlackoutEvaluator_NextWindowEnd(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	dtstart := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	store.set([]model.BlackoutWindow{
+		mkWindow("g", model.BlackoutScopeGlobal, nil,
+			fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=DAILY;BYHOUR=12;BYMINUTE=0;BYSECOND=0", dtstart.Format("20060102T150405Z")),
+			time.Hour, "UTC", dtstart),
+	})
+	e := NewBlackoutEvaluator(store)
+	mustRefresh(t, e)
+
+	at := time.Date(2026, 4, 19, 12, 30, 0, 0, time.UTC)
+	end := e.NextWindowEnd("t", at)
+	if end == nil {
+		t.Fatalf("expected end time")
+	}
+	want := time.Date(2026, 4, 19, 13, 0, 0, 0, time.UTC)
+	if !end.Equal(want) {
+		t.Fatalf("end = %s, want %s", end, want)
+	}
+
+	inactive := time.Date(2026, 4, 19, 14, 0, 0, 0, time.UTC)
+	if e.NextWindowEnd("t", inactive) != nil {
+		t.Fatalf("expected nil when inactive")
+	}
+}
+
+func TestBlackoutEvaluator_DisabledSkipped(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	dtstart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	w := mkWindow("g", model.BlackoutScopeGlobal, nil,
+		fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=DAILY;BYHOUR=0", dtstart.Format("20060102T150405Z")),
+		24*time.Hour, "UTC", dtstart)
+	w.Enabled = false
+	store.set([]model.BlackoutWindow{w})
+	e := NewBlackoutEvaluator(store)
+	mustRefresh(t, e)
+
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	if active, _ := e.IsActive("t", now); active {
+		t.Fatalf("disabled window should not activate")
+	}
+}

--- a/internal/daemon/intervalsched/cascade_recompute.go
+++ b/internal/daemon/intervalsched/cascade_recompute.go
@@ -1,0 +1,70 @@
+package intervalsched
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// RecomputeNextRunForTemplate walks every schedule referencing
+// templateID and recomputes its next_run_at via `expander`. Schedules
+// that override the template's rrule or timezone are skipped (their
+// cadence is set at the schedule layer and is unaffected by the
+// template change).
+//
+// Returns the number of schedules whose next_run_at was updated. Errors
+// expanding a single schedule do not abort the loop — they are logged
+// and the schedule is skipped; `affected` reflects successes only.
+//
+// SCHED1.2a ships this as library code; SCHED1.2b wires it into
+// TemplateStore.Update so the cascade fires automatically.
+func RecomputeNextRunForTemplate(
+	ctx context.Context,
+	templateID string,
+	schedStore storage.ScheduleStore,
+	tmplStore storage.TemplateStore,
+	expander *RRuleExpander,
+) (int, error) {
+	if expander == nil {
+		return 0, fmt.Errorf("recompute: expander is required")
+	}
+	tmpl, err := tmplStore.Get(ctx, templateID)
+	if err != nil {
+		return 0, fmt.Errorf("recompute: get template %s: %w", templateID, err)
+	}
+	schedules, err := schedStore.ListByTemplate(ctx, templateID)
+	if err != nil {
+		return 0, fmt.Errorf("recompute: list schedules for template %s: %w", templateID, err)
+	}
+
+	var affected int
+	for _, s := range schedules {
+		if overrideContains(s.Overrides, "rrule") || overrideContains(s.Overrides, "timezone") {
+			continue
+		}
+		next, err := expander.ComputeNextRunAt(s, tmpl)
+		if err != nil {
+			slog.Default().Error("recompute: expand schedule failed",
+				"schedule_id", s.ID, "template_id", templateID, "error", err)
+			continue
+		}
+		if err := schedStore.SetNextRunAt(ctx, s.ID, next); err != nil {
+			slog.Default().Error("recompute: set next_run_at failed",
+				"schedule_id", s.ID, "template_id", templateID, "error", err)
+			continue
+		}
+		affected++
+	}
+	return affected, nil
+}
+
+func overrideContains(overrides []string, name string) bool {
+	for _, o := range overrides {
+		if o == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/daemon/intervalsched/cascade_recompute_test.go
+++ b/internal/daemon/intervalsched/cascade_recompute_test.go
@@ -1,0 +1,282 @@
+package intervalsched
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// fakeTemplateStore is a minimal in-memory stand-in for
+// storage.TemplateStore.
+type fakeTemplateStore struct {
+	mu        sync.Mutex
+	templates map[string]model.Template
+}
+
+func newFakeTemplateStore() *fakeTemplateStore {
+	return &fakeTemplateStore{templates: map[string]model.Template{}}
+}
+
+func (f *fakeTemplateStore) Create(ctx context.Context, t *model.Template) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.templates[t.ID] = *t
+	return nil
+}
+func (f *fakeTemplateStore) Get(ctx context.Context, id string) (*model.Template, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	t, ok := f.templates[id]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+	return &t, nil
+}
+func (f *fakeTemplateStore) GetByName(ctx context.Context, name string) (*model.Template, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeTemplateStore) List(ctx context.Context) ([]model.Template, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeTemplateStore) Update(ctx context.Context, t *model.Template) error {
+	return errors.New("not implemented")
+}
+func (f *fakeTemplateStore) Delete(ctx context.Context, id string) error {
+	return errors.New("not implemented")
+}
+
+var _ storage.TemplateStore = (*fakeTemplateStore)(nil)
+
+// fakeScheduleStore supports the recompute flow: ListByTemplate and
+// SetNextRunAt. Other methods return errors.
+type fakeScheduleStore struct {
+	mu        sync.Mutex
+	schedules []model.Schedule
+	nextRun   map[string]*time.Time
+	setErr    map[string]error // schedule-id → error to return from SetNextRunAt
+}
+
+func newFakeScheduleStore() *fakeScheduleStore {
+	return &fakeScheduleStore{
+		nextRun: map[string]*time.Time{},
+		setErr:  map[string]error{},
+	}
+}
+
+func (f *fakeScheduleStore) Create(ctx context.Context, s *model.Schedule) error {
+	return errors.New("not implemented")
+}
+func (f *fakeScheduleStore) Get(ctx context.Context, id string) (*model.Schedule, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeScheduleStore) GetByTargetAndName(ctx context.Context, targetID, name string) (*model.Schedule, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeScheduleStore) ListByTarget(ctx context.Context, targetID string) ([]model.Schedule, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeScheduleStore) ListAll(ctx context.Context) ([]model.Schedule, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeScheduleStore) ListDue(ctx context.Context, now time.Time, limit int) ([]model.Schedule, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeScheduleStore) ListByTemplate(ctx context.Context, templateID string) ([]model.Schedule, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []model.Schedule
+	for _, s := range f.schedules {
+		if s.TemplateID != nil && *s.TemplateID == templateID {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+func (f *fakeScheduleStore) Update(ctx context.Context, s *model.Schedule) error {
+	return errors.New("not implemented")
+}
+func (f *fakeScheduleStore) SetNextRunAt(ctx context.Context, id string, next *time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.setErr[id]; err != nil {
+		return err
+	}
+	f.nextRun[id] = next
+	return nil
+}
+func (f *fakeScheduleStore) RecordRun(ctx context.Context, id string, status model.ScheduleRunStatus, scanID *string, at time.Time) error {
+	return errors.New("not implemented")
+}
+func (f *fakeScheduleStore) Delete(ctx context.Context, id string) error {
+	return errors.New("not implemented")
+}
+func (f *fakeScheduleStore) CountByTarget(ctx context.Context, targetID string) (int, error) {
+	return 0, errors.New("not implemented")
+}
+
+var _ storage.ScheduleStore = (*fakeScheduleStore)(nil)
+
+func mkCascadeSched(id string, tmplID string, overrides []string) model.Schedule {
+	return model.Schedule{
+		ID:         id,
+		TargetID:   "t-" + id,
+		Name:       id,
+		RRule:      "FREQ=DAILY;BYHOUR=2",
+		Timezone:   "UTC",
+		DTStart:    time.Date(2026, 4, 18, 2, 0, 0, 0, time.UTC),
+		TemplateID: &tmplID,
+		Overrides:  overrides,
+		Enabled:    true,
+	}
+}
+
+func TestRecomputeNextRunForTemplate_Mixed(t *testing.T) {
+	t.Parallel()
+	ts := newFakeTemplateStore()
+	_ = ts.Create(context.Background(), &model.Template{
+		ID:       "T1",
+		Name:     "nightly",
+		RRule:    "FREQ=DAILY;BYHOUR=3",
+		Timezone: "UTC",
+	})
+
+	ss := newFakeScheduleStore()
+	// 10 schedules: 3 override rrule, 2 override timezone, 1 overrides both,
+	// 4 override nothing → 4 affected.
+	ss.schedules = []model.Schedule{
+		mkCascadeSched("s1", "T1", []string{"rrule"}),
+		mkCascadeSched("s2", "T1", []string{"rrule"}),
+		mkCascadeSched("s3", "T1", []string{"rrule"}),
+		mkCascadeSched("s4", "T1", []string{"timezone"}),
+		mkCascadeSched("s5", "T1", []string{"timezone"}),
+		mkCascadeSched("s6", "T1", []string{"rrule", "timezone"}),
+		mkCascadeSched("s7", "T1", nil),
+		mkCascadeSched("s8", "T1", []string{}),
+		mkCascadeSched("s9", "T1", []string{"maintenance_window"}),
+		mkCascadeSched("s10", "T1", []string{"tool_config"}),
+	}
+
+	now := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	exp := NewRRuleExpander(model.ScheduleDefaults{}, nil, frozenClock{now: now}, 1)
+
+	affected, err := RecomputeNextRunForTemplate(context.Background(), "T1", ss, ts, exp)
+	if err != nil {
+		t.Fatalf("RecomputeNextRunForTemplate: %v", err)
+	}
+	if affected != 4 {
+		t.Fatalf("expected 4 affected, got %d", affected)
+	}
+	// Confirm the unaffected schedules were not touched.
+	for _, id := range []string{"s1", "s2", "s3", "s4", "s5", "s6"} {
+		if _, ok := ss.nextRun[id]; ok {
+			t.Fatalf("schedule %s should not have been updated", id)
+		}
+	}
+	for _, id := range []string{"s7", "s8", "s9", "s10"} {
+		if _, ok := ss.nextRun[id]; !ok {
+			t.Fatalf("schedule %s should have been updated", id)
+		}
+	}
+}
+
+func TestRecomputeNextRunForTemplate_NoSchedules(t *testing.T) {
+	t.Parallel()
+	ts := newFakeTemplateStore()
+	_ = ts.Create(context.Background(), &model.Template{
+		ID:       "T-empty",
+		RRule:    "FREQ=DAILY",
+		Timezone: "UTC",
+	})
+	ss := newFakeScheduleStore()
+	exp := NewRRuleExpander(model.ScheduleDefaults{}, nil, frozenClock{now: time.Now()}, 1)
+
+	affected, err := RecomputeNextRunForTemplate(context.Background(), "T-empty", ss, ts, exp)
+	if err != nil {
+		t.Fatalf("RecomputeNextRunForTemplate: %v", err)
+	}
+	if affected != 0 {
+		t.Fatalf("expected 0 affected, got %d", affected)
+	}
+}
+
+func TestRecomputeNextRunForTemplate_TemplateNotFound(t *testing.T) {
+	t.Parallel()
+	ts := newFakeTemplateStore()
+	ss := newFakeScheduleStore()
+	exp := NewRRuleExpander(model.ScheduleDefaults{}, nil, frozenClock{now: time.Now()}, 1)
+
+	_, err := RecomputeNextRunForTemplate(context.Background(), "nonexistent", ss, ts, exp)
+	if err == nil {
+		t.Fatalf("expected error for missing template")
+	}
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("expected wrapped ErrNotFound, got %v", err)
+	}
+}
+
+func TestRecomputeNextRunForTemplate_ExpanderError(t *testing.T) {
+	t.Parallel()
+	// Template with an invalid timezone — every non-overriding schedule
+	// hits a LoadLocation failure inside the expander. The cascade must
+	// continue-on-error, returning nil and affected=0.
+	ts := newFakeTemplateStore()
+	_ = ts.Create(context.Background(), &model.Template{
+		ID:       "Tbad",
+		RRule:    "FREQ=DAILY",
+		Timezone: "Not/A/Zone",
+	})
+	ss := newFakeScheduleStore()
+	ss.schedules = []model.Schedule{
+		mkCascadeSched("s1", "Tbad", nil),
+		mkCascadeSched("s2", "Tbad", nil),
+	}
+
+	now := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	exp := NewRRuleExpander(model.ScheduleDefaults{}, nil, frozenClock{now: now}, 1)
+
+	affected, err := RecomputeNextRunForTemplate(context.Background(), "Tbad", ss, ts, exp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if affected != 0 {
+		t.Fatalf("expected 0 affected (all expander errors), got %d", affected)
+	}
+	if len(ss.nextRun) != 0 {
+		t.Fatalf("no schedule should have been updated, got %d", len(ss.nextRun))
+	}
+}
+
+func TestRecomputeNextRunForTemplate_SetNextRunAtError(t *testing.T) {
+	t.Parallel()
+	ts := newFakeTemplateStore()
+	_ = ts.Create(context.Background(), &model.Template{
+		ID:       "T1",
+		RRule:    "FREQ=DAILY",
+		Timezone: "UTC",
+	})
+	ss := newFakeScheduleStore()
+	ss.schedules = []model.Schedule{
+		mkCascadeSched("a", "T1", nil),
+		mkCascadeSched("b", "T1", nil),
+	}
+	ss.setErr["a"] = errors.New("forced")
+
+	now := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	exp := NewRRuleExpander(model.ScheduleDefaults{}, nil, frozenClock{now: now}, 1)
+
+	affected, err := RecomputeNextRunForTemplate(context.Background(), "T1", ss, ts, exp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if affected != 1 {
+		t.Fatalf("expected 1 affected, got %d", affected)
+	}
+	if _, ok := ss.nextRun["b"]; !ok {
+		t.Fatalf("expected b updated")
+	}
+}

--- a/internal/daemon/intervalsched/locks.go
+++ b/internal/daemon/intervalsched/locks.go
@@ -1,0 +1,58 @@
+package intervalsched
+
+import "sync"
+
+// TargetLockIndex provides non-blocking, per-target mutual exclusion. The
+// master ticker uses it to guarantee that a target has at most one scan
+// in flight at a time without blocking the dispatch loop.
+//
+// Each target's lock is a buffered(1) channel kept in a sync.Map. Acquire
+// is a non-blocking send; release is a non-blocking receive. The channel
+// itself is created lazily on first touch.
+type TargetLockIndex struct {
+	m sync.Map // map[string]chan struct{}
+}
+
+// NewTargetLockIndex returns an empty lock index.
+func NewTargetLockIndex() *TargetLockIndex {
+	return &TargetLockIndex{}
+}
+
+// TryAcquire attempts to take the lock for targetID. Returns true on
+// success, false if already held. Never blocks.
+func (i *TargetLockIndex) TryAcquire(targetID string) bool {
+	ch := i.channelFor(targetID)
+	select {
+	case ch <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+// Release drops the lock for targetID. A release without a matching
+// acquire is a no-op (it does not panic).
+func (i *TargetLockIndex) Release(targetID string) {
+	ch := i.channelFor(targetID)
+	select {
+	case <-ch:
+	default:
+	}
+}
+
+// IsHeld reports whether targetID's lock is currently held. The result is
+// a snapshot — by the time the caller reads it the state may already
+// have changed. Intended for debug/introspection only.
+func (i *TargetLockIndex) IsHeld(targetID string) bool {
+	ch := i.channelFor(targetID)
+	return len(ch) > 0
+}
+
+func (i *TargetLockIndex) channelFor(targetID string) chan struct{} {
+	if v, ok := i.m.Load(targetID); ok {
+		return v.(chan struct{})
+	}
+	ch := make(chan struct{}, 1)
+	actual, _ := i.m.LoadOrStore(targetID, ch)
+	return actual.(chan struct{})
+}

--- a/internal/daemon/intervalsched/locks_test.go
+++ b/internal/daemon/intervalsched/locks_test.go
@@ -1,0 +1,129 @@
+package intervalsched
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestTargetLocks_MutualExclusion(t *testing.T) {
+	t.Parallel()
+	idx := NewTargetLockIndex()
+
+	const goroutines = 1000
+	var success int64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if idx.TryAcquire("t1") {
+				atomic.AddInt64(&success, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if success != 1 {
+		t.Fatalf("expected exactly 1 successful acquire, got %d", success)
+	}
+	if !idx.IsHeld("t1") {
+		t.Fatalf("expected lock to be held after single successful acquire")
+	}
+
+	idx.Release("t1")
+	if idx.IsHeld("t1") {
+		t.Fatalf("expected lock released")
+	}
+	if !idx.TryAcquire("t1") {
+		t.Fatalf("expected acquire after release to succeed")
+	}
+}
+
+func TestTargetLocks_PerTarget(t *testing.T) {
+	t.Parallel()
+	idx := NewTargetLockIndex()
+
+	const targets = 100
+	for i := 0; i < targets; i++ {
+		id := fmt.Sprintf("t%d", i)
+		if !idx.TryAcquire(id) {
+			t.Fatalf("expected to acquire %s on fresh index", id)
+		}
+	}
+	for i := 0; i < targets; i++ {
+		id := fmt.Sprintf("t%d", i)
+		if !idx.IsHeld(id) {
+			t.Fatalf("expected %s held", id)
+		}
+	}
+	// Second acquire on any target must fail while first is held.
+	for i := 0; i < targets; i++ {
+		id := fmt.Sprintf("t%d", i)
+		if idx.TryAcquire(id) {
+			t.Fatalf("expected second acquire on %s to fail", id)
+		}
+	}
+}
+
+func TestTargetLocks_ReleaseWithoutAcquire(t *testing.T) {
+	t.Parallel()
+	idx := NewTargetLockIndex()
+
+	idx.Release("nonexistent")
+	idx.Release("nonexistent")
+
+	if idx.IsHeld("nonexistent") {
+		t.Fatalf("expected fresh lock to be not held")
+	}
+	if !idx.TryAcquire("nonexistent") {
+		t.Fatalf("expected acquire to succeed after spurious releases")
+	}
+}
+
+func TestTargetLocks_IsHeld(t *testing.T) {
+	t.Parallel()
+	idx := NewTargetLockIndex()
+
+	if idx.IsHeld("t") {
+		t.Fatalf("fresh lock reports held")
+	}
+	if !idx.TryAcquire("t") {
+		t.Fatalf("first acquire failed")
+	}
+	if !idx.IsHeld("t") {
+		t.Fatalf("after acquire, IsHeld should be true")
+	}
+	idx.Release("t")
+	if idx.IsHeld("t") {
+		t.Fatalf("after release, IsHeld should be false")
+	}
+	if !idx.TryAcquire("t") {
+		t.Fatalf("reacquire after release failed")
+	}
+	if !idx.IsHeld("t") {
+		t.Fatalf("after reacquire, IsHeld should be true")
+	}
+}
+
+func TestTargetLocks_ConcurrentAcquireRelease(t *testing.T) {
+	t.Parallel()
+	idx := NewTargetLockIndex()
+
+	const workers = 64
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func(id string) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				if idx.TryAcquire(id) {
+					idx.Release(id)
+				}
+			}
+		}(fmt.Sprintf("t%d", w%8))
+	}
+	wg.Wait()
+}

--- a/internal/daemon/intervalsched/overlap.go
+++ b/internal/daemon/intervalsched/overlap.go
@@ -1,0 +1,124 @@
+package intervalsched
+
+import (
+	"fmt"
+	"time"
+
+	extrrule "github.com/teambition/rrule-go"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// OverlapConflict records a pair of occurrences — one from the
+// candidate schedule, one from an existing schedule — whose estimated
+// run windows would overlap.
+type OverlapConflict struct {
+	ScheduleID  string
+	OccurrenceA time.Time // candidate's occurrence (UTC)
+	OccurrenceB time.Time // existing schedule's occurrence (UTC)
+}
+
+// ValidateNoOverlap expands the candidate and each existing schedule's
+// rrule over [now, now+horizon] and returns every pair of occurrences
+// (one per pair, each sharing a target) whose starts sit within
+// estimatedDuration of each other.
+//
+// The function is pure: no store access, no wall-clock reads inside.
+// Callers drive "now" through the clock by passing a horizon; the
+// implementation uses time.Now as the lower bound.
+func ValidateNoOverlap(
+	candidate model.Schedule,
+	candidateTmpl *model.Template,
+	existing []model.Schedule,
+	existingTmpls map[string]model.Template,
+	defaults model.ScheduleDefaults,
+	horizon time.Duration,
+	estimatedDuration time.Duration,
+) ([]OverlapConflict, error) {
+	now := time.Now()
+	return validateNoOverlapAt(candidate, candidateTmpl, existing, existingTmpls, defaults, now, horizon, estimatedDuration)
+}
+
+func validateNoOverlapAt(
+	candidate model.Schedule,
+	candidateTmpl *model.Template,
+	existing []model.Schedule,
+	existingTmpls map[string]model.Template,
+	defaults model.ScheduleDefaults,
+	now time.Time,
+	horizon time.Duration,
+	estimatedDuration time.Duration,
+) ([]OverlapConflict, error) {
+	candOccs, err := expandSchedule(candidate, candidateTmpl, defaults, now, horizon)
+	if err != nil {
+		return nil, fmt.Errorf("expanding candidate: %w", err)
+	}
+	if len(candOccs) == 0 {
+		return nil, nil
+	}
+
+	var conflicts []OverlapConflict
+	for _, ex := range existing {
+		if ex.ID == candidate.ID {
+			continue
+		}
+		if ex.TargetID != candidate.TargetID {
+			continue
+		}
+		var tmpl *model.Template
+		if ex.TemplateID != nil && existingTmpls != nil {
+			if t, ok := existingTmpls[*ex.TemplateID]; ok {
+				tmpl = &t
+			}
+		}
+		exOccs, err := expandSchedule(ex, tmpl, defaults, now, horizon)
+		if err != nil {
+			return nil, fmt.Errorf("expanding schedule %s: %w", ex.ID, err)
+		}
+		for _, a := range candOccs {
+			for _, b := range exOccs {
+				diff := a.Sub(b)
+				if diff < 0 {
+					diff = -diff
+				}
+				if diff < estimatedDuration {
+					conflicts = append(conflicts, OverlapConflict{
+						ScheduleID:  ex.ID,
+						OccurrenceA: a.UTC(),
+						OccurrenceB: b.UTC(),
+					})
+				}
+			}
+		}
+	}
+	return conflicts, nil
+}
+
+// expandSchedule produces the list of occurrences of `s` between `now`
+// and `now+horizon`, honoring the effective rrule and timezone.
+func expandSchedule(s model.Schedule, tmpl *model.Template, defaults model.ScheduleDefaults, now time.Time, horizon time.Duration) ([]time.Time, error) {
+	eff, err := model.ResolveEffectiveConfig(s, tmpl, defaults)
+	if err != nil {
+		return nil, err
+	}
+	loc, err := time.LoadLocation(eff.Timezone)
+	if err != nil {
+		return nil, fmt.Errorf("loading timezone %q: %w", eff.Timezone, err)
+	}
+	opt, err := extrrule.StrToROption(eff.RRule)
+	if err != nil {
+		return nil, fmt.Errorf("parsing rrule: %w", err)
+	}
+	if !s.DTStart.IsZero() {
+		opt.Dtstart = s.DTStart.In(loc)
+	} else if !opt.Dtstart.IsZero() {
+		opt.Dtstart = opt.Dtstart.In(loc)
+	} else {
+		opt.Dtstart = now.In(loc)
+	}
+	rule, err := extrrule.NewRRule(*opt)
+	if err != nil {
+		return nil, fmt.Errorf("building rrule: %w", err)
+	}
+	return rule.Between(now, now.Add(horizon), true), nil
+}

--- a/internal/daemon/intervalsched/overlap_test.go
+++ b/internal/daemon/intervalsched/overlap_test.go
@@ -1,0 +1,140 @@
+package intervalsched
+
+import (
+	"testing"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+func makeSched(id, targetID, rrule string, dtstart time.Time) model.Schedule {
+	return model.Schedule{
+		ID:       id,
+		TargetID: targetID,
+		Name:     id,
+		RRule:    rrule,
+		Timezone: "UTC",
+		DTStart:  dtstart,
+		Enabled:  true,
+	}
+}
+
+func TestValidateNoOverlap_Clean(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	dtstart := now.Add(-time.Hour)
+	cand := makeSched("cand", "T", "FREQ=HOURLY;BYMINUTE=0", dtstart)
+	other := makeSched("other", "T", "FREQ=HOURLY;BYMINUTE=30", dtstart)
+
+	conflicts, err := validateNoOverlapAt(cand, nil, []model.Schedule{other}, nil,
+		model.ScheduleDefaults{}, now, 24*time.Hour, 10*time.Minute)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if len(conflicts) != 0 {
+		t.Fatalf("expected 0 conflicts, got %d: %+v", len(conflicts), conflicts)
+	}
+}
+
+func TestValidateNoOverlap_Conflict(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	dtstart := now.Add(-time.Hour)
+	cand := makeSched("cand", "T", "FREQ=HOURLY;BYMINUTE=0", dtstart)
+	other := makeSched("other", "T", "FREQ=HOURLY;BYMINUTE=0", dtstart)
+
+	conflicts, err := validateNoOverlapAt(cand, nil, []model.Schedule{other}, nil,
+		model.ScheduleDefaults{}, now, 24*time.Hour, 10*time.Minute)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if len(conflicts) == 0 {
+		t.Fatalf("expected conflicts")
+	}
+	// Over 24h and hourly → ≥ 24 conflicts.
+	if len(conflicts) < 24 {
+		t.Fatalf("expected ≥24 conflicts, got %d", len(conflicts))
+	}
+}
+
+func TestValidateNoOverlap_DifferentTargets(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	dtstart := now.Add(-time.Hour)
+	cand := makeSched("cand", "T", "FREQ=HOURLY;BYMINUTE=0", dtstart)
+	other := makeSched("other", "U", "FREQ=HOURLY;BYMINUTE=0", dtstart)
+
+	conflicts, err := validateNoOverlapAt(cand, nil, []model.Schedule{other}, nil,
+		model.ScheduleDefaults{}, now, 24*time.Hour, 10*time.Minute)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if len(conflicts) != 0 {
+		t.Fatalf("different target should yield no conflicts, got %d", len(conflicts))
+	}
+}
+
+func TestValidateNoOverlap_EstimatedDuration(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	dtstart := now.Add(-time.Hour)
+	cand := makeSched("cand", "T", "FREQ=HOURLY;BYMINUTE=0", dtstart)
+	other := makeSched("other", "T", "FREQ=HOURLY;BYMINUTE=30", dtstart)
+
+	// 60-min estimated duration: :00 and :30 slots collide.
+	conflicts, err := validateNoOverlapAt(cand, nil, []model.Schedule{other}, nil,
+		model.ScheduleDefaults{}, now, 6*time.Hour, 60*time.Minute)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if len(conflicts) == 0 {
+		t.Fatalf("expected conflicts with 60m estimated duration")
+	}
+}
+
+func TestValidateNoOverlap_EmptyExisting(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	dtstart := now.Add(-time.Hour)
+	cand := makeSched("cand", "T", "FREQ=HOURLY", dtstart)
+	conflicts, err := validateNoOverlapAt(cand, nil, nil, nil,
+		model.ScheduleDefaults{}, now, 24*time.Hour, 10*time.Minute)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if len(conflicts) != 0 {
+		t.Fatalf("expected no conflicts, got %d", len(conflicts))
+	}
+}
+
+func TestValidateNoOverlap_CandidateUntilPast(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	dtstart := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+	cand := makeSched("cand", "T", "FREQ=DAILY;UNTIL=20200101T000000Z", dtstart)
+	other := makeSched("other", "T", "FREQ=HOURLY", now.Add(-time.Hour))
+	conflicts, err := validateNoOverlapAt(cand, nil, []model.Schedule{other}, nil,
+		model.ScheduleDefaults{}, now, 24*time.Hour, 10*time.Minute)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if len(conflicts) != 0 {
+		t.Fatalf("candidate with UNTIL in past should yield no conflicts, got %d", len(conflicts))
+	}
+}
+
+func TestValidateNoOverlap_SelfExcluded(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	dtstart := now.Add(-time.Hour)
+	s := makeSched("same", "T", "FREQ=HOURLY", dtstart)
+	// Pass the candidate itself in the existing list — must be skipped.
+	conflicts, err := validateNoOverlapAt(s, nil, []model.Schedule{s}, nil,
+		model.ScheduleDefaults{}, now, 6*time.Hour, 10*time.Minute)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if len(conflicts) != 0 {
+		t.Fatalf("self should be excluded, got %d conflicts", len(conflicts))
+	}
+}

--- a/internal/daemon/intervalsched/rrule_expand.go
+++ b/internal/daemon/intervalsched/rrule_expand.go
@@ -1,0 +1,123 @@
+package intervalsched
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	extrrule "github.com/teambition/rrule-go"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// ErrBlackoutSaturated is returned by RRuleExpander.ComputeNextRunAt
+// when the blackout-skip loop fails to find a free slot within the
+// safety budget. In production this signals a misconfigured blackout
+// that covers the entire rrule horizon.
+var ErrBlackoutSaturated = errors.New("blackout saturated rrule horizon")
+
+// maxBlackoutSkipIterations caps the blackout-skip loop defensively.
+const maxBlackoutSkipIterations = 100
+
+// RRuleExpander computes the next fire time for a schedule, honoring
+// the effective rrule, timezone, jitter, and any active blackout
+// windows (which are skipped over).
+type RRuleExpander struct {
+	defaults  model.ScheduleDefaults
+	blackouts *BlackoutEvaluator
+	clock     Clock
+
+	mu        sync.Mutex
+	jitterRNG *rand.Rand
+}
+
+// NewRRuleExpander constructs an expander. `seed` seeds the jitter RNG;
+// callers that want nondeterministic jitter pass time.Now().UnixNano().
+func NewRRuleExpander(defaults model.ScheduleDefaults, blackouts *BlackoutEvaluator, clock Clock, seed int64) *RRuleExpander {
+	if clock == nil {
+		clock = NewRealClock()
+	}
+	return &RRuleExpander{
+		defaults:  defaults,
+		blackouts: blackouts,
+		clock:     clock,
+		jitterRNG: rand.New(rand.NewSource(seed)),
+	}
+}
+
+// ComputeNextRunAt returns the next UTC fire time for `s`, or nil when
+// the schedule can never fire again (UNTIL in past, COUNT exhausted).
+// Returns ErrBlackoutSaturated when blackouts cover the rrule horizon.
+func (e *RRuleExpander) ComputeNextRunAt(s model.Schedule, tmpl *model.Template) (*time.Time, error) {
+	eff, err := model.ResolveEffectiveConfig(s, tmpl, e.defaults)
+	if err != nil {
+		return nil, fmt.Errorf("resolving effective config: %w", err)
+	}
+
+	loc, err := time.LoadLocation(eff.Timezone)
+	if err != nil {
+		return nil, fmt.Errorf("loading timezone %q: %w", eff.Timezone, err)
+	}
+
+	opt, err := extrrule.StrToROption(eff.RRule)
+	if err != nil {
+		return nil, fmt.Errorf("parsing rrule: %w", err)
+	}
+	dtstart := s.DTStart
+	if !dtstart.IsZero() {
+		opt.Dtstart = dtstart.In(loc)
+	} else if !opt.Dtstart.IsZero() {
+		opt.Dtstart = opt.Dtstart.In(loc)
+	} else {
+		opt.Dtstart = e.clock.Now().In(loc)
+	}
+
+	rule, err := extrrule.NewRRule(*opt)
+	if err != nil {
+		return nil, fmt.Errorf("building rrule: %w", err)
+	}
+
+	now := e.clock.Now()
+	candidate := rule.After(now, false)
+	if candidate.IsZero() {
+		return nil, nil
+	}
+	candidate = candidate.Add(e.nextJitter())
+
+	if e.blackouts != nil {
+		for i := 0; i < maxBlackoutSkipIterations; i++ {
+			active, _ := e.blackouts.IsActive(s.TargetID, candidate)
+			if !active {
+				out := candidate.UTC()
+				return &out, nil
+			}
+			end := e.blackouts.NextWindowEnd(s.TargetID, candidate)
+			if end == nil {
+				// Defensive: IsActive said yes but NextWindowEnd said no.
+				// Nudge forward by 1s and retry.
+				candidate = candidate.Add(time.Second)
+				continue
+			}
+			next := rule.After(*end, false)
+			if next.IsZero() {
+				return nil, nil
+			}
+			candidate = next.Add(e.nextJitter())
+		}
+		return nil, ErrBlackoutSaturated
+	}
+
+	out := candidate.UTC()
+	return &out, nil
+}
+
+func (e *RRuleExpander) nextJitter() time.Duration {
+	if e.defaults.JitterSeconds <= 0 {
+		return 0
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return time.Duration(e.jitterRNG.Intn(e.defaults.JitterSeconds+1)) * time.Second
+}

--- a/internal/daemon/intervalsched/rrule_expand_test.go
+++ b/internal/daemon/intervalsched/rrule_expand_test.go
@@ -13,8 +13,8 @@ import (
 // frozenClock implements the package's Clock interface with a frozen now.
 type frozenClock struct{ now time.Time }
 
-func (f frozenClock) Now() time.Time                   { return f.now }
-func (f frozenClock) NewTimer(d time.Duration) Timer   { return &frozenTimer{} }
+func (f frozenClock) Now() time.Time                 { return f.now }
+func (f frozenClock) NewTimer(d time.Duration) Timer { return &frozenTimer{} }
 
 type frozenTimer struct{}
 
@@ -225,4 +225,3 @@ func TestRRuleExpander_BlackoutSaturated(t *testing.T) {
 		t.Fatalf("expected ErrBlackoutSaturated, got %v", err)
 	}
 }
-

--- a/internal/daemon/intervalsched/rrule_expand_test.go
+++ b/internal/daemon/intervalsched/rrule_expand_test.go
@@ -1,0 +1,228 @@
+package intervalsched
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// frozenClock implements the package's Clock interface with a frozen now.
+type frozenClock struct{ now time.Time }
+
+func (f frozenClock) Now() time.Time                   { return f.now }
+func (f frozenClock) NewTimer(d time.Duration) Timer   { return &frozenTimer{} }
+
+type frozenTimer struct{}
+
+func (*frozenTimer) C() <-chan time.Time { return nil }
+func (*frozenTimer) Stop() bool          { return true }
+
+func mkSchedule(rrule, tz string, dtstart time.Time, targetID string) model.Schedule {
+	return model.Schedule{
+		ID:       "s-" + targetID,
+		TargetID: targetID,
+		Name:     "n",
+		RRule:    rrule,
+		Timezone: tz,
+		DTStart:  dtstart,
+		Enabled:  true,
+	}
+}
+
+func TestRRuleExpander_Basic(t *testing.T) {
+	t.Parallel()
+	defaults := model.ScheduleDefaults{JitterSeconds: 0}
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	exp := NewRRuleExpander(defaults, nil, frozenClock{now: now}, 1)
+
+	dtstart := time.Date(2026, 4, 18, 2, 0, 0, 0, time.UTC)
+	s := mkSchedule("FREQ=DAILY;BYHOUR=2;BYMINUTE=0;BYSECOND=0", "UTC", dtstart, "t")
+
+	next, err := exp.ComputeNextRunAt(s, nil)
+	if err != nil {
+		t.Fatalf("ComputeNextRunAt: %v", err)
+	}
+	if next == nil {
+		t.Fatalf("expected a next time")
+	}
+	want := time.Date(2026, 4, 20, 2, 0, 0, 0, time.UTC)
+	if !next.Equal(want) {
+		t.Fatalf("got %s, want %s", next, want)
+	}
+}
+
+func TestRRuleExpander_UntilInPast(t *testing.T) {
+	t.Parallel()
+	defaults := model.ScheduleDefaults{}
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	exp := NewRRuleExpander(defaults, nil, frozenClock{now: now}, 1)
+
+	dtstart := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+	s := mkSchedule("FREQ=DAILY;UNTIL=20200101T000000Z", "UTC", dtstart, "t")
+
+	next, err := exp.ComputeNextRunAt(s, nil)
+	if err != nil {
+		t.Fatalf("ComputeNextRunAt: %v", err)
+	}
+	if next != nil {
+		t.Fatalf("expected nil, got %s", next)
+	}
+}
+
+func TestRRuleExpander_CountExhausted(t *testing.T) {
+	t.Parallel()
+	defaults := model.ScheduleDefaults{}
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	exp := NewRRuleExpander(defaults, nil, frozenClock{now: now}, 1)
+
+	// DTSTART 5 days ago, COUNT=3 → fires have all happened.
+	dtstart := now.AddDate(0, 0, -5)
+	s := mkSchedule("FREQ=DAILY;COUNT=3", "UTC", dtstart, "t")
+
+	next, err := exp.ComputeNextRunAt(s, nil)
+	if err != nil {
+		t.Fatalf("ComputeNextRunAt: %v", err)
+	}
+	if next != nil {
+		t.Fatalf("expected nil, got %s", next)
+	}
+}
+
+func TestRRuleExpander_DST_Spring(t *testing.T) {
+	t.Parallel()
+	defaults := model.ScheduleDefaults{}
+	// 2026-03-08 is US spring-forward (02:00 → 03:00 local).
+	loc, _ := time.LoadLocation("America/New_York")
+	// Start before the gap.
+	dtstart := time.Date(2026, 3, 7, 2, 30, 0, 0, loc)
+	now := time.Date(2026, 3, 8, 0, 0, 0, 0, time.UTC)
+	exp := NewRRuleExpander(defaults, nil, frozenClock{now: now}, 1)
+	s := mkSchedule("FREQ=DAILY;BYHOUR=2;BYMINUTE=30;BYSECOND=0", "America/New_York", dtstart, "t")
+
+	next, err := exp.ComputeNextRunAt(s, nil)
+	if err != nil {
+		t.Fatalf("ComputeNextRunAt: %v", err)
+	}
+	if next == nil {
+		t.Fatalf("expected next time")
+	}
+	// Must be strictly after `now`. We don't pin exactly when rrule-go
+	// puts the missing 02:30 — just that it doesn't return before now.
+	if !next.After(now) {
+		t.Fatalf("next %s should be after now %s", next, now)
+	}
+}
+
+func TestRRuleExpander_DST_Fall(t *testing.T) {
+	t.Parallel()
+	defaults := model.ScheduleDefaults{}
+	loc, _ := time.LoadLocation("America/New_York")
+	// Start before fall-back.
+	dtstart := time.Date(2026, 10, 30, 1, 30, 0, 0, loc)
+	now := time.Date(2026, 11, 1, 0, 0, 0, 0, time.UTC)
+	exp := NewRRuleExpander(defaults, nil, frozenClock{now: now}, 1)
+	s := mkSchedule("FREQ=DAILY;BYHOUR=1;BYMINUTE=30;BYSECOND=0", "America/New_York", dtstart, "t")
+
+	next, err := exp.ComputeNextRunAt(s, nil)
+	if err != nil {
+		t.Fatalf("ComputeNextRunAt: %v", err)
+	}
+	if next == nil {
+		t.Fatalf("expected next time")
+	}
+	if !next.After(now) {
+		t.Fatalf("next %s should be after %s", next, now)
+	}
+}
+
+func TestRRuleExpander_JitterDeterministic(t *testing.T) {
+	t.Parallel()
+	defaults := model.ScheduleDefaults{JitterSeconds: 60}
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	dtstart := time.Date(2026, 4, 18, 2, 0, 0, 0, time.UTC)
+	s := mkSchedule("FREQ=DAILY;BYHOUR=2;BYMINUTE=0;BYSECOND=0", "UTC", dtstart, "t")
+
+	exp1 := NewRRuleExpander(defaults, nil, frozenClock{now: now}, 42)
+	exp2 := NewRRuleExpander(defaults, nil, frozenClock{now: now}, 42)
+
+	n1, err := exp1.ComputeNextRunAt(s, nil)
+	if err != nil {
+		t.Fatalf("ComputeNextRunAt 1: %v", err)
+	}
+	n2, err := exp2.ComputeNextRunAt(s, nil)
+	if err != nil {
+		t.Fatalf("ComputeNextRunAt 2: %v", err)
+	}
+	if n1 == nil || n2 == nil {
+		t.Fatalf("expected both non-nil")
+	}
+	if !n1.Equal(*n2) {
+		t.Fatalf("same seed yielded different times: %s vs %s", n1, n2)
+	}
+}
+
+func TestRRuleExpander_BlackoutSkip(t *testing.T) {
+	t.Parallel()
+	defaults := model.ScheduleDefaults{}
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+
+	// Blackout [12:00, 15:00) UTC, daily.
+	store := newFakeStore()
+	store.set([]model.BlackoutWindow{
+		mkWindow("g", model.BlackoutScopeGlobal, nil,
+			fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=DAILY;BYHOUR=12;BYMINUTE=0;BYSECOND=0", now.Format("20060102T150405Z")),
+			3*time.Hour, "UTC", now),
+	})
+	ev := NewBlackoutEvaluator(store)
+	if err := ev.Refresh(context.Background()); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	exp := NewRRuleExpander(defaults, ev, frozenClock{now: now}, 1)
+	dtstart := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	s := mkSchedule("FREQ=HOURLY", "UTC", dtstart, "t")
+
+	next, err := exp.ComputeNextRunAt(s, nil)
+	if err != nil {
+		t.Fatalf("ComputeNextRunAt: %v", err)
+	}
+	if next == nil {
+		t.Fatalf("expected a next time")
+	}
+	blackoutEnd := time.Date(2026, 4, 19, 15, 0, 0, 0, time.UTC)
+	if next.Before(blackoutEnd) {
+		t.Fatalf("next %s should be at or after blackout end %s", next, blackoutEnd)
+	}
+}
+
+func TestRRuleExpander_BlackoutSaturated(t *testing.T) {
+	t.Parallel()
+	defaults := model.ScheduleDefaults{}
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+
+	// Blackout that covers every hour: FREQ=HOURLY, duration=3600s.
+	store := newFakeStore()
+	store.set([]model.BlackoutWindow{
+		mkWindow("g", model.BlackoutScopeGlobal, nil,
+			fmt.Sprintf("DTSTART:%s\nRRULE:FREQ=HOURLY", now.Format("20060102T150405Z")),
+			time.Hour, "UTC", now),
+	})
+	ev := NewBlackoutEvaluator(store)
+	if err := ev.Refresh(context.Background()); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	exp := NewRRuleExpander(defaults, ev, frozenClock{now: now}, 1)
+	dtstart := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	s := mkSchedule("FREQ=HOURLY", "UTC", dtstart, "t")
+
+	_, err := exp.ComputeNextRunAt(s, nil)
+	if !errors.Is(err, ErrBlackoutSaturated) {
+		t.Fatalf("expected ErrBlackoutSaturated, got %v", err)
+	}
+}
+

--- a/internal/daemon/intervalsched/workerpool.go
+++ b/internal/daemon/intervalsched/workerpool.go
@@ -1,0 +1,221 @@
+package intervalsched
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// Job is an opaque unit of work dispatched to the pool. The master
+// ticker fills in Payload; the pool is scheduler-agnostic.
+type Job struct {
+	ScheduleID string
+	TargetID   string
+	Payload    any
+}
+
+// JobRunner is the behavior a worker invokes for every job it pulls off
+// the queue. The returned error is logged by the pool and does not stop
+// the worker.
+type JobRunner interface {
+	Run(ctx context.Context, job Job) error
+}
+
+// WorkerPool is a bounded goroutine pool with a non-blocking dispatch
+// queue. Resize grows immediately and shrinks by letting excess workers
+// exit after their current job completes — in-flight jobs are never
+// cancelled by a resize.
+//
+// The job queue buffer is set at construction to the initial size and
+// never shrinks. Resize changes the number of worker goroutines only;
+// bounded concurrency is enforced by worker count, not buffer capacity.
+type WorkerPool struct {
+	runner JobRunner
+	log    *slog.Logger
+
+	mu      sync.Mutex
+	size    int
+	active  int
+	jobs    chan Job
+	started bool
+	stopped bool
+	ctx     context.Context
+	wg      sync.WaitGroup
+	workers int
+	// excessQuit carries shrink tokens. A worker that observes a token
+	// here exits after its current job completes.
+	excessQuit chan struct{}
+}
+
+// NewWorkerPool constructs a pool with `size` worker slots. Non-positive
+// size is normalized to 1. Start must be called before Dispatch.
+func NewWorkerPool(size int, runner JobRunner, log *slog.Logger) *WorkerPool {
+	if size <= 0 {
+		size = 1
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &WorkerPool{
+		runner:     runner,
+		log:        log,
+		size:       size,
+		jobs:       make(chan Job, size),
+		excessQuit: make(chan struct{}, 1024),
+	}
+}
+
+// Start spawns `size` worker goroutines. Re-entrant: a second call is a
+// no-op.
+func (p *WorkerPool) Start(ctx context.Context) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.started {
+		return
+	}
+	p.started = true
+	p.ctx = ctx
+	for i := 0; i < p.size; i++ {
+		p.spawnWorkerLocked()
+	}
+}
+
+func (p *WorkerPool) spawnWorkerLocked() {
+	p.workers++
+	p.wg.Add(1)
+	go p.workerLoop()
+}
+
+func (p *WorkerPool) workerLoop() {
+	defer p.wg.Done()
+	defer func() {
+		p.mu.Lock()
+		p.workers--
+		p.mu.Unlock()
+	}()
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case job, ok := <-p.jobs:
+			if !ok {
+				return
+			}
+			p.mu.Lock()
+			p.active++
+			p.mu.Unlock()
+
+			if err := p.runner.Run(p.ctx, job); err != nil {
+				p.log.Error("worker job failed",
+					"schedule_id", job.ScheduleID,
+					"target_id", job.TargetID,
+					"error", err)
+			}
+
+			p.mu.Lock()
+			p.active--
+			p.mu.Unlock()
+
+			// Cooperative shrink: after each job, see whether we've been
+			// asked to step down.
+			select {
+			case <-p.excessQuit:
+				return
+			default:
+			}
+		}
+	}
+}
+
+// Free returns the number of idle worker slots (size - active).
+func (p *WorkerPool) Free() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	free := p.size - p.active
+	if free < 0 {
+		return 0
+	}
+	return free
+}
+
+// Active returns the number of workers currently executing a job.
+func (p *WorkerPool) Active() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.active
+}
+
+// Dispatch enqueues a job. Non-blocking: returns false when the queue
+// is full.
+func (p *WorkerPool) Dispatch(job Job) bool {
+	p.mu.Lock()
+	if p.stopped {
+		p.mu.Unlock()
+		return false
+	}
+	ch := p.jobs
+	p.mu.Unlock()
+	select {
+	case ch <- job:
+		return true
+	default:
+		return false
+	}
+}
+
+// Resize changes the number of workers. Grow spawns new goroutines
+// immediately. Shrink queues excess-exit tokens; excess workers exit
+// after their current job completes. In-flight jobs are never cancelled.
+func (p *WorkerPool) Resize(newSize int) {
+	if newSize <= 0 {
+		newSize = 1
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if newSize == p.size {
+		return
+	}
+	if newSize > p.size {
+		toAdd := newSize - p.size
+		p.size = newSize
+		if p.started && !p.stopped {
+			for i := 0; i < toAdd; i++ {
+				p.spawnWorkerLocked()
+			}
+		}
+		return
+	}
+	toRemove := p.size - newSize
+	p.size = newSize
+	for i := 0; i < toRemove; i++ {
+		select {
+		case p.excessQuit <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// Stop closes the job queue and waits for workers to drain remaining
+// jobs. Returns ctx.Err() if the deadline fires before all workers exit.
+func (p *WorkerPool) Stop(ctx context.Context) error {
+	p.mu.Lock()
+	if p.stopped {
+		p.mu.Unlock()
+		return nil
+	}
+	p.stopped = true
+	close(p.jobs)
+	p.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/internal/daemon/intervalsched/workerpool.go
+++ b/internal/daemon/intervalsched/workerpool.go
@@ -24,7 +24,7 @@ type JobRunner interface {
 // WorkerPool is a bounded goroutine pool with a non-blocking dispatch
 // queue. Resize grows immediately and shrinks by letting excess workers
 // exit after their current job completes — in-flight jobs are never
-// cancelled by a resize.
+// canceled by a resize.
 //
 // The job queue buffer is set at construction to the initial size and
 // never shrinks. Resize changes the number of worker goroutines only;
@@ -165,7 +165,7 @@ func (p *WorkerPool) Dispatch(job Job) bool {
 
 // Resize changes the number of workers. Grow spawns new goroutines
 // immediately. Shrink queues excess-exit tokens; excess workers exit
-// after their current job completes. In-flight jobs are never cancelled.
+// after their current job completes. In-flight jobs are never canceled.
 func (p *WorkerPool) Resize(newSize int) {
 	if newSize <= 0 {
 		newSize = 1

--- a/internal/daemon/intervalsched/workerpool_test.go
+++ b/internal/daemon/intervalsched/workerpool_test.go
@@ -1,0 +1,332 @@
+package intervalsched
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// runnerFunc adapts a plain function to JobRunner.
+type runnerFunc func(ctx context.Context, job Job) error
+
+func (f runnerFunc) Run(ctx context.Context, job Job) error { return f(ctx, job) }
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// trackPeak wraps a runner body while tracking the peak concurrent
+// active count observed.
+type peakTracker struct {
+	mu   sync.Mutex
+	cur  int
+	peak int
+}
+
+func (pt *peakTracker) enter() {
+	pt.mu.Lock()
+	pt.cur++
+	if pt.cur > pt.peak {
+		pt.peak = pt.cur
+	}
+	pt.mu.Unlock()
+}
+
+func (pt *peakTracker) leave() {
+	pt.mu.Lock()
+	pt.cur--
+	pt.mu.Unlock()
+}
+
+func (pt *peakTracker) Peak() int {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
+	return pt.peak
+}
+
+// dispatchUntil retries Dispatch at a short cadence until the queue
+// accepts it or the deadline passes.
+func dispatchUntil(t *testing.T, p *WorkerPool, job Job, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if p.Dispatch(job) {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("dispatch timed out after %s", timeout)
+}
+
+func TestWorkerPool_BoundedConcurrency(t *testing.T) {
+	t.Parallel()
+	pt := &peakTracker{}
+	runner := runnerFunc(func(ctx context.Context, job Job) error {
+		pt.enter()
+		time.Sleep(100 * time.Millisecond)
+		pt.leave()
+		return nil
+	})
+	pool := NewWorkerPool(2, runner, quietLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool.Start(ctx)
+
+	for i := 0; i < 5; i++ {
+		dispatchUntil(t, pool, Job{ScheduleID: "s", TargetID: "t"}, time.Second)
+	}
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	if err := pool.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if pt.Peak() > 2 {
+		t.Fatalf("peak active %d exceeds size 2", pt.Peak())
+	}
+	if pt.Peak() < 1 {
+		t.Fatalf("expected jobs to run, peak=%d", pt.Peak())
+	}
+}
+
+func TestWorkerPool_FullBufferNonBlocking(t *testing.T) {
+	t.Parallel()
+	// One worker, buffer sized to 1. Submit two blocking jobs: first
+	// takes the worker, second sits in the buffer. Third Dispatch must
+	// return false immediately.
+	hold := make(chan struct{})
+	runner := runnerFunc(func(ctx context.Context, job Job) error {
+		<-hold
+		return nil
+	})
+	pool := NewWorkerPool(1, runner, quietLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool.Start(ctx)
+
+	// Fill the running worker.
+	if !pool.Dispatch(Job{ScheduleID: "a"}) {
+		t.Fatalf("first dispatch failed")
+	}
+	// Wait until the worker has pulled it off, freeing the buffer.
+	deadline := time.Now().Add(time.Second)
+	for pool.Active() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	// Now queue up the buffer.
+	if !pool.Dispatch(Job{ScheduleID: "b"}) {
+		t.Fatalf("buffering dispatch failed")
+	}
+	start := time.Now()
+	accepted := pool.Dispatch(Job{ScheduleID: "c"})
+	elapsed := time.Since(start)
+	if accepted {
+		t.Fatalf("expected third dispatch to return false")
+	}
+	if elapsed > 10*time.Millisecond {
+		t.Fatalf("dispatch took too long: %s", elapsed)
+	}
+	close(hold)
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	if err := pool.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}
+
+func TestWorkerPool_Resize_Grow(t *testing.T) {
+	t.Parallel()
+	pt := &peakTracker{}
+	runner := runnerFunc(func(ctx context.Context, job Job) error {
+		pt.enter()
+		time.Sleep(80 * time.Millisecond)
+		pt.leave()
+		return nil
+	})
+	pool := NewWorkerPool(2, runner, quietLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool.Start(ctx)
+
+	pool.Resize(4)
+	// Dispatch a burst. Buffer was sized to 2 so retry until accepted.
+	for i := 0; i < 8; i++ {
+		dispatchUntil(t, pool, Job{ScheduleID: "s"}, time.Second)
+	}
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	if err := pool.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if pt.Peak() > 4 {
+		t.Fatalf("peak active %d exceeds post-grow size 4", pt.Peak())
+	}
+	if pt.Peak() <= 2 {
+		t.Fatalf("expected grow to raise peak above 2, got %d", pt.Peak())
+	}
+}
+
+func TestWorkerPool_Resize_Shrink(t *testing.T) {
+	t.Parallel()
+	var active int64
+	var peak int64
+	// Jobs whose TargetID is "phase1" block on hold1; phase2 blocks on hold2.
+	hold1 := make(chan struct{})
+	hold2 := make(chan struct{})
+	runner := runnerFunc(func(ctx context.Context, job Job) error {
+		n := atomic.AddInt64(&active, 1)
+		for {
+			p := atomic.LoadInt64(&peak)
+			if n <= p || atomic.CompareAndSwapInt64(&peak, p, n) {
+				break
+			}
+		}
+		switch job.TargetID {
+		case "phase1":
+			<-hold1
+		case "phase2":
+			<-hold2
+		}
+		atomic.AddInt64(&active, -1)
+		return nil
+	})
+	pool := NewWorkerPool(4, runner, quietLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool.Start(ctx)
+
+	for i := 0; i < 4; i++ {
+		dispatchUntil(t, pool, Job{TargetID: "phase1"}, time.Second)
+	}
+	deadline := time.Now().Add(time.Second)
+	for atomic.LoadInt64(&active) < 4 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := atomic.LoadInt64(&active); got != 4 {
+		t.Fatalf("expected 4 active, got %d", got)
+	}
+
+	pool.Resize(2)
+	close(hold1) // let the 4 in-flight finish; 2 workers will exit
+
+	// Wait for 2 workers to exit.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		pool.mu.Lock()
+		workers := pool.workers
+		pool.mu.Unlock()
+		if workers == 2 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	pool.mu.Lock()
+	workers := pool.workers
+	pool.mu.Unlock()
+	if workers != 2 {
+		t.Fatalf("expected 2 remaining workers after shrink, got %d", workers)
+	}
+
+	// Reset peak for phase 2.
+	atomic.StoreInt64(&peak, 0)
+
+	for i := 0; i < 4; i++ {
+		dispatchUntil(t, pool, Job{TargetID: "phase2"}, time.Second)
+	}
+	// Give workers time to hit peak.
+	deadline = time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt64(&active) >= 2 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(hold2)
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	if err := pool.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if p := atomic.LoadInt64(&peak); p > 2 {
+		t.Fatalf("post-shrink peak %d exceeds 2", p)
+	}
+}
+
+func TestWorkerPool_Stop_Graceful(t *testing.T) {
+	t.Parallel()
+	var ran int64
+	runner := runnerFunc(func(ctx context.Context, job Job) error {
+		time.Sleep(30 * time.Millisecond)
+		atomic.AddInt64(&ran, 1)
+		return nil
+	})
+	pool := NewWorkerPool(2, runner, quietLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool.Start(ctx)
+
+	for i := 0; i < 4; i++ {
+		dispatchUntil(t, pool, Job{}, time.Second)
+	}
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	if err := pool.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if atomic.LoadInt64(&ran) != 4 {
+		t.Fatalf("expected 4 jobs to run, got %d", ran)
+	}
+}
+
+func TestWorkerPool_Stop_Deadline(t *testing.T) {
+	t.Parallel()
+	runner := runnerFunc(func(ctx context.Context, job Job) error {
+		time.Sleep(time.Second)
+		return nil
+	})
+	pool := NewWorkerPool(1, runner, quietLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool.Start(ctx)
+
+	if !pool.Dispatch(Job{}) {
+		t.Fatalf("dispatch failed")
+	}
+	// Wait until the job is active.
+	deadline := time.Now().Add(time.Second)
+	for pool.Active() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer stopCancel()
+	err := pool.Stop(stopCtx)
+	if err == nil {
+		t.Fatalf("expected deadline error")
+	}
+	if err != context.DeadlineExceeded {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestWorkerPool_DispatchAfterStop(t *testing.T) {
+	t.Parallel()
+	runner := runnerFunc(func(ctx context.Context, job Job) error { return nil })
+	pool := NewWorkerPool(1, runner, quietLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool.Start(ctx)
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+	defer stopCancel()
+	if err := pool.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if pool.Dispatch(Job{}) {
+		t.Fatalf("dispatch after stop should fail")
+	}
+}


### PR DESCRIPTION
## Summary

Adds six library primitives under `internal/daemon/intervalsched/` for SCHED1.2b to consume. Pure additions; zero runtime behavior change.

- `TargetLockIndex` — per-target non-blocking mutex via a `sync.Map` of buffered(1) channels.
- `WorkerPool` — bounded goroutine pool with non-blocking `Dispatch`, cooperative shrink, graceful `Stop`.
- `BlackoutEvaluator` — cached RRULE-expanding "is target T in a blackout at time t?" evaluator; global + per-target scopes; 30s TTL.
- `RRuleExpander` — computes next UTC fire for a schedule honoring effective config, deterministic jitter, and blackout-skip loop (bails with `ErrBlackoutSaturated`).
- `ValidateNoOverlap` — pure per-target overlap detector over a horizon.
- `RecomputeNextRunForTemplate` — cascade service that recomputes `next_run_at` for schedules that don't override rrule/timezone.

Every primitive has its own file + its own tests. No caller anywhere in the daemon / HTTP / CLI / detection / storage layers — consumers land in SCHED1.2b.

## Review checklist

- [x] Each primitive has its own file + its own test file.
- [x] Zero callers outside `internal/daemon/intervalsched/`.
- [x] `scheduler.go` diff is empty (only new sibling files added).
- [x] `daemon.go`, detection tools, webui, cli untouched.
- [x] `go test ./internal/daemon/intervalsched/... -race` passes.
- [x] ≥ 85% coverage per new file.
- [x] No file > 500 LOC (source + tests).
- [x] No `-tags=integration`, no daemon boot in tests.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/daemon/intervalsched/...`
- [x] `go test ./... -count=1 -race`
- [x] `golangci-lint run ./...`