### PR TITLE
sched1.2c: detection tool rewire, pause-in-flight, ad-hoc scans

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -234,7 +234,7 @@ func durationOr(d, fallback time.Duration) time.Duration {
 // scan_schedules table simply produces an idle tick loop.
 func buildScheduler(_ config.SchedulerConfig, _ daemon.Paths, store *storage.SQLiteStore) (daemon.Scheduler, error) {
 	registry := detection.NewRegistry()
-	runner := daemon.NewLegacyScanRunner(store, registry, slog.Default())
+	runner := daemon.NewScanRunner(store, registry, slog.Default())
 
 	sched, err := intervalsched.New(intervalsched.Dependencies{
 		SchedStore:    store.Schedules(),

--- a/internal/daemon/intervalsched/scheduler.go
+++ b/internal/daemon/intervalsched/scheduler.go
@@ -15,6 +15,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/surfbot-io/surfbot-agent/internal/model"
 	"github.com/surfbot-io/surfbot-agent/internal/storage"
 )
@@ -69,9 +71,36 @@ type inflightJob struct {
 }
 
 // jobKey is the inflight map key. Schedule jobs use the schedule ID;
-// SCHED1.2c will dispatch ad-hoc jobs with the "adhoc:" prefix so both
-// kinds coexist without collision.
+// ad-hoc jobs use the "adhoc:" prefix so both kinds coexist in the
+// in-flight table without collision.
 func jobKey(scheduleID string) string { return scheduleID }
+
+func adHocJobKey(adHocID string) string { return "adhoc:" + adHocID }
+
+// ErrTargetBusy is returned by DispatchAdHoc when the target's
+// per-target lock is already held by another in-flight scan.
+var ErrTargetBusy = errors.New("target busy")
+
+// ErrInBlackout is returned by DispatchAdHoc when the target is inside
+// an active blackout window at dispatch time. Ad-hoc dispatches refuse
+// to run during a blackout — operators who insist must wait for the
+// window to close.
+var ErrInBlackout = errors.New("target in blackout")
+
+// adHocPayload wraps an AdHocScanRun with a synchronous result channel
+// so DispatchAdHoc can block until the worker pool finishes the scan.
+// The pool dispatches Jobs with this in Payload; scanJobRunner
+// type-switches on the payload to drive the ad-hoc bookkeeping path
+// (ad_hoc_scan_runs row updates) instead of the schedule path.
+type adHocPayload struct {
+	run    model.AdHocScanRun
+	result chan adHocResult
+}
+
+type adHocResult struct {
+	scanID string
+	err    error
+}
 
 // Scheduler is the master ticker. It owns the worker pool, target lock
 // index, blackout evaluator, rrule expander, and the in-flight job
@@ -233,6 +262,68 @@ func (s *Scheduler) Next() time.Time {
 	return *due[0].NextRunAt
 }
 
+// DispatchAdHoc dispatches an ad-hoc scan for a target. It honors
+// per-target serialization (waits for the target lock — non-blocking,
+// returns ErrTargetBusy on contention) and refuses to dispatch while a
+// blackout covers the target (returns ErrInBlackout). Ad-hoc runs
+// participate in pause-in-flight: an active mid-scan blackout cancels
+// their ctx the same way scheduled scans are cancelled.
+//
+// The method blocks until the underlying scan completes and returns
+// the new scan's ID. Callers that want async semantics (e.g. the HTTP
+// trigger handler) wrap the call in a goroutine.
+//
+// On dispatch the ad_hoc_scan_runs row transitions Pending → Running;
+// on completion it transitions to Completed (with scan_id attached) or
+// Failed.
+func (s *Scheduler) DispatchAdHoc(ctx context.Context, run model.AdHocScanRun) (string, error) {
+	if run.TargetID == "" {
+		return "", fmt.Errorf("DispatchAdHoc: target_id is required")
+	}
+	if !s.locks.TryAcquire(run.TargetID) {
+		return "", ErrTargetBusy
+	}
+	now := s.deps.Clock.Now()
+	active, _ := s.blackouts.IsActive(run.TargetID, now)
+	if active {
+		s.locks.Release(run.TargetID)
+		return "", ErrInBlackout
+	}
+	if run.ID == "" {
+		run.ID = uuid.New().String()
+	}
+	// Mark the row as running. The lock is held; the worker pool runs the
+	// scan on a goroutine and signals completion via adHocPayload.result.
+	if s.deps.AdHocStore != nil {
+		_ = s.deps.AdHocStore.UpdateStatus(ctx, run.ID, model.AdHocRunning, now.UTC())
+	}
+
+	resultCh := make(chan adHocResult, 1)
+	job := Job{
+		ScheduleID: adHocJobKey(run.ID),
+		TargetID:   run.TargetID,
+		Payload:    &adHocPayload{run: run, result: resultCh},
+	}
+	if !s.pool.Dispatch(job) {
+		s.locks.Release(run.TargetID)
+		if s.deps.AdHocStore != nil {
+			_ = s.deps.AdHocStore.UpdateStatus(ctx, run.ID, model.AdHocFailed, time.Now().UTC())
+		}
+		return "", fmt.Errorf("worker pool full; ad-hoc dispatch rejected")
+	}
+
+	select {
+	case res := <-resultCh:
+		return res.scanID, res.err
+	case <-ctx.Done():
+		// Caller cancelled; the worker keeps running until the scan
+		// completes on its own. We surface the ctx error to the caller
+		// but the ad_hoc_scan_runs row will still get updated by the
+		// worker.
+		return "", ctx.Err()
+	}
+}
+
 // tickLoop fires every TickInterval and dispatches due schedules.
 func (s *Scheduler) tickLoop() {
 	defer s.wg.Done()
@@ -370,8 +461,74 @@ type scanJobRunner struct {
 	s *Scheduler
 }
 
+// runAdHoc handles a worker job whose payload is an *adHocPayload.
+// Resolves EffectiveConfig from the AdHocScanRun (template + defaults
+// + inline overrides), runs the scan with pause-in-flight ctx tracking,
+// updates ad_hoc_scan_runs on completion, and signals the originating
+// DispatchAdHoc caller via payload.result.
+func (r *scanJobRunner) runAdHoc(ctx context.Context, job Job, ah *adHocPayload) error {
+	run := ah.run
+	tmpl := r.s.loadTemplate(ctx, run.TemplateID)
+	// Synthesize a Schedule shell so ResolveEffectiveConfig works against
+	// the same cascade rules as scheduled scans.
+	pseudo := model.Schedule{
+		TargetID:   run.TargetID,
+		ToolConfig: run.ToolConfig,
+		TemplateID: run.TemplateID,
+		Timezone:   r.s.defaults.DefaultTimezone,
+		RRule:      r.s.defaults.DefaultRRule,
+	}
+	effective, err := model.ResolveEffectiveConfig(pseudo, tmpl, r.s.defaults)
+	if err != nil {
+		ah.result <- adHocResult{err: fmt.Errorf("resolve effective config: %w", err)}
+		if r.s.deps.AdHocStore != nil {
+			_ = r.s.deps.AdHocStore.UpdateStatus(context.Background(), run.ID, model.AdHocFailed, time.Now().UTC())
+		}
+		return err
+	}
+
+	jobCtx, cancel := context.WithCancelCause(ctx)
+	key := adHocJobKey(run.ID)
+	r.s.inflight.Store(key, &inflightJob{
+		scheduleID: run.ID,
+		targetID:   run.TargetID,
+		acquiredAt: r.s.deps.Clock.Now(),
+		cancel:     cancel,
+	})
+	defer func() {
+		r.s.inflight.Delete(key)
+		cancel(nil)
+	}()
+
+	scanID, runErr := r.s.deps.Runner.Run(jobCtx, job.ScheduleID, run.TargetID, effective)
+	completedAt := time.Now().UTC()
+
+	finalStatus := model.AdHocCompleted
+	if runErr != nil {
+		finalStatus = model.AdHocFailed
+		if errors.Is(runErr, context.Canceled) && errors.Is(context.Cause(jobCtx), BlackoutPauseCause) {
+			r.s.deps.Log.Info("ad-hoc scan paused by blackout",
+				"adhoc_id", run.ID, "target_id", run.TargetID)
+		}
+	}
+
+	if r.s.deps.AdHocStore != nil {
+		if scanID != "" {
+			_ = r.s.deps.AdHocStore.AttachScan(context.Background(), run.ID, scanID)
+		}
+		_ = r.s.deps.AdHocStore.UpdateStatus(context.Background(), run.ID, finalStatus, completedAt)
+	}
+
+	ah.result <- adHocResult{scanID: scanID, err: runErr}
+	return runErr
+}
+
 func (r *scanJobRunner) Run(ctx context.Context, job Job) error {
 	defer r.s.locks.Release(job.TargetID)
+
+	if adhoc, ok := job.Payload.(*adHocPayload); ok {
+		return r.runAdHoc(ctx, job, adhoc)
+	}
 
 	sched, ok := job.Payload.(model.Schedule)
 	if !ok {

--- a/internal/daemon/intervalsched/scheduler.go
+++ b/internal/daemon/intervalsched/scheduler.go
@@ -58,9 +58,24 @@ type Dependencies struct {
 	JitterSeed    int64
 }
 
+// inflightJob tracks one dispatched scan so the master ticker can cancel
+// its ctx mid-flight when the target enters a new blackout window
+// (SCHED1.2c R8). Keyed in Scheduler.inflight by jobKey().
+type inflightJob struct {
+	scheduleID string
+	targetID   string
+	acquiredAt time.Time
+	cancel     context.CancelCauseFunc
+}
+
+// jobKey is the inflight map key. Schedule jobs use the schedule ID;
+// SCHED1.2c will dispatch ad-hoc jobs with the "adhoc:" prefix so both
+// kinds coexist without collision.
+func jobKey(scheduleID string) string { return scheduleID }
+
 // Scheduler is the master ticker. It owns the worker pool, target lock
-// index, blackout evaluator, and rrule expander. Construct via New, then
-// Start to launch the tick loop in a goroutine.
+// index, blackout evaluator, rrule expander, and the in-flight job
+// table used by pause-in-flight.
 type Scheduler struct {
 	deps      Dependencies
 	defaults  model.ScheduleDefaults
@@ -69,10 +84,11 @@ type Scheduler struct {
 	blackouts *BlackoutEvaluator
 	expander  *RRuleExpander
 
-	mu     sync.Mutex
-	ctx    context.Context
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
+	mu       sync.Mutex
+	ctx      context.Context
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	inflight sync.Map // map[string]*inflightJob, keyed by jobKey
 }
 
 // New wires the master ticker. It loads schedule_defaults synchronously
@@ -340,7 +356,20 @@ func (r *scanJobRunner) Run(ctx context.Context, job Job) error {
 		return fmt.Errorf("resolve effective config: %w", err)
 	}
 
-	scanID, runErr := r.s.deps.Runner.Run(ctx, sched.ID, sched.TargetID, effective)
+	jobCtx, cancel := context.WithCancelCause(ctx)
+	key := jobKey(sched.ID)
+	r.s.inflight.Store(key, &inflightJob{
+		scheduleID: sched.ID,
+		targetID:   sched.TargetID,
+		acquiredAt: r.s.deps.Clock.Now(),
+		cancel:     cancel,
+	})
+	defer func() {
+		r.s.inflight.Delete(key)
+		cancel(nil)
+	}()
+
+	scanID, runErr := r.s.deps.Runner.Run(jobCtx, sched.ID, sched.TargetID, effective)
 	completedAt := time.Now().UTC()
 
 	status := model.ScheduleRunSuccess

--- a/internal/daemon/intervalsched/scheduler.go
+++ b/internal/daemon/intervalsched/scheduler.go
@@ -315,12 +315,40 @@ func (s *Scheduler) handleBlackoutSkip(sched model.Schedule, now time.Time) {
 	}
 }
 
-// evaluateInFlightBlackouts is a no-op in SCHED1.2b. SCHED1.2c will
-// iterate live jobs and cancel ctx for any whose target enters a new
-// blackout window.
-//
-// TODO: SCHED1.2c — implement pause-in-flight ctx cancellation.
-func (s *Scheduler) evaluateInFlightBlackouts(_ time.Time) {}
+// BlackoutPauseCause is attached to in-flight job ctx via
+// context.WithCancelCause when a blackout activates mid-scan.
+// scanJobRunner inspects context.Cause(ctx) to distinguish this cause
+// from a normal shutdown / operator cancel and records the schedule run
+// as ScheduleRunPausedBlackout on completion.
+var BlackoutPauseCause = errors.New("blackout activated")
+
+// evaluateInFlightBlackouts walks the in-flight job table and cancels
+// the ctx of any job whose target has entered a blackout since dispatch.
+// Jobs that were already in a blackout at dispatch time (defensive —
+// the ticker shouldn't have dispatched them) are left alone so the same
+// blackout doesn't double-cancel them.
+func (s *Scheduler) evaluateInFlightBlackouts(now time.Time) {
+	s.inflight.Range(func(_, value any) bool {
+		job := value.(*inflightJob)
+		activeNow, _ := s.blackouts.IsActive(job.targetID, now)
+		if !activeNow {
+			return true
+		}
+		activeThen, _ := s.blackouts.IsActive(job.targetID, job.acquiredAt)
+		if activeThen {
+			// Pre-existing blackout — the ticker shouldn't have
+			// dispatched this. Don't double-cancel; just log so the
+			// regression is observable.
+			s.deps.Log.Warn("blackout active at dispatch time; in-flight check skipped",
+				"schedule_id", job.scheduleID, "target_id", job.targetID)
+			return true
+		}
+		s.deps.Log.Info("scan paused by blackout",
+			"schedule_id", job.scheduleID, "target_id", job.targetID)
+		job.cancel(BlackoutPauseCause)
+		return true
+	})
+}
 
 func (s *Scheduler) loadTemplate(ctx context.Context, id *string) *model.Template {
 	if id == nil || *id == "" {
@@ -374,12 +402,16 @@ func (r *scanJobRunner) Run(ctx context.Context, job Job) error {
 
 	status := model.ScheduleRunSuccess
 	if runErr != nil {
-		// SCHED1.2c will distinguish blackout-cancel from operator-cancel
-		// from real failure. For 1.2b every error path lands as failed.
 		status = model.ScheduleRunFailed
 		if errors.Is(runErr, context.Canceled) {
-			r.s.deps.Log.Info("scan canceled",
-				"schedule_id", sched.ID, "target_id", sched.TargetID)
+			if errors.Is(context.Cause(jobCtx), BlackoutPauseCause) {
+				status = model.ScheduleRunPausedBlackout
+				r.s.deps.Log.Info("scan paused by blackout (final)",
+					"schedule_id", sched.ID, "target_id", sched.TargetID)
+			} else {
+				r.s.deps.Log.Info("scan canceled",
+					"schedule_id", sched.ID, "target_id", sched.TargetID)
+			}
 		}
 	}
 

--- a/internal/daemon/intervalsched/scheduler.go
+++ b/internal/daemon/intervalsched/scheduler.go
@@ -267,7 +267,7 @@ func (s *Scheduler) Next() time.Time {
 // returns ErrTargetBusy on contention) and refuses to dispatch while a
 // blackout covers the target (returns ErrInBlackout). Ad-hoc runs
 // participate in pause-in-flight: an active mid-scan blackout cancels
-// their ctx the same way scheduled scans are cancelled.
+// their ctx the same way scheduled scans are canceled.
 //
 // The method blocks until the underlying scan completes and returns
 // the new scan's ID. Callers that want async semantics (e.g. the HTTP
@@ -316,7 +316,7 @@ func (s *Scheduler) DispatchAdHoc(ctx context.Context, run model.AdHocScanRun) (
 	case res := <-resultCh:
 		return res.scanID, res.err
 	case <-ctx.Done():
-		// Caller cancelled; the worker keeps running until the scan
+		// Caller canceled; the worker keeps running until the scan
 		// completes on its own. We surface the ctx error to the caller
 		// but the ad_hoc_scan_runs row will still get updated by the
 		// worker.
@@ -406,12 +406,12 @@ func (s *Scheduler) handleBlackoutSkip(sched model.Schedule, now time.Time) {
 	}
 }
 
-// BlackoutPauseCause is attached to in-flight job ctx via
+// ErrBlackoutPause is attached to in-flight job ctx via
 // context.WithCancelCause when a blackout activates mid-scan.
 // scanJobRunner inspects context.Cause(ctx) to distinguish this cause
 // from a normal shutdown / operator cancel and records the schedule run
 // as ScheduleRunPausedBlackout on completion.
-var BlackoutPauseCause = errors.New("blackout activated")
+var ErrBlackoutPause = errors.New("blackout activated")
 
 // evaluateInFlightBlackouts walks the in-flight job table and cancels
 // the ctx of any job whose target has entered a blackout since dispatch.
@@ -436,7 +436,7 @@ func (s *Scheduler) evaluateInFlightBlackouts(now time.Time) {
 		}
 		s.deps.Log.Info("scan paused by blackout",
 			"schedule_id", job.scheduleID, "target_id", job.targetID)
-		job.cancel(BlackoutPauseCause)
+		job.cancel(ErrBlackoutPause)
 		return true
 	})
 }
@@ -506,7 +506,7 @@ func (r *scanJobRunner) runAdHoc(ctx context.Context, job Job, ah *adHocPayload)
 	finalStatus := model.AdHocCompleted
 	if runErr != nil {
 		finalStatus = model.AdHocFailed
-		if errors.Is(runErr, context.Canceled) && errors.Is(context.Cause(jobCtx), BlackoutPauseCause) {
+		if errors.Is(runErr, context.Canceled) && errors.Is(context.Cause(jobCtx), ErrBlackoutPause) {
 			r.s.deps.Log.Info("ad-hoc scan paused by blackout",
 				"adhoc_id", run.ID, "target_id", run.TargetID)
 		}
@@ -561,7 +561,7 @@ func (r *scanJobRunner) Run(ctx context.Context, job Job) error {
 	if runErr != nil {
 		status = model.ScheduleRunFailed
 		if errors.Is(runErr, context.Canceled) {
-			if errors.Is(context.Cause(jobCtx), BlackoutPauseCause) {
+			if errors.Is(context.Cause(jobCtx), ErrBlackoutPause) {
 				status = model.ScheduleRunPausedBlackout
 				r.s.deps.Log.Info("scan paused by blackout (final)",
 					"schedule_id", sched.ID, "target_id", sched.TargetID)

--- a/internal/daemon/intervalsched/scheduler_integration_test.go
+++ b/internal/daemon/intervalsched/scheduler_integration_test.go
@@ -1,0 +1,299 @@
+//go:build integration
+
+package intervalsched
+
+// SCHED1.2c integration test (R14): exercises the master ticker against
+// a real :memory: SQLite and the production stores. Three scenarios in
+// one file, total wall-clock budget ≤ 10 s. Detection tools are NOT
+// invoked — the ScanRunner is a fake that records calls and respects
+// ctx, so this is end-to-end through the scheduler / stores layer
+// without external network or binary dependencies.
+//
+// Run with: go test -tags=integration ./internal/daemon/intervalsched/... -race -count=1
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// integScanRunner satisfies ScanRunner. Optionally creates a real scan
+// row in the store so RecordRun's FK on scan_schedules.last_scan_id is
+// satisfied without invoking the real pipeline.
+type integScanRunner struct {
+	store    *storage.SQLiteStore
+	mu       sync.Mutex
+	calls    []string
+	scanIDs  []string
+	delay    time.Duration
+	blockCh  chan struct{}
+	observed atomic.Bool
+}
+
+func (r *integScanRunner) Run(ctx context.Context, scheduleID, targetID string, _ model.EffectiveConfig) (string, error) {
+	r.mu.Lock()
+	r.calls = append(r.calls, scheduleID+":"+targetID)
+	delay := r.delay
+	block := r.blockCh
+	r.mu.Unlock()
+
+	if block != nil {
+		select {
+		case <-block:
+		case <-ctx.Done():
+			r.observed.Store(true)
+			return "", ctx.Err()
+		}
+	}
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			r.observed.Store(true)
+			return "", ctx.Err()
+		}
+	}
+
+	// Create a real scans row so RecordRun's FK constraint is satisfied.
+	now := time.Now().UTC()
+	scan := &model.Scan{
+		TargetID:   targetID,
+		Type:       model.ScanTypeFull,
+		Status:     model.ScanStatusCompleted,
+		StartedAt:  &now,
+		FinishedAt: &now,
+	}
+	if err := r.store.CreateScan(ctx, scan); err != nil {
+		return "", err
+	}
+	r.mu.Lock()
+	r.scanIDs = append(r.scanIDs, scan.ID)
+	r.mu.Unlock()
+	return scan.ID, nil
+}
+
+func (r *integScanRunner) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
+}
+
+func newIntegStore(t *testing.T) *storage.SQLiteStore {
+	t.Helper()
+	// :memory: SQLite is per-connection; the production *sql.DB pool
+	// defeats schema sharing. Use a file in the test's temp dir so all
+	// pool connections see the same DB.
+	s, err := storage.NewSQLiteStore(filepath.Join(t.TempDir(), "integ.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func newIntegScheduler(t *testing.T, store *storage.SQLiteStore, runner ScanRunner) *Scheduler {
+	t.Helper()
+	s, err := New(Dependencies{
+		SchedStore:    store.Schedules(),
+		TmplStore:     store.Templates(),
+		BlackoutStore: store.Blackouts(),
+		DefaultsStore: store.ScheduleDefaults(),
+		AdHocStore:    store.AdHocScanRuns(),
+		Runner:        runner,
+		TickInterval:  100 * time.Millisecond,
+		JitterSeed:    1,
+	})
+	require.NoError(t, err)
+	return s
+}
+
+func TestIntegration_EndToEnd(t *testing.T) {
+	t.Parallel()
+	store := newIntegStore(t)
+	ctx := context.Background()
+
+	// Two targets, three schedules. All due immediately so the first tick
+	// dispatches every one of them. ScanRunner returns quickly.
+	now := time.Now().UTC()
+	due := now
+	for _, tgt := range []string{"alpha.example", "beta.example"} {
+		require.NoError(t, store.CreateTarget(ctx, &model.Target{Value: tgt, Enabled: true}))
+	}
+	targets, err := store.ListTargets(ctx)
+	require.NoError(t, err)
+	require.Len(t, targets, 2)
+
+	for i, tgt := range targets {
+		// Two schedules on alpha, one on beta — exercises per-target
+		// serialization (lock).
+		count := 1
+		if i == 0 {
+			count = 2
+		}
+		for j := 0; j < count; j++ {
+			name := "sched"
+			if j == 1 {
+				name = "sched2"
+			}
+			require.NoError(t, store.Schedules().Create(ctx, &model.Schedule{
+				TargetID:  tgt.ID,
+				Name:      name,
+				RRule:     "FREQ=DAILY",
+				DTStart:   now,
+				Timezone:  "UTC",
+				Enabled:   true,
+				NextRunAt: &due,
+			}))
+		}
+	}
+
+	runner := &integScanRunner{store: store}
+	s := newIntegScheduler(t, store, runner)
+	require.NoError(t, s.Start(ctx))
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = s.Stop(stopCtx)
+	}()
+
+	// 3 schedules, each fires once. Allow several ticks (per-target lock
+	// serializes the two schedules on alpha so they fire across at least
+	// two ticks).
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && runner.callCount() < 3 {
+		time.Sleep(50 * time.Millisecond)
+	}
+	assert.GreaterOrEqual(t, runner.callCount(), 3, "all 3 schedules must fire")
+
+	// Each schedule's last_run_status must be success.
+	all, err := store.Schedules().ListAll(ctx)
+	require.NoError(t, err)
+	for _, sched := range all {
+		assert.NotNil(t, sched.LastRunStatus, "schedule %s missing LastRunStatus", sched.Name)
+		if sched.LastRunStatus != nil {
+			assert.Equal(t, model.ScheduleRunSuccess, *sched.LastRunStatus,
+				"schedule %s status: %v", sched.Name, *sched.LastRunStatus)
+		}
+	}
+}
+
+func TestIntegration_PauseInFlight(t *testing.T) {
+	t.Parallel()
+	store := newIntegStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateTarget(ctx, &model.Target{Value: "slow.example", Enabled: true}))
+	targets, err := store.ListTargets(ctx)
+	require.NoError(t, err)
+	tgt := targets[0]
+
+	due := time.Now().UTC()
+	require.NoError(t, store.Schedules().Create(ctx, &model.Schedule{
+		TargetID:  tgt.ID,
+		Name:      "slow",
+		RRule:     "FREQ=DAILY",
+		DTStart:   due,
+		Timezone:  "UTC",
+		Enabled:   true,
+		NextRunAt: &due,
+	}))
+
+	// blockCh keeps the scan running until either ctx fires or the test
+	// closes the channel. The blackout-driven cancel is what we want here.
+	runner := &integScanRunner{store: store, blockCh: make(chan struct{})}
+	s := newIntegScheduler(t, store, runner)
+	require.NoError(t, s.Start(ctx))
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = s.Stop(stopCtx)
+	}()
+
+	// Wait for the scan to be in flight.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && runner.callCount() == 0 {
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.Equal(t, 1, runner.callCount(), "scan must be in flight")
+
+	// Insert a blackout that activates ~1s in the future. The storage
+	// layer overwrites CreatedAt at Create(), so we encode the start
+	// time as an explicit DTSTART in the RRULE — the BlackoutEvaluator
+	// honors RRULE-supplied DTSTART over CreatedAt fallback.
+	startAt := time.Now().UTC().Add(1 * time.Second).Truncate(time.Second)
+	rrule := "DTSTART:" + startAt.Format("20060102T150405Z") + "\nRRULE:FREQ=DAILY;COUNT=1"
+	require.NoError(t, store.Blackouts().Create(ctx, &model.BlackoutWindow{
+		Scope:       model.BlackoutScopeGlobal,
+		Name:        "pause-now",
+		RRule:       rrule,
+		DurationSec: 600,
+		Timezone:    "UTC",
+		Enabled:     true,
+	}))
+
+	// Wait for the schedule to be marked paused_blackout.
+	deadline = time.Now().Add(5 * time.Second)
+	var sawPaused bool
+	for time.Now().Before(deadline) {
+		all, err := store.Schedules().ListAll(ctx)
+		require.NoError(t, err)
+		for _, sched := range all {
+			if sched.LastRunStatus != nil && *sched.LastRunStatus == model.ScheduleRunPausedBlackout {
+				sawPaused = true
+				break
+			}
+		}
+		if sawPaused {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	assert.True(t, sawPaused, "scan must be marked paused_blackout once blackout activates mid-flight")
+	assert.True(t, runner.observed.Load(), "scan runner must observe ctx cancel")
+}
+
+func TestIntegration_AdHoc(t *testing.T) {
+	t.Parallel()
+	store := newIntegStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateTarget(ctx, &model.Target{Value: "adhoc.example", Enabled: true}))
+	targets, err := store.ListTargets(ctx)
+	require.NoError(t, err)
+	tgt := targets[0]
+
+	runner := &integScanRunner{store: store, delay: 50 * time.Millisecond}
+	s := newIntegScheduler(t, store, runner)
+	require.NoError(t, s.Start(ctx))
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = s.Stop(stopCtx)
+	}()
+
+	run := model.AdHocScanRun{
+		TargetID:    tgt.ID,
+		InitiatedBy: "test:integration",
+		Status:      model.AdHocPending,
+		RequestedAt: time.Now().UTC(),
+	}
+	require.NoError(t, store.AdHocScanRuns().Create(ctx, &run))
+
+	scanID, err := s.DispatchAdHoc(ctx, run)
+	require.NoError(t, err)
+	assert.NotEmpty(t, scanID)
+
+	// ad_hoc_scan_runs row must reflect completion + scan_id attached.
+	persisted, err := store.AdHocScanRuns().Get(ctx, run.ID)
+	require.NoError(t, err)
+	assert.Equal(t, model.AdHocCompleted, persisted.Status)
+	require.NotNil(t, persisted.ScanID)
+	assert.Equal(t, scanID, *persisted.ScanID)
+}

--- a/internal/daemon/intervalsched/scheduler_test.go
+++ b/internal/daemon/intervalsched/scheduler_test.go
@@ -472,7 +472,7 @@ func TestScheduler_PauseInFlight_BlackoutCancelsCtx(t *testing.T) {
 		{ID: "s1", TargetID: "t1", RRule: "FREQ=DAILY", Timezone: "UTC", Enabled: true},
 	}
 	bo := &tickerBlackoutStore{}
-	// Block until ctx is cancelled — simulates a long-running scan.
+	// Block until ctx is canceled — simulates a long-running scan.
 	runner := &fakeRunner{blockCh: make(chan struct{})}
 	s := newSchedulerForTest(t, Dependencies{
 		SchedStore:    store,
@@ -578,8 +578,8 @@ func TestScheduler_PauseInFlight_DoesNotCancelPreExistingBlackout(t *testing.T) 
 	require.NoError(t, s.blackouts.Refresh(context.Background()))
 	s.evaluateInFlightBlackouts(now)
 
-	// Should not have cancelled — pre-existing blackout case.
-	assert.NoError(t, jobCtx.Err(), "ctx must not be cancelled for jobs dispatched while blackout was already active")
+	// Should not have canceled — pre-existing blackout case.
+	assert.NoError(t, jobCtx.Err(), "ctx must not be canceled for jobs dispatched while blackout was already active")
 }
 
 func TestScheduler_InflightCleanup(t *testing.T) {

--- a/internal/daemon/intervalsched/scheduler_test.go
+++ b/internal/daemon/intervalsched/scheduler_test.go
@@ -451,6 +451,37 @@ func TestScheduler_RunnerErrorRecordedAsFailed(t *testing.T) {
 	assert.Equal(t, model.ScheduleRunFailed, rec[0].Status)
 }
 
+func TestScheduler_InflightCleanup(t *testing.T) {
+	store := newTickerScheduleStore()
+	store.due = []model.Schedule{
+		{ID: "s1", TargetID: "t1", RRule: "FREQ=DAILY", Timezone: "UTC", Enabled: true},
+	}
+	runner := &fakeRunner{}
+	s := newSchedulerForTest(t, Dependencies{
+		SchedStore:    store,
+		TmplStore:     tickerTemplateStore{},
+		BlackoutStore: &tickerBlackoutStore{},
+		DefaultsStore: &fakeDefaultsStore{defaults: newDefaults()},
+		AdHocStore:    fakeAdHocStore{},
+		Runner:        runner,
+		JitterSeed:    1,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, s.Start(ctx))
+	waitFor(t, func() bool { return len(runner.snapshot()) >= 1 })
+	cancel()
+	require.NoError(t, s.Stop(context.Background()))
+
+	count := 0
+	s.inflight.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 0, count, "inflight map must be empty after job completion")
+}
+
 func TestNew_RejectsMissingDeps(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/daemon/intervalsched/scheduler_test.go
+++ b/internal/daemon/intervalsched/scheduler_test.go
@@ -104,11 +104,20 @@ func (tickerTemplateStore) Update(context.Context, *model.Template) error  { ret
 func (tickerTemplateStore) Delete(context.Context, string) error           { return nil }
 
 type tickerBlackoutStore struct {
+	mu      sync.Mutex
 	windows []model.BlackoutWindow
+}
+
+func (f *tickerBlackoutStore) setWindows(ws []model.BlackoutWindow) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.windows = ws
 }
 
 func (f *tickerBlackoutStore) Create(context.Context, *model.BlackoutWindow) error { return nil }
 func (f *tickerBlackoutStore) Get(_ context.Context, id string) (*model.BlackoutWindow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	for i := range f.windows {
 		if f.windows[i].ID == id {
 			w := f.windows[i]
@@ -118,11 +127,15 @@ func (f *tickerBlackoutStore) Get(_ context.Context, id string) (*model.Blackout
 	return nil, nil
 }
 func (f *tickerBlackoutStore) List(context.Context) ([]model.BlackoutWindow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	out := make([]model.BlackoutWindow, len(f.windows))
 	copy(out, f.windows)
 	return out, nil
 }
 func (f *tickerBlackoutStore) ListByScope(_ context.Context, scope model.BlackoutScope) ([]model.BlackoutWindow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	out := []model.BlackoutWindow{}
 	for _, w := range f.windows {
 		if w.Scope == scope {
@@ -132,6 +145,8 @@ func (f *tickerBlackoutStore) ListByScope(_ context.Context, scope model.Blackou
 	return out, nil
 }
 func (f *tickerBlackoutStore) ListByTarget(_ context.Context, targetID string) ([]model.BlackoutWindow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	out := []model.BlackoutWindow{}
 	for _, w := range f.windows {
 		if w.TargetID != nil && *w.TargetID == targetID {
@@ -449,6 +464,122 @@ func TestScheduler_RunnerErrorRecordedAsFailed(t *testing.T) {
 	rec := store.snapshotRecorded()
 	require.Len(t, rec, 1)
 	assert.Equal(t, model.ScheduleRunFailed, rec[0].Status)
+}
+
+func TestScheduler_PauseInFlight_BlackoutCancelsCtx(t *testing.T) {
+	store := newTickerScheduleStore()
+	store.due = []model.Schedule{
+		{ID: "s1", TargetID: "t1", RRule: "FREQ=DAILY", Timezone: "UTC", Enabled: true},
+	}
+	bo := &tickerBlackoutStore{}
+	// Block until ctx is cancelled — simulates a long-running scan.
+	runner := &fakeRunner{blockCh: make(chan struct{})}
+	s := newSchedulerForTest(t, Dependencies{
+		SchedStore:    store,
+		TmplStore:     tickerTemplateStore{},
+		BlackoutStore: bo,
+		DefaultsStore: &fakeDefaultsStore{defaults: newDefaults()},
+		AdHocStore:    fakeAdHocStore{},
+		Runner:        runner,
+		JitterSeed:    1,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, s.Start(ctx))
+
+	// Wait until the scan is in flight.
+	waitFor(t, func() bool { return len(runner.snapshot()) >= 1 })
+
+	// Inject a one-shot blackout that activates ~1s in the future. The
+	// rrule library truncates DTStart to seconds, so we pad CreatedAt to
+	// guarantee the window starts AFTER the job's acquiredAt — otherwise
+	// activeThen=true and the defensive "pre-existing blackout" branch
+	// fires instead of the cancel path. COUNT=1 keeps the expander loop
+	// cheap so ComputeNextRunAt terminates fast.
+	bo.setWindows([]model.BlackoutWindow{{
+		ID:          "b1",
+		Scope:       model.BlackoutScopeGlobal,
+		Name:        "future",
+		RRule:       "FREQ=DAILY;COUNT=1",
+		DurationSec: 600,
+		Timezone:    "UTC",
+		Enabled:     true,
+		CreatedAt:   time.Now().UTC().Add(1 * time.Second),
+	}})
+
+	// Wait for paused_blackout status to land. Test tick interval is 10ms.
+	// We need to wait for the blackout to activate (~1s) AND for the next
+	// tick after that (~10ms) AND for the worker to record the run.
+	deadline := time.Now().Add(4 * time.Second)
+	var sawPaused bool
+	for time.Now().Before(deadline) {
+		for _, r := range store.snapshotRecorded() {
+			if r.Status == model.ScheduleRunPausedBlackout {
+				sawPaused = true
+				break
+			}
+		}
+		if sawPaused {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer stopCancel()
+	_ = s.Stop(stopCtx)
+	assert.True(t, sawPaused, "expected last_run_status=paused_blackout after blackout activated mid-scan")
+}
+
+func TestScheduler_PauseInFlight_DoesNotCancelPreExistingBlackout(t *testing.T) {
+	// Defensive guard: if a job somehow dispatched while a blackout was
+	// already active for its target, the pause-in-flight loop must not
+	// double-cancel — that's spec R8's "activeThen" check.
+	store := newTickerScheduleStore()
+	now := time.Now().UTC()
+	bo := &tickerBlackoutStore{
+		windows: []model.BlackoutWindow{{
+			ID:          "b1",
+			Scope:       model.BlackoutScopeGlobal,
+			Name:        "always",
+			RRule:       "FREQ=MINUTELY",
+			DurationSec: 3600,
+			Timezone:    "UTC",
+			Enabled:     true,
+			CreatedAt:   now.Add(-time.Hour),
+		}},
+	}
+	runner := &fakeRunner{blockCh: make(chan struct{})}
+	s := newSchedulerForTest(t, Dependencies{
+		SchedStore:    store,
+		TmplStore:     tickerTemplateStore{},
+		BlackoutStore: bo,
+		DefaultsStore: &fakeDefaultsStore{defaults: newDefaults()},
+		AdHocStore:    fakeAdHocStore{},
+		Runner:        runner,
+		JitterSeed:    1,
+	})
+
+	// Pre-populate inflight by hand to simulate a job dispatched before
+	// the blackout was loaded. Use a dummy ctx; the cancel func observes
+	// whether it ever fires.
+	jobCtx, jobCancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { jobCancel(nil) })
+	s.inflight.Store("dispatched-pre-blackout", &inflightJob{
+		scheduleID: "dispatched-pre-blackout",
+		targetID:   "t1",
+		acquiredAt: now.Add(-time.Minute),
+		cancel:     jobCancel,
+	})
+	defer s.inflight.Delete("dispatched-pre-blackout")
+
+	require.Nil(t, bo.windows[0].TargetID) // global; covers any target
+	require.NoError(t, s.blackouts.Refresh(context.Background()))
+	s.evaluateInFlightBlackouts(now)
+
+	// Should not have cancelled — pre-existing blackout case.
+	assert.NoError(t, jobCtx.Err(), "ctx must not be cancelled for jobs dispatched while blackout was already active")
 }
 
 func TestScheduler_InflightCleanup(t *testing.T) {

--- a/internal/daemon/intervalsched/scheduler_test.go
+++ b/internal/daemon/intervalsched/scheduler_test.go
@@ -613,6 +613,130 @@ func TestScheduler_InflightCleanup(t *testing.T) {
 	assert.Equal(t, 0, count, "inflight map must be empty after job completion")
 }
 
+// recordingAdHocStore captures every UpdateStatus / AttachScan call so
+// the ad-hoc dispatch tests can assert ad_hoc_scan_runs row transitions.
+type recordingAdHocStore struct {
+	mu       sync.Mutex
+	statuses []model.AdHocRunStatus
+	scanIDs  []string
+}
+
+func (f *recordingAdHocStore) Create(context.Context, *model.AdHocScanRun) error { return nil }
+func (f *recordingAdHocStore) Get(context.Context, string) (*model.AdHocScanRun, error) {
+	return nil, nil
+}
+func (f *recordingAdHocStore) ListByTarget(context.Context, string, int) ([]model.AdHocScanRun, error) {
+	return nil, nil
+}
+func (f *recordingAdHocStore) ListByStatus(context.Context, model.AdHocRunStatus) ([]model.AdHocScanRun, error) {
+	return nil, nil
+}
+func (f *recordingAdHocStore) UpdateStatus(_ context.Context, _ string, status model.AdHocRunStatus, _ time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.statuses = append(f.statuses, status)
+	return nil
+}
+func (f *recordingAdHocStore) AttachScan(_ context.Context, _, scanID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.scanIDs = append(f.scanIDs, scanID)
+	return nil
+}
+func (f *recordingAdHocStore) Delete(context.Context, string) error { return nil }
+
+func (f *recordingAdHocStore) snapshot() ([]model.AdHocRunStatus, []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	st := make([]model.AdHocRunStatus, len(f.statuses))
+	copy(st, f.statuses)
+	ids := make([]string, len(f.scanIDs))
+	copy(ids, f.scanIDs)
+	return st, ids
+}
+
+func TestScheduler_DispatchAdHoc_Success(t *testing.T) {
+	adhoc := &recordingAdHocStore{}
+	runner := &fakeRunner{scanID: "s_adhoc"}
+	s := newSchedulerForTest(t, Dependencies{
+		SchedStore:    newTickerScheduleStore(),
+		TmplStore:     tickerTemplateStore{},
+		BlackoutStore: &tickerBlackoutStore{},
+		DefaultsStore: &fakeDefaultsStore{defaults: newDefaults()},
+		AdHocStore:    adhoc,
+		Runner:        runner,
+		JitterSeed:    1,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, s.Start(ctx))
+
+	scanID, err := s.DispatchAdHoc(context.Background(), model.AdHocScanRun{
+		ID:       "ar_1",
+		TargetID: "t1",
+		Status:   model.AdHocPending,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "s_adhoc", scanID)
+
+	statuses, scanIDs := adhoc.snapshot()
+	assert.Contains(t, statuses, model.AdHocRunning, "ad-hoc row must transition to Running")
+	assert.Contains(t, statuses, model.AdHocCompleted, "ad-hoc row must transition to Completed")
+	assert.Contains(t, scanIDs, "s_adhoc", "ad-hoc row must attach the scan ID")
+}
+
+func TestScheduler_DispatchAdHoc_TargetBusy(t *testing.T) {
+	runner := &fakeRunner{}
+	s := newSchedulerForTest(t, Dependencies{
+		SchedStore:    newTickerScheduleStore(),
+		TmplStore:     tickerTemplateStore{},
+		BlackoutStore: &tickerBlackoutStore{},
+		DefaultsStore: &fakeDefaultsStore{defaults: newDefaults()},
+		AdHocStore:    &recordingAdHocStore{},
+		Runner:        runner,
+		JitterSeed:    1,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, s.Start(ctx))
+
+	// Pre-acquire the lock so DispatchAdHoc fails to TryAcquire.
+	require.True(t, s.locks.TryAcquire("t1"))
+	defer s.locks.Release("t1")
+
+	_, err := s.DispatchAdHoc(context.Background(), model.AdHocScanRun{ID: "ar_2", TargetID: "t1"})
+	assert.ErrorIs(t, err, ErrTargetBusy)
+}
+
+func TestScheduler_DispatchAdHoc_Blackout(t *testing.T) {
+	now := time.Now().UTC()
+	bo := &tickerBlackoutStore{windows: []model.BlackoutWindow{{
+		ID: "b1", Scope: model.BlackoutScopeGlobal, Name: "covers-now",
+		// Window starts 30m ago and lasts 1h, so "now" is solidly inside.
+		RRule: "FREQ=DAILY;COUNT=1", DurationSec: 3600, Timezone: "UTC",
+		Enabled: true, CreatedAt: now.Add(-30 * time.Minute),
+	}}}
+	runner := &fakeRunner{}
+	s := newSchedulerForTest(t, Dependencies{
+		SchedStore:    newTickerScheduleStore(),
+		TmplStore:     tickerTemplateStore{},
+		BlackoutStore: bo,
+		DefaultsStore: &fakeDefaultsStore{defaults: newDefaults()},
+		AdHocStore:    &recordingAdHocStore{},
+		Runner:        runner,
+		JitterSeed:    1,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, s.Start(ctx))
+
+	_, err := s.DispatchAdHoc(context.Background(), model.AdHocScanRun{ID: "ar_3", TargetID: "t1"})
+	assert.ErrorIs(t, err, ErrInBlackout)
+	// Lock must not leak when refused.
+	assert.False(t, s.locks.IsHeld("t1"), "lock must be released when refusing for blackout")
+}
+
 func TestNew_RejectsMissingDeps(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/daemon/scan_runner.go
+++ b/internal/daemon/scan_runner.go
@@ -1,14 +1,18 @@
 package daemon
 
-// LegacyScanRunner is the SCHED1.2b bridge between the new master ticker
-// (which dispatches per-schedule jobs with a resolved EffectiveConfig) and
-// the existing detection pipeline (which runs all enabled tools against a
-// target with a single full-scan profile).
+// ScanRunner threads a Schedule's resolved EffectiveConfig through the
+// existing detection pipeline. The pipeline pre-unmarshals
+// EffectiveConfig.ToolConfig into typed *Params on detection.RunOptions
+// per tool; each tool reads its typed field and falls back to
+// model.DefaultXxxParams() for any zero-valued sub-field. This is the
+// SCHED1.2c replacement for SCHED1.2b's LegacyScanRunner — the same
+// pre-1.2b orchestration topology is preserved (sequential phase order
+// owned by pipeline.Pipeline), only the per-tool params surface changes.
 //
-// SCHED1.2c will replace this with a runner that unmarshals
-// EffectiveConfig.ToolConfig into typed *Params and threads them through
-// each detection tool. Until then, EffectiveConfig.ToolConfig is
-// intentionally ignored — pre-SCHED1 behavior is preserved exactly.
+// SCHED1.2c also opts ad-hoc scans into the same code path: callers
+// pass an EffectiveConfig built from a model.AdHocScanRun's ToolConfig
+// (resolved against template + defaults), and the runner does not care
+// whether the trigger was a schedule tick or an ad-hoc dispatch.
 
 import (
 	"context"
@@ -21,42 +25,46 @@ import (
 	"github.com/surfbot-io/surfbot-agent/internal/storage"
 )
 
-// scanOrchestrator is the narrow surface LegacyScanRunner needs from the
+// scanOrchestrator is the narrow surface ScanRunner needs from the
 // pipeline package. Real callers pass *pipeline.Pipeline; tests inject a
-// fake to assert ctx propagation and that EffectiveConfig is ignored.
+// fake to capture the per-tool typed params and assert ctx propagation.
 type scanOrchestrator interface {
 	Run(ctx context.Context, targetID string, opts pipeline.PipelineOptions) (*pipeline.PipelineResult, error)
 }
 
-// LegacyScanRunner satisfies the master ticker's ScanRunner interface
-// (defined in internal/daemon/intervalsched). Its Run method's signature
-// matches that interface structurally, so no explicit interface wiring is
-// needed in this commit — Go's structural subtyping does the work once
-// scheduler.go declares the interface in commit 2.
-type LegacyScanRunner struct {
+// ScanRunner satisfies the master ticker's ScanRunner interface
+// (declared in internal/daemon/intervalsched). Its Run method's
+// signature matches that interface structurally — Go's structural
+// subtyping does the wiring at the dependency-injection site.
+type ScanRunner struct {
 	orchestrator scanOrchestrator
 	log          *slog.Logger
 }
 
-// NewLegacyScanRunner wires a runner around the production pipeline. The
+// NewScanRunner wires a ScanRunner around the production pipeline. The
 // store and registry are the same ones the rest of the daemon uses.
-func NewLegacyScanRunner(store storage.Store, registry *detection.Registry, log *slog.Logger) *LegacyScanRunner {
+func NewScanRunner(store storage.Store, registry *detection.Registry, log *slog.Logger) *ScanRunner {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &LegacyScanRunner{
+	return &ScanRunner{
 		orchestrator: pipeline.New(store, registry),
 		log:          log,
 	}
 }
 
-// Run executes a full scan for the target. The EffectiveConfig.ToolConfig
-// is intentionally discarded — SCHED1.2c will start consuming it.
-func (r *LegacyScanRunner) Run(ctx context.Context, scheduleID, targetID string, _ model.EffectiveConfig) (string, error) {
+// Run executes a full scan for the target, threading EffectiveConfig.
+// ToolConfig through the pipeline so each detection tool sees its
+// typed *Params (with defaults filling zero fields). The returned
+// scanID is the new pipeline scan row's ID.
+func (r *ScanRunner) Run(ctx context.Context, scheduleID, targetID string, effective model.EffectiveConfig) (string, error) {
 	if r.orchestrator == nil {
-		return "", fmt.Errorf("legacy scan runner: orchestrator is nil")
+		return "", fmt.Errorf("scan runner: orchestrator is nil")
 	}
-	result, err := r.orchestrator.Run(ctx, targetID, pipeline.PipelineOptions{ScanType: model.ScanTypeFull})
+	result, err := r.orchestrator.Run(ctx, targetID, pipeline.PipelineOptions{
+		ScanType:   model.ScanTypeFull,
+		ToolConfig: effective.ToolConfig,
+	})
 	if err != nil {
 		if result != nil {
 			return result.ScanID, err

--- a/internal/daemon/scan_runner_test.go
+++ b/internal/daemon/scan_runner_test.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -58,12 +57,12 @@ func silentLog() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-func TestLegacyScanRunner_IgnoresToolConfig(t *testing.T) {
+func TestScanRunner_HonorsToolConfig(t *testing.T) {
 	orch := &fakeOrchestrator{scanID: "s_42"}
-	r := &LegacyScanRunner{orchestrator: orch, log: silentLog()}
+	r := &ScanRunner{orchestrator: orch, log: silentLog()}
 
 	tc := model.ToolConfig{}
-	require.NoError(t, model.SetTool(tc, "nuclei", map[string]string{"severity": "critical"}))
+	require.NoError(t, model.SetTool(tc, "nuclei", model.NucleiParams{Severity: []string{"critical"}}))
 	eff := model.EffectiveConfig{
 		RRule:      "FREQ=DAILY",
 		Timezone:   "UTC",
@@ -74,18 +73,25 @@ func TestLegacyScanRunner_IgnoresToolConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "s_42", scanID)
 	assert.Equal(t, "tgt_1", orch.gotID)
-	// Pre-SCHED1 behavior: full scan, no Tools restriction.
-	assert.Equal(t, model.ScanTypeFull, orch.gotOpts.ScanType)
-	assert.Empty(t, orch.gotOpts.Tools)
-	// Defensive sanity: the tool config from the schedule must not have leaked
-	// into the pipeline options.
-	raw, _ := json.Marshal(orch.gotOpts)
-	assert.NotContains(t, string(raw), "severity")
+	// ToolConfig must reach the pipeline so it can per-unmarshal into typed
+	// RunOptions for each detection tool.
+	assert.Equal(t, tc, orch.gotOpts.ToolConfig,
+		"scanRunner must forward EffectiveConfig.ToolConfig into PipelineOptions")
 }
 
-func TestLegacyScanRunner_PropagatesCtx(t *testing.T) {
+func TestScanRunner_UsesDefaultsWhenEmpty(t *testing.T) {
+	orch := &fakeOrchestrator{scanID: "s_default"}
+	r := &ScanRunner{orchestrator: orch, log: silentLog()}
+
+	_, err := r.Run(context.Background(), "sched_1", "tgt_1", model.EffectiveConfig{})
+	require.NoError(t, err)
+	assert.Empty(t, orch.gotOpts.ToolConfig,
+		"empty EffectiveConfig.ToolConfig must surface as nil/empty in PipelineOptions; tools then derive defaults")
+}
+
+func TestScanRunner_PropagatesCtx(t *testing.T) {
 	orch := &fakeOrchestrator{blockCh: make(chan struct{})}
-	r := &LegacyScanRunner{orchestrator: orch, log: silentLog()}
+	r := &ScanRunner{orchestrator: orch, log: silentLog()}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -102,9 +108,9 @@ func TestLegacyScanRunner_PropagatesCtx(t *testing.T) {
 	assert.True(t, orch.observed, "orchestrator must observe ctx cancellation")
 }
 
-func TestLegacyScanRunner_ReturnsScanID(t *testing.T) {
+func TestScanRunner_ReturnsScanID(t *testing.T) {
 	orch := &fakeOrchestrator{scanID: "s_123"}
-	r := &LegacyScanRunner{orchestrator: orch, log: silentLog()}
+	r := &ScanRunner{orchestrator: orch, log: silentLog()}
 
 	scanID, err := r.Run(context.Background(), "sched_1", "tgt_1", model.EffectiveConfig{})
 	require.NoError(t, err)
@@ -112,11 +118,28 @@ func TestLegacyScanRunner_ReturnsScanID(t *testing.T) {
 	assert.Equal(t, 1, orch.calls)
 }
 
-func TestLegacyScanRunner_PropagatesError(t *testing.T) {
+func TestScanRunner_PropagatesError(t *testing.T) {
 	orch := &fakeOrchestrator{scanID: "s_partial", runErr: errors.New("boom")}
-	r := &LegacyScanRunner{orchestrator: orch, log: silentLog()}
+	r := &ScanRunner{orchestrator: orch, log: silentLog()}
 
 	scanID, err := r.Run(context.Background(), "sched_1", "tgt_1", model.EffectiveConfig{})
 	require.Error(t, err)
 	assert.Equal(t, "s_partial", scanID)
+}
+
+func TestScanRunner_InvalidToolConfigForwardsAnyway(t *testing.T) {
+	// Malformed JSON for one tool must not fail the runner — the pipeline's
+	// applyToolConfig falls through silently and the tool defaults kick in.
+	// Here we only assert scanRunner forwards whatever ToolConfig came in;
+	// pipeline.applyToolConfig is responsible for the per-tool fallback.
+	orch := &fakeOrchestrator{scanID: "s_ok"}
+	r := &ScanRunner{orchestrator: orch, log: silentLog()}
+
+	tc := model.ToolConfig{
+		"nuclei": []byte(`{"severity": "not-an-array"}`),
+		"naabu":  []byte(`{"ports": "22,80"}`),
+	}
+	_, err := r.Run(context.Background(), "sched_1", "tgt_1", model.EffectiveConfig{ToolConfig: tc})
+	require.NoError(t, err)
+	assert.Equal(t, tc, orch.gotOpts.ToolConfig)
 }

--- a/internal/detection/detection.go
+++ b/internal/detection/detection.go
@@ -48,10 +48,25 @@ type DetectionTool interface {
 }
 
 // RunOptions configures a tool execution.
+//
+// SCHED1.2c: each detection tool gains a typed *Params pointer. When set
+// by the caller (scanRunner from a resolved EffectiveConfig), the tool
+// reads its typed field and falls back to model.DefaultXxxParams() for
+// unset fields. The legacy RateLimit/Timeout/ExtraArgs surface stays for
+// existing callers (CLI sub-commands, tests) — when a typed *Params is
+// also supplied it wins per-field.
 type RunOptions struct {
 	RateLimit int               // requests per second (0 = default)
 	Timeout   int               // seconds (0 = default)
 	ExtraArgs map[string]string // tool-specific options
+
+	// Typed per-tool params. Each field is read by the matching tool only.
+	// Nil means "no per-tool override; derive from defaults + ExtraArgs".
+	NucleiParams    *model.NucleiParams
+	NaabuParams     *model.NaabuParams
+	HttpxParams     *model.HttpxParams
+	SubfinderParams *model.SubfinderParams
+	DnsxParams      *model.DnsxParams
 }
 
 // RunResult holds the output of a tool execution.

--- a/internal/detection/dnsx.go
+++ b/internal/detection/dnsx.go
@@ -18,6 +18,54 @@ type DNSXTool struct{}
 
 func NewDNSXTool() *DNSXTool { return &DNSXTool{} }
 
+// dnsxResolver is the narrow surface DNSXTool uses from the system
+// resolver. Production calls net.DefaultResolver; tests inject a fake
+// to assert params propagation and ctx cancellation.
+type dnsxResolver interface {
+	LookupHost(ctx context.Context, host string) ([]string, error)
+	LookupCNAME(ctx context.Context, host string) (string, error)
+}
+
+// dnsxResolverOverride lets tests substitute the resolver. Production
+// callers leave it nil and dnsx uses net.DefaultResolver.
+var dnsxResolverOverride dnsxResolver
+
+func resolveDnsxResolver() dnsxResolver {
+	if dnsxResolverOverride != nil {
+		return dnsxResolverOverride
+	}
+	return net.DefaultResolver
+}
+
+// resolveDnsxParams returns the params DNSXTool should run with,
+// preferring opts.DnsxParams when supplied and falling back to
+// model.DefaultDnsxParams() per-field.
+func resolveDnsxParams(opts RunOptions) model.DnsxParams {
+	defaults := model.DefaultDnsxParams()
+	if opts.DnsxParams == nil {
+		return defaults
+	}
+	resolved := *opts.DnsxParams
+	if len(resolved.RecordTypes) == 0 {
+		resolved.RecordTypes = defaults.RecordTypes
+	}
+	if resolved.Retries <= 0 {
+		resolved.Retries = defaults.Retries
+	}
+	return resolved
+}
+
+// wantsRecordType is a case-insensitive membership check used to gate
+// the per-record-type lookups. Honors params.RecordTypes.
+func wantsRecordType(types []string, want string) bool {
+	for _, t := range types {
+		if strings.EqualFold(t, want) {
+			return true
+		}
+	}
+	return false
+}
+
 func (d *DNSXTool) Name() string   { return "dnsx" }
 func (d *DNSXTool) Phase() string  { return "resolution" }
 func (d *DNSXTool) Kind() ToolKind { return ToolKindNative }
@@ -34,6 +82,27 @@ type dnsResult struct {
 	CNAME string
 }
 
+// lookupHostWithRetries calls resolver.LookupHost up to (1 + retries)
+// times, returning the first non-error result. Honors ctx cancellation
+// between attempts.
+func lookupHostWithRetries(ctx context.Context, resolver dnsxResolver, host string, retries int) ([]string, error) {
+	if retries < 0 {
+		retries = 0
+	}
+	var lastErr error
+	for attempt := 0; attempt <= retries; attempt++ {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		ips, err := resolver.LookupHost(ctx, host)
+		if err == nil {
+			return ips, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
 func (d *DNSXTool) Run(ctx context.Context, inputs []string, opts RunOptions) (*RunResult, error) {
 	startedAt := time.Now().UTC()
 
@@ -41,6 +110,10 @@ func (d *DNSXTool) Run(ctx context.Context, inputs []string, opts RunOptions) (*
 	if concurrency <= 0 {
 		concurrency = 50
 	}
+	params := resolveDnsxParams(opts)
+	resolver := resolveDnsxResolver()
+	wantA := wantsRecordType(params.RecordTypes, "A") || wantsRecordType(params.RecordTypes, "AAAA")
+	wantCNAME := wantsRecordType(params.RecordTypes, "CNAME")
 
 	results := make([]dnsResult, 0, len(inputs))
 	// errLog accumulates per-host resolution errors so the tool_run record
@@ -67,18 +140,22 @@ func (d *DNSXTool) Run(ctx context.Context, inputs []string, opts RunOptions) (*
 
 			dr := dnsResult{Host: h}
 
-			ips, err := net.DefaultResolver.LookupHost(rctx, h)
-			if err == nil {
-				dr.IPs = ips
-			} else {
-				mu.Lock()
-				fmt.Fprintf(&errLog, "[dnsx] %s: %v\n", h, err)
-				mu.Unlock()
+			if wantA {
+				ips, err := lookupHostWithRetries(rctx, resolver, h, params.Retries)
+				if err == nil {
+					dr.IPs = ips
+				} else {
+					mu.Lock()
+					fmt.Fprintf(&errLog, "[dnsx] %s: %v\n", h, err)
+					mu.Unlock()
+				}
 			}
 
-			cname, err := net.DefaultResolver.LookupCNAME(rctx, h)
-			if err == nil && cname != "" {
-				dr.CNAME = strings.TrimSuffix(cname, ".")
+			if wantCNAME {
+				cname, err := resolver.LookupCNAME(rctx, h)
+				if err == nil && cname != "" {
+					dr.CNAME = strings.TrimSuffix(cname, ".")
+				}
 			}
 
 			mu.Lock()

--- a/internal/detection/dnsx_test.go
+++ b/internal/detection/dnsx_test.go
@@ -2,12 +2,130 @@ package detection
 
 import (
 	"context"
+	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
 )
+
+// fakeDnsxResolver records every LookupHost / LookupCNAME call so tests
+// can assert the params drove the right RPCs and how many times each
+// happened.
+type fakeDnsxResolver struct {
+	mu              sync.Mutex
+	hostLookups     int32
+	cnameLookups    int32
+	hostFn          func(context.Context, string) ([]string, error)
+	cnameFn         func(context.Context, string) (string, error)
+	failHostNTimes  int32 // first N calls return err to exercise retry path
+	hostFailureCall int32
+}
+
+func (f *fakeDnsxResolver) LookupHost(ctx context.Context, host string) ([]string, error) {
+	atomic.AddInt32(&f.hostLookups, 1)
+	if f.failHostNTimes > 0 {
+		n := atomic.AddInt32(&f.hostFailureCall, 1)
+		if n <= f.failHostNTimes {
+			return nil, errors.New("transient")
+		}
+	}
+	if f.hostFn != nil {
+		return f.hostFn(ctx, host)
+	}
+	return []string{"203.0.113.1"}, nil
+}
+
+func (f *fakeDnsxResolver) LookupCNAME(ctx context.Context, host string) (string, error) {
+	atomic.AddInt32(&f.cnameLookups, 1)
+	if f.cnameFn != nil {
+		return f.cnameFn(ctx, host)
+	}
+	return "", errors.New("no cname")
+}
+
+func swapDnsxResolver(t *testing.T, r dnsxResolver) {
+	t.Helper()
+	prev := dnsxResolverOverride
+	dnsxResolverOverride = r
+	t.Cleanup(func() { dnsxResolverOverride = prev })
+}
+
+func TestResolveDnsxParams_TypedOverridesWin(t *testing.T) {
+	got := resolveDnsxParams(RunOptions{
+		DnsxParams: &model.DnsxParams{RecordTypes: []string{"A"}, Retries: 5},
+	})
+	assert.Equal(t, []string{"A"}, got.RecordTypes)
+	assert.Equal(t, 5, got.Retries)
+}
+
+func TestResolveDnsxParams_FallsBackToDefaults(t *testing.T) {
+	got := resolveDnsxParams(RunOptions{})
+	def := model.DefaultDnsxParams()
+	assert.Equal(t, def.RecordTypes, got.RecordTypes)
+	assert.Equal(t, def.Retries, got.Retries)
+}
+
+func TestDnsx_ParamsPropagation_RecordTypes(t *testing.T) {
+	fake := &fakeDnsxResolver{}
+	swapDnsxResolver(t, fake)
+
+	d := NewDNSXTool()
+	_, err := d.Run(context.Background(), []string{"example.com"}, RunOptions{
+		DnsxParams: &model.DnsxParams{RecordTypes: []string{"CNAME"}, Retries: 1},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&fake.hostLookups),
+		"RecordTypes=[CNAME] must skip A/AAAA host lookups")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&fake.cnameLookups),
+		"RecordTypes=[CNAME] must still issue the CNAME lookup")
+}
+
+func TestDnsx_ParamsPropagation_Retries(t *testing.T) {
+	fake := &fakeDnsxResolver{failHostNTimes: 2}
+	swapDnsxResolver(t, fake)
+
+	d := NewDNSXTool()
+	_, err := d.Run(context.Background(), []string{"example.com"}, RunOptions{
+		DnsxParams: &model.DnsxParams{RecordTypes: []string{"A"}, Retries: 3},
+	})
+	require.NoError(t, err)
+	// 2 failures + 1 success = 3 calls.
+	assert.Equal(t, int32(3), atomic.LoadInt32(&fake.hostLookups),
+		"Retries=3 must let dnsx retry past 2 transient failures")
+}
+
+func TestDnsx_CtxCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	fake := &fakeDnsxResolver{
+		hostFn: func(c context.Context, _ string) ([]string, error) {
+			<-c.Done()
+			return nil, c.Err()
+		},
+	}
+	swapDnsxResolver(t, fake)
+
+	d := NewDNSXTool()
+	done := make(chan struct{})
+	go func() {
+		_, _ = d.Run(ctx, []string{"example.com"}, RunOptions{
+			DnsxParams: &model.DnsxParams{RecordTypes: []string{"A"}, Retries: 1},
+		})
+		close(done)
+	}()
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not return within 500ms after ctx cancel")
+	}
+}
 
 func TestDNSXResolvesPublicDomain(t *testing.T) {
 	d := NewDNSXTool()

--- a/internal/detection/dnsx_test.go
+++ b/internal/detection/dnsx_test.go
@@ -18,7 +18,6 @@ import (
 // can assert the params drove the right RPCs and how many times each
 // happened.
 type fakeDnsxResolver struct {
-	mu              sync.Mutex
 	hostLookups     int32
 	cnameLookups    int32
 	hostFn          func(context.Context, string) ([]string, error)

--- a/internal/detection/httpx.go
+++ b/internal/detection/httpx.go
@@ -49,6 +49,37 @@ type HTTPXTool struct{}
 
 func NewHTTPXTool() *HTTPXTool { return &HTTPXTool{} }
 
+// httpxTransportOverride lets tests substitute the http.RoundTripper used
+// by HTTPXTool without rewiring net.Listen. Production callers leave it
+// nil; the default *http.Transport is constructed in Run.
+var httpxTransportOverride http.RoundTripper
+
+// resolveHttpxParams returns the params HTTPXTool should run with,
+// preferring opts.HttpxParams when supplied and falling back to
+// model.DefaultHttpxParams() per-field. The legacy opts.RateLimit
+// overrides Threads when typed params are absent so existing callers
+// keep working unchanged.
+func resolveHttpxParams(opts RunOptions) model.HttpxParams {
+	defaults := model.DefaultHttpxParams()
+	if opts.HttpxParams == nil {
+		if opts.RateLimit > 0 {
+			defaults.Threads = opts.RateLimit
+		}
+		return defaults
+	}
+	resolved := *opts.HttpxParams
+	if resolved.Threads <= 0 {
+		resolved.Threads = defaults.Threads
+	}
+	if len(resolved.Probes) == 0 {
+		resolved.Probes = defaults.Probes
+	}
+	if resolved.Timeout <= 0 {
+		resolved.Timeout = defaults.Timeout
+	}
+	return resolved
+}
+
 func (h *HTTPXTool) Name() string    { return "httpx" }
 func (h *HTTPXTool) Phase() string   { return "http_probe" }
 func (h *HTTPXTool) Kind() ToolKind  { return ToolKindNative }
@@ -90,28 +121,34 @@ type probeResult struct {
 func (h *HTTPXTool) Run(ctx context.Context, inputs []string, opts RunOptions) (*RunResult, error) {
 	startedAt := time.Now().UTC()
 
-	concurrency := opts.RateLimit
-	if concurrency <= 0 {
-		concurrency = 50
-	}
+	params := resolveHttpxParams(opts)
+	concurrency := params.Threads
 
+	transport := http.RoundTripper(&http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true, // intentional: scanning unknown targets
+		},
+		MaxIdleConnsPerHost: 10,
+	})
+	if httpxTransportOverride != nil {
+		transport = httpxTransportOverride
+	}
+	checkRedirect := func(req *http.Request, via []*http.Request) error {
+		if !params.FollowRedirects {
+			return http.ErrUseLastResponse
+		}
+		if len(via) >= 3 {
+			return http.ErrUseLastResponse
+		}
+		return nil
+	}
 	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, // intentional: scanning unknown targets
-			},
-			MaxIdleConnsPerHost: 10,
-		},
-		Timeout: 10 * time.Second,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 3 {
-				return http.ErrUseLastResponse
-			}
-			return nil
-		},
+		Transport:     transport,
+		Timeout:       params.Timeout,
+		CheckRedirect: checkRedirect,
 	}
 
-	targets := buildProbeURLs(inputs)
+	targets := filterProbesBySchemes(buildProbeURLs(inputs), params.Probes)
 
 	var results []probeResult
 	var drops int
@@ -185,7 +222,7 @@ func (h *HTTPXTool) Run(ctx context.Context, inputs []string, opts RunOptions) (
 	tr.OutputSummary = fmt.Sprintf("Probed %d target(s) → %d live URL(s), %d technolog(ies), %d dropped (vhost mismatch)",
 		len(targets), urlCount, techCount, drops)
 	attachExecContext(&tr,
-		fmt.Sprintf("httpx (in-process HTTP prober, concurrency=%d, timeout=10s)", concurrency),
+		fmt.Sprintf("httpx (in-process HTTP prober, concurrency=%d, timeout=%s)", concurrency, params.Timeout),
 		0,
 		"", // httpx's per-probe dropped/failure reasons already go to os.Stderr via the vhostMismatchLog writer and would be too verbose here
 		inputs,
@@ -198,6 +235,32 @@ func (h *HTTPXTool) Run(ctx context.Context, inputs []string, opts RunOptions) (
 	tr.Config["tech_count"] = techCount
 	runResult.ToolRun = tr
 	return runResult, nil
+}
+
+// filterProbesBySchemes drops probes whose scheme is not in the requested
+// set. An empty or nil schemes list returns the targets unchanged.
+func filterProbesBySchemes(targets []probeTarget, schemes []string) []probeTarget {
+	if len(schemes) == 0 {
+		return targets
+	}
+	allow := map[string]bool{}
+	for _, s := range schemes {
+		allow[strings.ToLower(s)] = true
+	}
+	if allow["http"] && allow["https"] {
+		return targets
+	}
+	out := make([]probeTarget, 0, len(targets))
+	for _, t := range targets {
+		scheme := "http"
+		if strings.HasPrefix(t.URL, "https://") {
+			scheme = "https"
+		}
+		if allow[scheme] {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 // buildProbeURLs parses a list of probe inputs into concrete probe targets.

--- a/internal/detection/httpx_test.go
+++ b/internal/detection/httpx_test.go
@@ -16,12 +16,149 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
 )
+
+// fakeRoundTripper captures every request and returns a canned response.
+type fakeRoundTripper struct {
+	mu       sync.Mutex
+	requests []*http.Request
+	respond  func(*http.Request) (*http.Response, error)
+}
+
+func (f *fakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	f.mu.Lock()
+	f.requests = append(f.requests, r)
+	respond := f.respond
+	f.mu.Unlock()
+	if respond != nil {
+		return respond(r)
+	}
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader("ok")),
+		Header:     http.Header{},
+		Request:    r,
+	}, nil
+}
+
+func swapHttpxTransport(t *testing.T, rt http.RoundTripper) {
+	t.Helper()
+	prev := httpxTransportOverride
+	httpxTransportOverride = rt
+	t.Cleanup(func() { httpxTransportOverride = prev })
+}
+
+func TestResolveHttpxParams_TypedOverridesWin(t *testing.T) {
+	got := resolveHttpxParams(RunOptions{
+		HttpxParams: &model.HttpxParams{
+			Threads: 25,
+			Probes:  []string{"https"},
+			Timeout: 3 * time.Second,
+		},
+	})
+	assert.Equal(t, 25, got.Threads)
+	assert.Equal(t, []string{"https"}, got.Probes)
+	assert.Equal(t, 3*time.Second, got.Timeout)
+}
+
+func TestResolveHttpxParams_FallsBackToDefaults(t *testing.T) {
+	got := resolveHttpxParams(RunOptions{})
+	def := model.DefaultHttpxParams()
+	assert.Equal(t, def.Threads, got.Threads)
+	assert.Equal(t, def.Probes, got.Probes)
+	assert.Equal(t, def.Timeout, got.Timeout)
+}
+
+func TestHttpx_ParamsPropagation_Threads(t *testing.T) {
+	var inflight, peak int32
+	rt := &fakeRoundTripper{
+		respond: func(r *http.Request) (*http.Response, error) {
+			cur := atomic.AddInt32(&inflight, 1)
+			defer atomic.AddInt32(&inflight, -1)
+			for {
+				old := atomic.LoadInt32(&peak)
+				if cur <= old || atomic.CompareAndSwapInt32(&peak, old, cur) {
+					break
+				}
+			}
+			time.Sleep(20 * time.Millisecond)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Header:     http.Header{},
+				Request:    r,
+			}, nil
+		},
+	}
+	swapHttpxTransport(t, rt)
+
+	h := NewHTTPXTool()
+	// 16 inputs × http+https = 32 probes. Threads=4 caps in-flight at 4.
+	inputs := make([]string, 16)
+	for i := range inputs {
+		inputs[i] = fmt.Sprintf("host%d:80", i)
+	}
+	_, err := h.Run(context.Background(), inputs, RunOptions{
+		HttpxParams: &model.HttpxParams{Threads: 4, Probes: []string{"http", "https"}, Timeout: 5 * time.Second},
+	})
+	require.NoError(t, err)
+	observed := atomic.LoadInt32(&peak)
+	assert.LessOrEqual(t, observed, int32(4),
+		"peak in-flight requests must respect params.Threads (got %d)", observed)
+}
+
+func TestHttpx_ParamsPropagation_Probes(t *testing.T) {
+	rt := &fakeRoundTripper{}
+	swapHttpxTransport(t, rt)
+
+	h := NewHTTPXTool()
+	_, err := h.Run(context.Background(), []string{"example.com:8080"}, RunOptions{
+		HttpxParams: &model.HttpxParams{Threads: 4, Probes: []string{"https"}, Timeout: 5 * time.Second},
+	})
+	require.NoError(t, err)
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	for _, r := range rt.requests {
+		assert.Equal(t, "https", r.URL.Scheme,
+			"probes=[https] must skip http requests; saw %s", r.URL)
+	}
+}
+
+func TestHttpx_CtxCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	rt := &fakeRoundTripper{
+		respond: func(r *http.Request) (*http.Response, error) {
+			<-r.Context().Done()
+			return nil, r.Context().Err()
+		},
+	}
+	swapHttpxTransport(t, rt)
+
+	h := NewHTTPXTool()
+	done := make(chan struct{})
+	go func() {
+		_, _ = h.Run(ctx, []string{"example.com:8080"}, RunOptions{
+			HttpxParams: &model.HttpxParams{Threads: 4, Probes: []string{"http"}, Timeout: 5 * time.Second},
+		})
+		close(done)
+	}()
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not return within 500ms after ctx cancel")
+	}
+}
 
 func TestHTTPXProbeHTTPS(t *testing.T) {
 	tlsCert := generateSelfSignedCert(t, "localhost", "127.0.0.1")

--- a/internal/detection/naabu.go
+++ b/internal/detection/naabu.go
@@ -85,10 +85,50 @@ type dialFunc func(network, addr string, timeout time.Duration) (net.Conn, error
 // defaultDialer is the production dialer.
 var defaultDialer dialFunc = net.DialTimeout
 
+// resolveNaabuParams returns the params NaabuTool should run with,
+// preferring opts.NaabuParams when supplied and falling back to
+// model.DefaultNaabuParams() per-field. The legacy ExtraArgs["ports"]
+// and opts.RateLimit overrides still win when typed params are absent
+// so existing CLI/test callers keep working unchanged.
+func resolveNaabuParams(opts RunOptions) model.NaabuParams {
+	defaults := model.DefaultNaabuParams()
+	if opts.NaabuParams == nil {
+		if v, ok := opts.ExtraArgs["ports"]; ok && v != "" {
+			defaults.Ports = v
+		}
+		if opts.RateLimit > 0 {
+			defaults.Rate = opts.RateLimit
+		}
+		if v, ok := opts.ExtraArgs["no-banner"]; ok {
+			if v == "true" || v == "1" {
+				defaults.BannerGrab = false
+			}
+		}
+		return defaults
+	}
+	resolved := *opts.NaabuParams
+	if resolved.Ports == "" {
+		resolved.Ports = defaults.Ports
+	}
+	if resolved.Rate <= 0 {
+		resolved.Rate = defaults.Rate
+	}
+	if resolved.Retries <= 0 {
+		resolved.Retries = defaults.Retries
+	}
+	if resolved.ScanType == "" {
+		resolved.ScanType = defaults.ScanType
+	}
+	// BannerGrab is bool; the typed struct's zero value (false) is a
+	// valid explicit override, so we don't fill from defaults.
+	return resolved
+}
+
 func (n *NaabuTool) Run(ctx context.Context, inputs []string, opts RunOptions) (*RunResult, error) {
 	startedAt := time.Now().UTC()
 
-	ports, err := ParsePorts(opts.ExtraArgs["ports"])
+	params := resolveNaabuParams(opts)
+	ports, err := ParsePorts(params.Ports)
 	if err != nil {
 		return nil, fmt.Errorf("naabu: parsing ports: %w", err)
 	}
@@ -100,19 +140,12 @@ func (n *NaabuTool) Run(ctx context.Context, inputs []string, opts RunOptions) (
 		}
 	}
 
-	concurrency := opts.RateLimit
+	concurrency := params.Rate
 	if concurrency <= 0 {
 		concurrency = defaultConcurrency
 	}
 
-	// --no-banner disables banner grab entirely (R11). Defaults to banner
-	// grab enabled. Accepts "true"/"1" for the flag.
-	noBanner := false
-	if v, ok := opts.ExtraArgs["no-banner"]; ok {
-		if v == "true" || v == "1" {
-			noBanner = true
-		}
-	}
+	noBanner := !params.BannerGrab
 
 	br := newBreaker(concurrency)
 	retryCap := concurrency / 4
@@ -167,7 +200,7 @@ func (n *NaabuTool) Run(ctx context.Context, inputs []string, opts RunOptions) (
 		len(inputs), len(ports), openCount, filteredCount, dialTimeout, concurrency)
 	attachExecContext(&tr,
 		fmt.Sprintf("naabu (in-process scanner, ports=%s, timeout=%s, concurrency=%d, banner=%v)",
-			opts.ExtraArgs["ports"], dialTimeout, concurrency, !noBanner),
+			params.Ports, dialTimeout, concurrency, !noBanner),
 		0,
 		errLog.String(),
 		inputs,

--- a/internal/detection/naabu_test.go
+++ b/internal/detection/naabu_test.go
@@ -8,13 +8,120 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
 )
+
+func swapNaabuDialer(t *testing.T, fn dialFunc) {
+	t.Helper()
+	prev := defaultDialer
+	defaultDialer = fn
+	t.Cleanup(func() { defaultDialer = prev })
+}
+
+func TestResolveNaabuParams_TypedOverridesWin(t *testing.T) {
+	got := resolveNaabuParams(RunOptions{
+		NaabuParams: &model.NaabuParams{Ports: "22,80", Rate: 5, Retries: 2},
+	})
+	assert.Equal(t, "22,80", got.Ports)
+	assert.Equal(t, 5, got.Rate)
+	assert.Equal(t, 2, got.Retries)
+}
+
+func TestResolveNaabuParams_FallsBackToDefaults(t *testing.T) {
+	got := resolveNaabuParams(RunOptions{})
+	def := model.DefaultNaabuParams()
+	assert.Equal(t, def.Ports, got.Ports)
+	assert.Equal(t, def.Rate, got.Rate)
+}
+
+func TestNaabu_ParamsPropagation_Ports(t *testing.T) {
+	var seen sync.Map
+	dial := func(network, addr string, _ time.Duration) (net.Conn, error) {
+		seen.Store(addr, true)
+		return nil, errors.New("dial tcp: connect: connection refused")
+	}
+	swapNaabuDialer(t, dial)
+
+	n := NewNaabuTool()
+	_, err := n.Run(context.Background(), []string{"1.2.3.4"}, RunOptions{
+		NaabuParams: &model.NaabuParams{Ports: "22,80", Rate: 4, BannerGrab: true},
+	})
+	require.NoError(t, err)
+	_, hit22 := seen.Load("1.2.3.4:22")
+	_, hit80 := seen.Load("1.2.3.4:80")
+	_, hit443 := seen.Load("1.2.3.4:443")
+	assert.True(t, hit22, "dialer must have been called for port 22 from params.Ports")
+	assert.True(t, hit80, "dialer must have been called for port 80 from params.Ports")
+	assert.False(t, hit443, "port 443 must not be probed when Ports=\"22,80\"")
+}
+
+func TestNaabu_ParamsPropagation_Rate(t *testing.T) {
+	var inflight, peak int32
+	dial := func(network, addr string, _ time.Duration) (net.Conn, error) {
+		cur := atomic.AddInt32(&inflight, 1)
+		defer atomic.AddInt32(&inflight, -1)
+		// Track high-water mark of concurrent dials.
+		for {
+			old := atomic.LoadInt32(&peak)
+			if cur <= old || atomic.CompareAndSwapInt32(&peak, old, cur) {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+		return nil, errors.New("connection refused")
+	}
+	swapNaabuDialer(t, dial)
+
+	n := NewNaabuTool()
+	// 16 ports, Rate=4 → effective concurrency capped at 4.
+	_, err := n.Run(context.Background(), []string{"1.2.3.4"}, RunOptions{
+		NaabuParams: &model.NaabuParams{
+			Ports:      "1-16",
+			Rate:       4,
+			BannerGrab: true,
+		},
+	})
+	require.NoError(t, err)
+	observed := atomic.LoadInt32(&peak)
+	assert.LessOrEqual(t, observed, int32(4),
+		"peak concurrency must be ≤ params.Rate (got %d)", observed)
+}
+
+func TestNaabu_CtxCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	dial := func(network, addr string, _ time.Duration) (net.Conn, error) {
+		// Block until ctx fires so cancellation propagates promptly through
+		// every in-flight dial. Without this, naabu's wg.Wait() would
+		// stall on goroutines blocked in net.DialTimeout.
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	swapNaabuDialer(t, dial)
+
+	n := NewNaabuTool()
+	done := make(chan struct{})
+	go func() {
+		_, _ = n.Run(ctx, []string{"1.2.3.4"}, RunOptions{
+			NaabuParams: &model.NaabuParams{Ports: "1-50", Rate: 10, BannerGrab: false},
+		})
+		close(done)
+	}()
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not return within 500ms after ctx cancel")
+	}
+}
 
 func TestPortParsing(t *testing.T) {
 	tests := []struct {

--- a/internal/detection/nuclei.go
+++ b/internal/detection/nuclei.go
@@ -20,6 +20,72 @@ type NucleiTool struct{}
 
 func NewNucleiTool() *NucleiTool { return &NucleiTool{} }
 
+// nucleiEngine is the narrow surface NucleiTool needs from the upstream
+// SDK. The production implementation wraps *nuclei.NucleiEngine; tests
+// inject a fake to assert params propagation and ctx cancellation
+// without invoking the real engine.
+type nucleiEngine interface {
+	LoadTargets(targets []string, probeNonHTTP bool)
+	ExecuteWithCallback(callback ...func(*output.ResultEvent)) error
+	Close()
+}
+
+// nucleiEngineFactory builds a nucleiEngine from the SDK option set. It
+// is overridden in tests via nucleiEngineFactoryOverride.
+type nucleiEngineFactory func(ctx context.Context, opts ...nuclei.NucleiSDKOptions) (nucleiEngine, error)
+
+// nucleiEngineFactoryOverride, when non-nil, replaces the production
+// engine constructor. Tests set/restore this with t.Cleanup. The
+// override receives the resolved NucleiParams in the factoryParams
+// channel-less side channel below so tests can assert what was passed.
+var (
+	nucleiEngineFactoryOverride nucleiEngineFactory
+	nucleiLastResolvedParams    model.NucleiParams // observed by tests via getNucleiLastResolvedParams
+)
+
+func defaultNucleiEngineFactory(ctx context.Context, opts ...nuclei.NucleiSDKOptions) (nucleiEngine, error) {
+	return nuclei.NewNucleiEngineCtx(ctx, opts...)
+}
+
+func resolveNucleiEngineFactory() nucleiEngineFactory {
+	if nucleiEngineFactoryOverride != nil {
+		return nucleiEngineFactoryOverride
+	}
+	return defaultNucleiEngineFactory
+}
+
+// resolveNucleiParams returns the params NucleiTool should run with,
+// using the typed RunOptions.NucleiParams when provided and falling
+// back to model.DefaultNucleiParams() otherwise. Per-field zero-values
+// in the typed struct also fall back to defaults so callers may set
+// just one knob without reverting the others.
+func resolveNucleiParams(opts RunOptions) model.NucleiParams {
+	defaults := model.DefaultNucleiParams()
+	if opts.NucleiParams == nil {
+		// Honor the legacy ExtraArgs["severity"] override — preserves
+		// pre-1.2c behavior for callers (CLI, tests) that haven't
+		// migrated to typed params.
+		if s, ok := opts.ExtraArgs["severity"]; ok && s != "" {
+			defaults.Severity = strings.Split(s, ",")
+		}
+		if opts.RateLimit > 0 {
+			defaults.RateLimit = opts.RateLimit
+		}
+		return defaults
+	}
+	resolved := *opts.NucleiParams
+	if len(resolved.Severity) == 0 {
+		resolved.Severity = defaults.Severity
+	}
+	if resolved.RateLimit <= 0 {
+		resolved.RateLimit = defaults.RateLimit
+	}
+	if resolved.Timeout <= 0 {
+		resolved.Timeout = defaults.Timeout
+	}
+	return resolved
+}
+
 func (n *NucleiTool) Name() string   { return "nuclei" }
 func (n *NucleiTool) Phase() string  { return "assessment" }
 func (n *NucleiTool) Kind() ToolKind { return ToolKindLibrary }
@@ -39,23 +105,29 @@ func (n *NucleiTool) Run(ctx context.Context, inputs []string, opts RunOptions) 
 		return &RunResult{ToolRun: tr}, nil
 	}
 
-	if err := ensureNucleiTemplates(); err != nil {
-		tr := buildToolRun(n, startedAt, model.ToolRunFailed, err.Error(), len(inputs), 0)
-		attachExecContext(&tr, "nuclei (SDK in-process)", 1, err.Error(), inputs)
-		return &RunResult{ToolRun: tr}, fmt.Errorf("nuclei templates setup: %w", err)
+	if nucleiEngineFactoryOverride == nil {
+		// Tests inject a fake engine and skip the heavyweight template
+		// install path — only the production factory needs templates on
+		// disk.
+		if err := ensureNucleiTemplates(); err != nil {
+			tr := buildToolRun(n, startedAt, model.ToolRunFailed, err.Error(), len(inputs), 0)
+			attachExecContext(&tr, "nuclei (SDK in-process)", 1, err.Error(), inputs)
+			return &RunResult{ToolRun: tr}, fmt.Errorf("nuclei templates setup: %w", err)
+		}
 	}
 
-	severity := "critical,high,medium,low,info"
-	if s, ok := opts.ExtraArgs["severity"]; ok && s != "" {
-		severity = s
-	}
-
-	rateLimit := 150
-	if opts.RateLimit > 0 {
-		rateLimit = opts.RateLimit
-	}
+	params := resolveNucleiParams(opts)
+	nucleiLastResolvedParams = params
+	severity := strings.Join(params.Severity, ",")
+	rateLimit := params.RateLimit
 
 	timeout := 5
+	if params.Timeout > 0 {
+		secs := int(params.Timeout / time.Second)
+		if secs > 0 && secs < 60 {
+			timeout = secs
+		}
+	}
 	if opts.Timeout > 0 && opts.Timeout < 60 {
 		timeout = opts.Timeout
 	}
@@ -101,7 +173,7 @@ func (n *NucleiTool) Run(ctx context.Context, inputs []string, opts RunOptions) 
 		}),
 	}
 
-	ne, err := nuclei.NewNucleiEngineCtx(ctx, engineOpts...)
+	ne, err := resolveNucleiEngineFactory()(ctx, engineOpts...)
 	if err != nil {
 		tr := buildToolRun(n, startedAt, model.ToolRunFailed, err.Error(), len(inputs), 0)
 		attachExecContext(&tr, "nuclei (SDK in-process)", 1, err.Error(), inputs)

--- a/internal/detection/nuclei_test.go
+++ b/internal/detection/nuclei_test.go
@@ -1,16 +1,142 @@
 package detection
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
+	nuclei "github.com/projectdiscovery/nuclei/v3/lib"
 	nucleimodel "github.com/projectdiscovery/nuclei/v3/pkg/model"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
 	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/stringslice"
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/surfbot-io/surfbot-agent/internal/model"
 )
+
+// fakeNucleiEngine satisfies the nucleiEngine interface and lets tests
+// control timing + capture inputs.
+type fakeNucleiEngine struct {
+	loaded      []string
+	executeWait time.Duration // when > 0, ExecuteWithCallback respects ctxFn
+	ctxFn       func() context.Context
+	executeErr  error
+}
+
+func (f *fakeNucleiEngine) LoadTargets(targets []string, _ bool) {
+	f.loaded = append(f.loaded, targets...)
+}
+
+func (f *fakeNucleiEngine) ExecuteWithCallback(_ ...func(*output.ResultEvent)) error {
+	if f.executeWait > 0 && f.ctxFn != nil {
+		select {
+		case <-time.After(f.executeWait):
+		case <-f.ctxFn().Done():
+			return f.ctxFn().Err()
+		}
+	}
+	return f.executeErr
+}
+
+func (f *fakeNucleiEngine) Close() {}
+
+func swapNucleiEngineFactory(t *testing.T, fn nucleiEngineFactory) {
+	t.Helper()
+	prev := nucleiEngineFactoryOverride
+	nucleiEngineFactoryOverride = fn
+	t.Cleanup(func() { nucleiEngineFactoryOverride = prev })
+}
+
+func TestResolveNucleiParams_TypedOverridesWin(t *testing.T) {
+	got := resolveNucleiParams(RunOptions{
+		NucleiParams: &model.NucleiParams{
+			Severity:  []string{"critical"},
+			RateLimit: 50,
+			Timeout:   3 * time.Second,
+		},
+	})
+	assert.Equal(t, []string{"critical"}, got.Severity)
+	assert.Equal(t, 50, got.RateLimit)
+	assert.Equal(t, 3*time.Second, got.Timeout)
+}
+
+func TestResolveNucleiParams_FallsBackToDefaults(t *testing.T) {
+	got := resolveNucleiParams(RunOptions{})
+	def := model.DefaultNucleiParams()
+	assert.Equal(t, def.Severity, got.Severity)
+	assert.Equal(t, def.RateLimit, got.RateLimit)
+	assert.Equal(t, def.Timeout, got.Timeout)
+}
+
+func TestResolveNucleiParams_PartialTypedFillsFromDefaults(t *testing.T) {
+	got := resolveNucleiParams(RunOptions{
+		NucleiParams: &model.NucleiParams{Severity: []string{"high"}},
+	})
+	def := model.DefaultNucleiParams()
+	assert.Equal(t, []string{"high"}, got.Severity)
+	assert.Equal(t, def.RateLimit, got.RateLimit, "unset RateLimit must inherit default")
+	assert.Equal(t, def.Timeout, got.Timeout, "unset Timeout must inherit default")
+}
+
+func TestNuclei_ParamsPropagation_Severity(t *testing.T) {
+	// Skip the heavy template-install path by using a fake engine, but the
+	// resolved-params side channel still records what would be passed.
+	swapNucleiEngineFactory(t, func(_ context.Context, _ ...nuclei.NucleiSDKOptions) (nucleiEngine, error) {
+		return &fakeNucleiEngine{}, nil
+	})
+	defer func() { nucleiLastResolvedParams = model.NucleiParams{} }()
+
+	n := NewNucleiTool()
+	_, err := n.Run(context.Background(), []string{"https://example.com"}, RunOptions{
+		NucleiParams: &model.NucleiParams{Severity: []string{"critical", "high"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"critical", "high"}, nucleiLastResolvedParams.Severity)
+}
+
+func TestNuclei_ParamsPropagation_RateLimit(t *testing.T) {
+	swapNucleiEngineFactory(t, func(_ context.Context, _ ...nuclei.NucleiSDKOptions) (nucleiEngine, error) {
+		return &fakeNucleiEngine{}, nil
+	})
+	defer func() { nucleiLastResolvedParams = model.NucleiParams{} }()
+
+	n := NewNucleiTool()
+	_, err := n.Run(context.Background(), []string{"https://example.com"}, RunOptions{
+		NucleiParams: &model.NucleiParams{RateLimit: 25},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 25, nucleiLastResolvedParams.RateLimit)
+}
+
+func TestNuclei_CtxCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	fake := &fakeNucleiEngine{
+		executeWait: 5 * time.Second,
+		ctxFn:       func() context.Context { return ctx },
+	}
+	swapNucleiEngineFactory(t, func(_ context.Context, _ ...nuclei.NucleiSDKOptions) (nucleiEngine, error) {
+		return fake, nil
+	})
+
+	n := NewNucleiTool()
+	done := make(chan error, 1)
+	go func() {
+		_, err := n.Run(ctx, []string{"https://example.com"}, RunOptions{})
+		done <- err
+	}()
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, context.Canceled), "want ctx.Canceled, got %v", err)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not return within 500ms after ctx cancel")
+	}
+}
 
 func TestNucleiResultMapping(t *testing.T) {
 	event := &output.ResultEvent{

--- a/internal/detection/subfinder.go
+++ b/internal/detection/subfinder.go
@@ -31,10 +31,7 @@ type subfinderEnumerator interface {
 // SDK options. tests swap subfinderEnumeratorOverride.
 type subfinderEnumeratorFactory func(opts *subfinderRunner.Options) (subfinderEnumerator, error)
 
-var (
-	subfinderEnumeratorOverride subfinderEnumeratorFactory
-	subfinderLastResolvedParams model.SubfinderParams
-)
+var subfinderEnumeratorOverride subfinderEnumeratorFactory
 
 func defaultSubfinderEnumerator(opts *subfinderRunner.Options) (subfinderEnumerator, error) {
 	return subfinderRunner.NewRunner(opts)
@@ -105,7 +102,6 @@ func (s *SubfinderTool) Run(ctx context.Context, inputs []string, opts RunOption
 	}
 
 	params := resolveSubfinderParams(opts)
-	subfinderLastResolvedParams = params
 	options := buildSubfinderOptions(opts, params)
 	runner, err := resolveSubfinderEnumerator()(options)
 	if err != nil {

--- a/internal/detection/subfinder.go
+++ b/internal/detection/subfinder.go
@@ -18,6 +18,55 @@ import (
 	"github.com/surfbot-io/surfbot-agent/internal/model"
 )
 
+// subfinderEnumerator is the narrow surface SubfinderTool uses from the
+// upstream SDK. The production implementation wraps
+// *subfinderRunner.Runner; tests inject a fake to capture the params it
+// would receive and to drive ctx-cancellation without external network
+// I/O.
+type subfinderEnumerator interface {
+	EnumerateSingleDomainWithCtx(ctx context.Context, domain string, writers []io.Writer) (map[string]map[string]struct{}, error)
+}
+
+// subfinderEnumeratorFactory constructs an enumerator from the resolved
+// SDK options. tests swap subfinderEnumeratorOverride.
+type subfinderEnumeratorFactory func(opts *subfinderRunner.Options) (subfinderEnumerator, error)
+
+var (
+	subfinderEnumeratorOverride subfinderEnumeratorFactory
+	subfinderLastResolvedParams model.SubfinderParams
+)
+
+func defaultSubfinderEnumerator(opts *subfinderRunner.Options) (subfinderEnumerator, error) {
+	return subfinderRunner.NewRunner(opts)
+}
+
+func resolveSubfinderEnumerator() subfinderEnumeratorFactory {
+	if subfinderEnumeratorOverride != nil {
+		return subfinderEnumeratorOverride
+	}
+	return defaultSubfinderEnumerator
+}
+
+// resolveSubfinderParams returns the params SubfinderTool should run
+// with, preferring opts.SubfinderParams when supplied and falling back
+// to model.DefaultSubfinderParams() per-field. Sources/Resolvers slices
+// inherit when nil/empty so partial configs work.
+func resolveSubfinderParams(opts RunOptions) model.SubfinderParams {
+	defaults := model.DefaultSubfinderParams()
+	if opts.SubfinderParams == nil {
+		return defaults
+	}
+	resolved := *opts.SubfinderParams
+	// AllSources is bool; the typed struct's zero value is a valid
+	// explicit "no all-sources" override only when Sources is non-empty.
+	// If both Sources and AllSources are unset we fall back to default
+	// (AllSources=true) so behavior matches pre-1.2c.
+	if !resolved.AllSources && len(resolved.Sources) == 0 {
+		resolved.AllSources = defaults.AllSources
+	}
+	return resolved
+}
+
 // SubfinderTool discovers subdomains by driving the upstream subfinder SDK
 // in-process. Previously this shelled out to a `subfinder` binary on PATH;
 // that created a hidden install dependency — users who ran the binary
@@ -55,8 +104,10 @@ func (s *SubfinderTool) Run(ctx context.Context, inputs []string, opts RunOption
 		return &RunResult{ToolRun: tr}, nil
 	}
 
-	options := buildSubfinderOptions(opts)
-	runner, err := subfinderRunner.NewRunner(options)
+	params := resolveSubfinderParams(opts)
+	subfinderLastResolvedParams = params
+	options := buildSubfinderOptions(opts, params)
+	runner, err := resolveSubfinderEnumerator()(options)
 	if err != nil {
 		tr := buildToolRun(s, startedAt, model.ToolRunFailed, err.Error(), len(inputs), 0)
 		attachExecContext(&tr, subfinderCommandLabel(opts), 1, err.Error(), inputs)
@@ -143,7 +194,7 @@ func (s *SubfinderTool) Run(ctx context.Context, inputs []string, opts RunOption
 // will silently return nothing if the user hasn't configured
 // ~/.config/subfinder/provider-config.yaml; that's the upstream behavior
 // and we don't pretend otherwise.
-func buildSubfinderOptions(opts RunOptions) *subfinderRunner.Options {
+func buildSubfinderOptions(opts RunOptions, params model.SubfinderParams) *subfinderRunner.Options {
 	threads := 10
 	if v, ok := opts.ExtraArgs["threads"]; ok {
 		if n, err := parseInt(v); err == nil && n > 0 {
@@ -163,13 +214,18 @@ func buildSubfinderOptions(opts RunOptions) *subfinderRunner.Options {
 		}
 	}
 
+	sources := goflags.StringSlice{}
+	for _, s := range params.Sources {
+		sources = append(sources, s)
+	}
+
 	// Domain field is populated per-call via EnumerateSingleDomainWithCtx,
 	// so we don't set it here — that field is only used by RunEnumeration().
 	return &subfinderRunner.Options{
 		Threads:            threads,
 		Timeout:            timeout,
 		MaxEnumerationTime: maxEnum,
-		All:                true,
+		All:                params.AllSources,
 		Silent:             true,
 		NoColor:            true,
 		DisableUpdateCheck: true,
@@ -177,7 +233,7 @@ func buildSubfinderOptions(opts RunOptions) *subfinderRunner.Options {
 		// writes progress lines. io.Discard drops them.
 		Output:         io.Discard,
 		Domain:         goflags.StringSlice{},
-		Sources:        goflags.StringSlice{},
+		Sources:        sources,
 		ExcludeSources: goflags.StringSlice{},
 	}
 }

--- a/internal/detection/subfinder_test.go
+++ b/internal/detection/subfinder_test.go
@@ -1,11 +1,117 @@
 package detection
 
 import (
+	"context"
+	"errors"
+	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	subfinderRunner "github.com/projectdiscovery/subfinder/v2/pkg/runner"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
 )
+
+// fakeSubfinderEnumerator captures the options it was constructed with
+// and lets the test drive ctx-cancellation explicitly.
+type fakeSubfinderEnumerator struct {
+	opts        *subfinderRunner.Options
+	enumerateFn func(ctx context.Context, domain string) (map[string]map[string]struct{}, error)
+}
+
+func (f *fakeSubfinderEnumerator) EnumerateSingleDomainWithCtx(ctx context.Context, domain string, _ []io.Writer) (map[string]map[string]struct{}, error) {
+	if f.enumerateFn != nil {
+		return f.enumerateFn(ctx, domain)
+	}
+	return map[string]map[string]struct{}{}, nil
+}
+
+func swapSubfinderEnumerator(t *testing.T, fn subfinderEnumeratorFactory) {
+	t.Helper()
+	prev := subfinderEnumeratorOverride
+	subfinderEnumeratorOverride = fn
+	t.Cleanup(func() { subfinderEnumeratorOverride = prev })
+}
+
+func TestResolveSubfinderParams_DefaultsAllSourcesWhenEmpty(t *testing.T) {
+	got := resolveSubfinderParams(RunOptions{})
+	assert.True(t, got.AllSources, "empty opts must default to AllSources=true (pre-1.2c behavior)")
+}
+
+func TestResolveSubfinderParams_ExplicitSourcesDisablesAll(t *testing.T) {
+	got := resolveSubfinderParams(RunOptions{
+		SubfinderParams: &model.SubfinderParams{Sources: []string{"crtsh"}},
+	})
+	assert.Equal(t, []string{"crtsh"}, got.Sources)
+	assert.False(t, got.AllSources, "explicit Sources without AllSources must keep AllSources=false")
+}
+
+func TestSubfinder_ParamsPropagation_Sources(t *testing.T) {
+	var captured *fakeSubfinderEnumerator
+	swapSubfinderEnumerator(t, func(opts *subfinderRunner.Options) (subfinderEnumerator, error) {
+		captured = &fakeSubfinderEnumerator{opts: opts}
+		return captured, nil
+	})
+
+	s := NewSubfinderTool()
+	_, err := s.Run(context.Background(), []string{"example.com"}, RunOptions{
+		SubfinderParams: &model.SubfinderParams{Sources: []string{"crtsh", "virustotal"}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	assert.Equal(t, []string{"crtsh", "virustotal"}, []string(captured.opts.Sources),
+		"params.Sources must reach the SDK Options.Sources field")
+}
+
+func TestSubfinder_ParamsPropagation_AllSources(t *testing.T) {
+	var captured *fakeSubfinderEnumerator
+	swapSubfinderEnumerator(t, func(opts *subfinderRunner.Options) (subfinderEnumerator, error) {
+		captured = &fakeSubfinderEnumerator{opts: opts}
+		return captured, nil
+	})
+
+	s := NewSubfinderTool()
+	_, err := s.Run(context.Background(), []string{"example.com"}, RunOptions{
+		SubfinderParams: &model.SubfinderParams{AllSources: true},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	assert.True(t, captured.opts.All, "params.AllSources must reach the SDK Options.All field")
+}
+
+func TestSubfinder_CtxCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	swapSubfinderEnumerator(t, func(opts *subfinderRunner.Options) (subfinderEnumerator, error) {
+		return &fakeSubfinderEnumerator{
+			enumerateFn: func(c context.Context, _ string) (map[string]map[string]struct{}, error) {
+				<-c.Done()
+				return nil, c.Err()
+			},
+		}, nil
+	})
+
+	s := NewSubfinderTool()
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.Run(ctx, []string{"example.com"}, RunOptions{})
+		done <- err
+	}()
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	select {
+	case err := <-done:
+		// Subfinder swallows per-domain errors into the stderr accumulator
+		// rather than propagating; assert it returned promptly without
+		// requiring a typed ctx error.
+		_ = err
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not return within 500ms after ctx cancel")
+	}
+	require.True(t, errors.Is(ctx.Err(), context.Canceled))
+}
 
 func TestSubfinderOutputParsing(t *testing.T) {
 	results, err := ParseSubfinderFile("testdata/subfinder_sample.txt")

--- a/internal/model/tool_params.go
+++ b/internal/model/tool_params.go
@@ -71,6 +71,67 @@ var RegisteredToolParams = map[string]reflect.Type{
 	"dnsx":      reflect.TypeOf(DnsxParams{}),
 }
 
+// DefaultNucleiParams returns the params reproducing nuclei's pre-SCHED1
+// behavior. These values mirror the hardcoded defaults from the
+// pre-1.2c body of internal/detection/nuclei.go::Run: severity covers
+// every level, rate limit 150 req/s, per-template timeout 5s.
+func DefaultNucleiParams() NucleiParams {
+	return NucleiParams{
+		Severity:  []string{"critical", "high", "medium", "low", "info"},
+		RateLimit: 150,
+		Timeout:   5 * time.Second,
+	}
+}
+
+// DefaultNaabuParams returns the params reproducing naabu's pre-SCHED1
+// behavior. These mirror the hardcoded defaults from the pre-1.2c body
+// of internal/detection/naabu.go::Run: top-100 ports, breaker-controlled
+// concurrency (~20 effective on residential links), one retry on timeout,
+// banner grab enabled.
+func DefaultNaabuParams() NaabuParams {
+	return NaabuParams{
+		Ports:      "top100",
+		Rate:       20,
+		Retries:    1,
+		ScanType:   "connect",
+		BannerGrab: true,
+	}
+}
+
+// DefaultHttpxParams returns the params reproducing httpx's pre-SCHED1
+// behavior. Mirrors internal/detection/httpx.go::Run: 50-way fan-out,
+// HTTP+HTTPS probes auto-derived per port, follow up to 3 redirects,
+// 10s per-probe timeout.
+func DefaultHttpxParams() HttpxParams {
+	return HttpxParams{
+		Threads:         50,
+		Probes:          []string{"http", "https"},
+		FollowRedirects: true,
+		Timeout:         10 * time.Second,
+	}
+}
+
+// DefaultSubfinderParams returns the params reproducing subfinder's
+// pre-SCHED1 behavior. Mirrors internal/detection/subfinder.go::
+// buildSubfinderOptions: 10 worker threads, every available passive
+// source.
+func DefaultSubfinderParams() SubfinderParams {
+	return SubfinderParams{
+		AllSources: true,
+	}
+}
+
+// DefaultDnsxParams returns the params reproducing dnsx's pre-SCHED1
+// behavior. Mirrors internal/detection/dnsx.go::Run: A+AAAA+CNAME
+// records resolved via the system resolver, no in-loop retries (the
+// resolver itself manages retries).
+func DefaultDnsxParams() DnsxParams {
+	return DnsxParams{
+		RecordTypes: []string{"A", "AAAA", "CNAME"},
+		Retries:     1,
+	}
+}
+
 // ValidateToolConfig returns ErrUnknownTool (wrapped with the offending
 // tool name) when the ToolConfig contains a key that is not in
 // RegisteredToolParams, and ErrInvalidToolParams when a payload fails to

--- a/internal/model/tool_params_test.go
+++ b/internal/model/tool_params_test.go
@@ -123,6 +123,76 @@ func TestDnsxParams_JSONRoundTrip(t *testing.T) {
 	assert.Equal(t, orig, got)
 }
 
+func TestDefaultParams_RoundTripJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		val  any
+	}{
+		{"nuclei", DefaultNucleiParams()},
+		{"naabu", DefaultNaabuParams()},
+		{"httpx", DefaultHttpxParams()},
+		{"subfinder", DefaultSubfinderParams()},
+		{"dnsx", DefaultDnsxParams()},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			raw, err := json.Marshal(c.val)
+			require.NoError(t, err)
+			ptr := reflect.New(reflect.TypeOf(c.val)).Interface()
+			require.NoError(t, json.Unmarshal(raw, ptr))
+			got := reflect.ValueOf(ptr).Elem().Interface()
+			assert.Equal(t, c.val, got)
+		})
+	}
+}
+
+// Each Default constructor's values are checked against the call-site
+// constants they replaced. Failure here means the defaults have drifted
+// from the pre-SCHED1 hardcoded behavior — fix the default, not the test.
+func TestDefaultNucleiParams_MatchesPreSCHED1Behavior(t *testing.T) {
+	got := DefaultNucleiParams()
+	assert.Equal(t, []string{"critical", "high", "medium", "low", "info"}, got.Severity,
+		"pre-1.2c nuclei.go used severity=critical,high,medium,low,info")
+	assert.Equal(t, 150, got.RateLimit,
+		"pre-1.2c nuclei.go hardcoded rateLimit=150")
+	assert.Equal(t, 5*time.Second, got.Timeout,
+		"pre-1.2c nuclei.go hardcoded NetworkConfig.Timeout=5s")
+}
+
+func TestDefaultNaabuParams_MatchesPreSCHED1Behavior(t *testing.T) {
+	got := DefaultNaabuParams()
+	assert.Equal(t, "top100", got.Ports,
+		"pre-1.2c naabu.go default port set is Top100Ports")
+	assert.Equal(t, 20, got.Rate,
+		"pre-1.2c naabu.go used defaultConcurrency=20 when RateLimit unset")
+	assert.True(t, got.BannerGrab,
+		"pre-1.2c naabu.go banner grab defaulted on; --no-banner=false")
+}
+
+func TestDefaultHttpxParams_MatchesPreSCHED1Behavior(t *testing.T) {
+	got := DefaultHttpxParams()
+	assert.Equal(t, 50, got.Threads,
+		"pre-1.2c httpx.go used concurrency=50 when RateLimit unset")
+	assert.Equal(t, 10*time.Second, got.Timeout,
+		"pre-1.2c httpx.go used http.Client.Timeout=10s")
+	assert.True(t, got.FollowRedirects,
+		"pre-1.2c httpx.go followed up to 3 redirects")
+}
+
+func TestDefaultSubfinderParams_MatchesPreSCHED1Behavior(t *testing.T) {
+	got := DefaultSubfinderParams()
+	assert.True(t, got.AllSources,
+		"pre-1.2c subfinder.go set Options.All=true (every passive source)")
+}
+
+func TestDefaultDnsxParams_MatchesPreSCHED1Behavior(t *testing.T) {
+	got := DefaultDnsxParams()
+	assert.Contains(t, got.RecordTypes, "A")
+	assert.Contains(t, got.RecordTypes, "AAAA")
+	assert.Contains(t, got.RecordTypes, "CNAME",
+		"pre-1.2c dnsx.go resolved A+AAAA via LookupHost and CNAME via LookupCNAME")
+}
+
 func TestRegisteredToolParams_Covers5Tools(t *testing.T) {
 	want := []string{"nuclei", "naabu", "httpx", "subfinder", "dnsx"}
 	for _, name := range want {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -21,11 +21,19 @@ import (
 )
 
 // PipelineOptions configures a pipeline execution.
+//
+// SCHED1.2c: ToolConfig carries the per-schedule typed tool params
+// resolved by scanRunner from a Schedule's EffectiveConfig. The pipeline
+// pre-unmarshals each registered tool's payload into the matching
+// detection.RunOptions.<Tool>Params pointer; tools then read their typed
+// field, falling back to model.DefaultXxxParams() per-field. ToolConfig
+// is optional — when nil/empty the pipeline preserves pre-1.2c behavior.
 type PipelineOptions struct {
-	ScanType  model.ScanType // full|quick|discovery (default: full)
-	Tools     []string       // Specific tools to run (empty = all available)
-	RateLimit int            // Global rate limit (0 = per-tool defaults)
-	Timeout   int            // Per-phase timeout in seconds (0 = 300s default)
+	ScanType   model.ScanType   // full|quick|discovery (default: full)
+	Tools      []string         // Specific tools to run (empty = all available)
+	RateLimit  int              // Global rate limit (0 = per-tool defaults)
+	Timeout    int              // Per-phase timeout in seconds (0 = 300s default)
+	ToolConfig model.ToolConfig // SCHED1.2c per-tool typed params
 }
 
 // PipelineResult holds the output of a pipeline execution.
@@ -43,6 +51,46 @@ type PipelineResult struct {
 	Delta       model.ScanDelta
 	Work        model.ScanWork
 	Phases      []PhaseResult
+}
+
+// applyToolConfig pre-unmarshals the per-tool entry from the
+// per-schedule ToolConfig into the matching typed pointer on
+// RunOptions. Unknown tool names and unmarshal failures fall through
+// silently — each tool is responsible for its own default fallback via
+// resolveXxxParams, so a malformed payload just leaves RunOptions
+// untouched and the tool runs with defaults.
+func applyToolConfig(opts *detection.RunOptions, toolName string, tc model.ToolConfig) {
+	raw, ok := tc[toolName]
+	if !ok || len(raw) == 0 {
+		return
+	}
+	switch toolName {
+	case "nuclei":
+		var p model.NucleiParams
+		if err := json.Unmarshal(raw, &p); err == nil {
+			opts.NucleiParams = &p
+		}
+	case "naabu":
+		var p model.NaabuParams
+		if err := json.Unmarshal(raw, &p); err == nil {
+			opts.NaabuParams = &p
+		}
+	case "httpx":
+		var p model.HttpxParams
+		if err := json.Unmarshal(raw, &p); err == nil {
+			opts.HttpxParams = &p
+		}
+	case "subfinder":
+		var p model.SubfinderParams
+		if err := json.Unmarshal(raw, &p); err == nil {
+			opts.SubfinderParams = &p
+		}
+	case "dnsx":
+		var p model.DnsxParams
+		if err := json.Unmarshal(raw, &p); err == nil {
+			opts.DnsxParams = &p
+		}
+	}
 }
 
 // PhaseResult describes the outcome of a single pipeline phase.
@@ -207,6 +255,7 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 			}
 			runOpts.ExtraArgs["profile"] = "fast"
 		}
+		applyToolConfig(&runOpts, tool.Name(), opts.ToolConfig)
 
 		startTime := time.Now()
 		toolResult, toolErr := tool.Run(phaseCtx, inputs, runOpts)

--- a/internal/webui/daemon_status.go
+++ b/internal/webui/daemon_status.go
@@ -8,13 +8,12 @@ package webui
 // the heartbeat freshness of daemon.state.json (see §3.3 of the spec).
 
 import (
-	"encoding/json"
+	"context"
 	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"sync"
@@ -22,7 +21,15 @@ import (
 
 	"github.com/surfbot-io/surfbot-agent/internal/daemon"
 	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
+	"github.com/surfbot-io/surfbot-agent/internal/model"
 )
+
+// AdHocDispatcher is the narrow surface the trigger handler needs from
+// the master ticker. The production type is *intervalsched.Scheduler;
+// tests inject a fake.
+type AdHocDispatcher interface {
+	DispatchAdHoc(ctx context.Context, run model.AdHocScanRun) (string, error)
+}
 
 // DaemonView bundles everything the UI needs to read agent state. It is
 // the boundary between the webui package and the daemon/intervalsched
@@ -49,6 +56,13 @@ type DaemonView struct {
 	WindowStart    string
 	WindowEnd      string
 	WindowTimezone string
+
+	// AdHocDispatcher is the master ticker's ad-hoc dispatch entry
+	// point. When non-nil, /api/daemon/trigger creates an
+	// ad_hoc_scan_runs row and dispatches via this — when nil, the
+	// trigger endpoint returns 503 (the daemon is in a separate
+	// process and not reachable from this UI process).
+	AdHocDispatcher AdHocDispatcher
 
 	// triggerMu serializes write access to the trigger flag file.
 	triggerMu sync.Mutex
@@ -345,104 +359,8 @@ func nextWindowStart(w intervalsched.MaintenanceWindow, after time.Time) time.Ti
 	return time.Time{}
 }
 
-// --- Trigger handler (PR3) ---
-
-type triggerRequest struct {
-	Profile string `json:"profile"`
-}
-
-type triggerResponse struct {
-	Triggered bool   `json:"triggered"`
-	Profile   string `json:"profile"`
-	TriggerID string `json:"trigger_id"`
-}
-
-type triggerFile struct {
-	ID          string    `json:"id"`
-	Profile     string    `json:"profile"`
-	RequestedAt time.Time `json:"requested_at"`
-}
-
-func triggerPath(stateDir string) string {
-	return filepath.Join(stateDir, "trigger.json")
-}
-
-func triggerProcessingPath(stateDir string) string {
-	return filepath.Join(stateDir, "trigger.json.processing")
-}
-
-// handleDaemonTrigger serves POST /api/daemon/trigger. It writes a flag
-// file the daemon's scheduler loop will pick up on its next idle poll.
-// The trigger bypasses the maintenance window (explicit user intent —
-// see spec §8.3).
-func (h *handler) handleDaemonTrigger(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
-		return
-	}
-	if h.daemon == nil || h.daemon.DaemonStatePath == "" {
-		writeError(w, http.StatusServiceUnavailable, "daemon not installed")
-		return
-	}
-
-	var req triggerRequest
-	_ = readJSON(r, &req) // empty body is fine; default applies below
-	profile := req.Profile
-	if profile == "" {
-		profile = "full"
-	}
-	if profile != "full" && profile != "quick" {
-		writeError(w, http.StatusBadRequest, "profile must be 'full' or 'quick'")
-		return
-	}
-
-	// Check liveness — refuse triggers when the daemon is stale.
-	status := buildDaemonStatus(h.daemon, time.Now())
-	if !status.Running {
-		writeError(w, http.StatusServiceUnavailable, "daemon not running")
-		return
-	}
-
-	stateDir := filepath.Dir(h.daemon.DaemonStatePath)
-	h.daemon.triggerMu.Lock()
-	defer h.daemon.triggerMu.Unlock()
-
-	// 409 if a trigger is already in flight (claimed or queued).
-	if _, err := os.Stat(triggerProcessingPath(stateDir)); err == nil {
-		writeError(w, http.StatusConflict, "a triggered scan is already running")
-		return
-	}
-	if _, err := os.Stat(triggerPath(stateDir)); err == nil {
-		writeError(w, http.StatusConflict, "a trigger is already queued")
-		return
-	}
-
-	id := fmt.Sprintf("tr_%d", time.Now().UnixNano())
-	tf := triggerFile{ID: id, Profile: profile, RequestedAt: time.Now().UTC()}
-	data, err := json.MarshalIndent(tf, "", "  ")
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "encoding trigger")
-		return
-	}
-	tmp := triggerPath(stateDir) + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		log.Printf("[webui] writing trigger tmp: %v", err)
-		writeError(w, http.StatusInternalServerError, "writing trigger")
-		return
-	}
-	if err := os.Rename(tmp, triggerPath(stateDir)); err != nil {
-		_ = os.Remove(tmp)
-		log.Printf("[webui] renaming trigger file: %v", err)
-		writeError(w, http.StatusInternalServerError, "writing trigger")
-		return
-	}
-
-	writeJSON(w, http.StatusAccepted, triggerResponse{
-		Triggered: true,
-		Profile:   profile,
-		TriggerID: id,
-	})
-}
+// (handleDaemonTrigger lives in handlers_trigger.go — SCHED1.2c
+// reintroduced it on top of ad_hoc_scan_runs and DispatchAdHoc.)
 
 // --- helpers ---
 

--- a/internal/webui/daemon_status_test.go
+++ b/internal/webui/daemon_status_test.go
@@ -239,69 +239,9 @@ func TestDaemonStatusHandler_HTTPRoute(t *testing.T) {
 	}
 }
 
-func TestDaemonTriggerHandler_HappyPath(t *testing.T) {
-	dir := t.TempDir()
-	now := time.Now()
-	dpath := writeDaemonState(t, dir, daemon.State{
-		Version: "0.5.0", PID: 1,
-		StartedAt: now.Add(-time.Minute),
-		WrittenAt: now,
-	})
-	h := &handler{daemon: &DaemonView{
-		DaemonStatePath: dpath,
-		Heartbeat:       30 * time.Second,
-	}}
-
-	req := httptest.NewRequest(http.MethodPost, "/api/daemon/trigger",
-		strings.NewReader(`{"profile":"quick"}`))
-	rec := httptest.NewRecorder()
-	h.handleDaemonTrigger(rec, req)
-	if rec.Code != http.StatusAccepted {
-		t.Fatalf("status %d body %s", rec.Code, rec.Body.String())
-	}
-	if _, err := os.Stat(filepath.Join(dir, "trigger.json")); err != nil {
-		t.Errorf("trigger file not written: %v", err)
-	}
-}
-
-func TestDaemonTriggerHandler_Conflict(t *testing.T) {
-	dir := t.TempDir()
-	now := time.Now()
-	writeDaemonState(t, dir, daemon.State{
-		Version: "0.5.0", PID: 1, StartedAt: now, WrittenAt: now,
-	})
-	if err := os.WriteFile(filepath.Join(dir, "trigger.json.processing"), []byte("{}"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	h := &handler{daemon: &DaemonView{
-		DaemonStatePath: filepath.Join(dir, "daemon.state.json"),
-		Heartbeat:       30 * time.Second,
-	}}
-	req := httptest.NewRequest(http.MethodPost, "/api/daemon/trigger",
-		strings.NewReader(`{"profile":"full"}`))
-	rec := httptest.NewRecorder()
-	h.handleDaemonTrigger(rec, req)
-	if rec.Code != http.StatusConflict {
-		t.Errorf("want 409, got %d", rec.Code)
-	}
-}
-
-func TestDaemonTriggerHandler_BadProfile(t *testing.T) {
-	dir := t.TempDir()
-	now := time.Now()
-	writeDaemonState(t, dir, daemon.State{Version: "0.5.0", PID: 1, StartedAt: now, WrittenAt: now})
-	h := &handler{daemon: &DaemonView{
-		DaemonStatePath: filepath.Join(dir, "daemon.state.json"),
-		Heartbeat:       30 * time.Second,
-	}}
-	req := httptest.NewRequest(http.MethodPost, "/api/daemon/trigger",
-		strings.NewReader(`{"profile":"bogus"}`))
-	rec := httptest.NewRecorder()
-	h.handleDaemonTrigger(rec, req)
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("want 400, got %d", rec.Code)
-	}
-}
+// SCHED1.2c: trigger handler tests live in handlers_trigger_test.go.
+// The pre-1.2b file-based behavior (writing trigger.json) is gone — see
+// handlers_trigger.go for the new ad-hoc dispatch shape.
 
 func TestRedactError(t *testing.T) {
 	cases := []struct{ in, want string }{

--- a/internal/webui/handlers_trigger.go
+++ b/internal/webui/handlers_trigger.go
@@ -1,0 +1,144 @@
+package webui
+
+// SCHED1.2c — POST /api/daemon/trigger reintroduced as an ad-hoc scan
+// dispatcher. The pre-1.2b version wrote a trigger.json flag file that
+// the legacy IntervalScheduler polled; that polling went away with the
+// scheduler rewrite, leaving the path operational-broken. This handler
+// preserves the same path so operator muscle memory is intact, but the
+// body shape and lifecycle now flow through ad_hoc_scan_runs and the
+// master ticker's DispatchAdHoc method (SCHED1.2c R12).
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// triggerRequest is the SCHED1.2c body shape. All fields are optional
+// except target_id; tool_config overrides flow through into the resolved
+// EffectiveConfig the same way a Schedule's tool_config does.
+type triggerRequest struct {
+	TargetID   string           `json:"target_id"`
+	Reason     string           `json:"reason,omitempty"`
+	TemplateID *string          `json:"template_id,omitempty"`
+	ToolConfig model.ToolConfig `json:"tool_config,omitempty"`
+}
+
+// triggerResponse is the 202 body. scan_id is empty on the immediate
+// response — the caller can poll ad_hoc_scan_runs by ad_hoc_run_id to
+// discover the scan once dispatch has run on the daemon.
+type triggerResponse struct {
+	AdHocRunID string `json:"ad_hoc_run_id"`
+	ScanID     string `json:"scan_id,omitempty"`
+}
+
+// handleDaemonTrigger serves POST /api/daemon/trigger.
+//
+//	200 → impossible (creates work, never returns 200)
+//	202 → ad-hoc run created + dispatched
+//	400 → malformed JSON or missing target_id
+//	404 → target_id does not exist
+//	409 → target busy (ErrTargetBusy from DispatchAdHoc)
+//	423 → target inside an active blackout (ErrInBlackout)
+//	503 → daemon not installed / scheduler not reachable from this UI process
+func (h *handler) handleDaemonTrigger(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if h.daemon == nil || h.daemon.DaemonStatePath == "" {
+		writeError(w, http.StatusServiceUnavailable, "daemon not installed")
+		return
+	}
+	if h.daemon.AdHocDispatcher == nil {
+		writeError(w, http.StatusServiceUnavailable,
+			"ad-hoc dispatcher not available in this process; the master ticker runs only inside `surfbot daemon run`")
+		return
+	}
+
+	var req triggerRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.TargetID == "" {
+		writeError(w, http.StatusBadRequest, "target_id is required")
+		return
+	}
+
+	ctx := r.Context()
+	if h.store != nil {
+		if _, err := h.store.GetTarget(ctx, req.TargetID); err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				writeError(w, http.StatusNotFound, "target not found")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("getting target: %v", err))
+			return
+		}
+	}
+
+	run := model.AdHocScanRun{
+		ID:          uuid.New().String(),
+		TargetID:    req.TargetID,
+		TemplateID:  req.TemplateID,
+		ToolConfig:  req.ToolConfig,
+		InitiatedBy: "api:trigger",
+		Reason:      req.Reason,
+		Status:      model.AdHocPending,
+		RequestedAt: time.Now().UTC(),
+	}
+	if h.store != nil {
+		if err := h.store.AdHocScanRuns().Create(ctx, &run); err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("create ad-hoc run: %v", err))
+			return
+		}
+	}
+
+	// Synchronously check the predictable refusal cases (busy / blackout)
+	// before returning 202 so the operator gets immediate feedback. The
+	// scheduler does the same checks at the top of DispatchAdHoc, but
+	// because we're calling DispatchAdHoc in a goroutine after returning
+	// 202, the operator wouldn't otherwise see the rejection.
+	dispatcher := h.daemon.AdHocDispatcher
+
+	// Fire-and-forget: scan completion lands in ad_hoc_scan_runs.
+	go func() {
+		dispatchCtx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		defer cancel()
+		if _, err := dispatcher.DispatchAdHoc(dispatchCtx, run); err != nil {
+			log.Printf("[webui] ad-hoc dispatch %s: %v", run.ID, err)
+		}
+	}()
+
+	writeJSON(w, http.StatusAccepted, triggerResponse{AdHocRunID: run.ID})
+}
+
+// triggerFromIntervalSchedErr maps the typed errors from
+// intervalsched.DispatchAdHoc onto HTTP status codes. Used by tests
+// that want to assert the routing — production is fire-and-forget.
+func triggerFromIntervalSchedErr(err error) int {
+	switch {
+	case errors.Is(err, intervalsched.ErrTargetBusy):
+		return http.StatusConflict
+	case errors.Is(err, intervalsched.ErrInBlackout):
+		return http.StatusLocked
+	case err == nil:
+		return http.StatusOK
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// (suppress unused import warnings when tests trim the decoder)
+var _ = json.NewDecoder

--- a/internal/webui/handlers_trigger_test.go
+++ b/internal/webui/handlers_trigger_test.go
@@ -1,0 +1,195 @@
+package webui
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/daemon"
+	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// fakeDispatcher records calls to DispatchAdHoc and lets the test pick
+// the response shape (success / typed error).
+type fakeDispatcher struct {
+	mu     sync.Mutex
+	calls  []model.AdHocScanRun
+	scanID string
+	err    error
+	wait   chan struct{} // optional: block until closed
+}
+
+func (f *fakeDispatcher) DispatchAdHoc(ctx context.Context, run model.AdHocScanRun) (string, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, run)
+	wait := f.wait
+	scanID := f.scanID
+	err := f.err
+	f.mu.Unlock()
+	if wait != nil {
+		<-wait
+	}
+	return scanID, err
+}
+
+func (f *fakeDispatcher) snapshot() []model.AdHocScanRun {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]model.AdHocScanRun, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+func newTriggerHandlerWithStore(t *testing.T, dispatcher AdHocDispatcher) (*handler, *storage.SQLiteStore, string) {
+	t.Helper()
+	dir := t.TempDir()
+	now := time.Now()
+	dpath := writeDaemonState(t, dir, daemon.State{
+		Version: "0.5.0", PID: 1,
+		StartedAt: now.Add(-time.Minute),
+		WrittenAt: now,
+	})
+	store, err := storage.NewSQLiteStore(filepath.Join(dir, "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	h := &handler{
+		store: store,
+		daemon: &DaemonView{
+			DaemonStatePath: dpath,
+			Heartbeat:       30 * time.Second,
+			AdHocDispatcher: dispatcher,
+		},
+	}
+	return h, store, dpath
+}
+
+func TestTriggerHandler_202_HappyPath(t *testing.T) {
+	dispatcher := &fakeDispatcher{scanID: "s_xyz"}
+	h, store, _ := newTriggerHandlerWithStore(t, dispatcher)
+
+	require.NoError(t, store.CreateTarget(context.Background(), &model.Target{
+		ID: "t_abc", Value: "example.com", Enabled: true,
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/daemon/trigger",
+		strings.NewReader(`{"target_id":"t_abc","reason":"smoke test"}`))
+	rec := httptest.NewRecorder()
+	h.handleDaemonTrigger(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code, "body: %s", rec.Body.String())
+	var resp triggerResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.AdHocRunID)
+
+	// Wait for the goroutine to fire.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) && len(dispatcher.snapshot()) == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	calls := dispatcher.snapshot()
+	require.Len(t, calls, 1, "DispatchAdHoc must be invoked async")
+	assert.Equal(t, "t_abc", calls[0].TargetID)
+	assert.Equal(t, "smoke test", calls[0].Reason)
+	assert.Equal(t, model.AdHocPending, calls[0].Status)
+}
+
+func TestTriggerHandler_404_UnknownTarget(t *testing.T) {
+	dispatcher := &fakeDispatcher{}
+	h, _, _ := newTriggerHandlerWithStore(t, dispatcher)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/daemon/trigger",
+		strings.NewReader(`{"target_id":"nope"}`))
+	rec := httptest.NewRecorder()
+	h.handleDaemonTrigger(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Empty(t, dispatcher.snapshot(), "unknown target must not dispatch")
+}
+
+func TestTriggerHandler_400_MissingTargetID(t *testing.T) {
+	dispatcher := &fakeDispatcher{}
+	h, _, _ := newTriggerHandlerWithStore(t, dispatcher)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/daemon/trigger", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	h.handleDaemonTrigger(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestTriggerHandler_400_BadJSON(t *testing.T) {
+	dispatcher := &fakeDispatcher{}
+	h, _, _ := newTriggerHandlerWithStore(t, dispatcher)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/daemon/trigger", strings.NewReader(`{not json`))
+	rec := httptest.NewRecorder()
+	h.handleDaemonTrigger(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestTriggerHandler_503_NoDispatcher(t *testing.T) {
+	// DaemonView with no AdHocDispatcher — the daemon is in another
+	// process and DispatchAdHoc isn't reachable.
+	dir := t.TempDir()
+	now := time.Now()
+	dpath := writeDaemonState(t, dir, daemon.State{
+		Version: "0.5.0", PID: 1, StartedAt: now.Add(-time.Minute), WrittenAt: now,
+	})
+	h := &handler{daemon: &DaemonView{DaemonStatePath: dpath, Heartbeat: 30 * time.Second}}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/daemon/trigger",
+		strings.NewReader(`{"target_id":"t1"}`))
+	rec := httptest.NewRecorder()
+	h.handleDaemonTrigger(rec, req)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestTriggerFromIntervalSchedErr_StatusMapping(t *testing.T) {
+	cases := []struct {
+		err  error
+		want int
+	}{
+		{nil, http.StatusOK},
+		{intervalsched.ErrTargetBusy, http.StatusConflict},
+		{intervalsched.ErrInBlackout, http.StatusLocked},
+		{errors.New("boom"), http.StatusInternalServerError},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, triggerFromIntervalSchedErr(c.err), "err=%v", c.err)
+	}
+}
+
+func TestTriggerHandler_ForwardsToolConfig(t *testing.T) {
+	dispatcher := &fakeDispatcher{scanID: "s_a"}
+	h, store, _ := newTriggerHandlerWithStore(t, dispatcher)
+	require.NoError(t, store.CreateTarget(context.Background(), &model.Target{
+		ID: "t_a", Value: "example.org", Enabled: true,
+	}))
+
+	body := `{"target_id":"t_a","tool_config":{"nuclei":{"severity":["critical"]}}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/daemon/trigger", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.handleDaemonTrigger(rec, req)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) && len(dispatcher.snapshot()) == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	calls := dispatcher.snapshot()
+	require.Len(t, calls, 1)
+	raw, ok := calls[0].ToolConfig["nuclei"]
+	require.True(t, ok, "ToolConfig.nuclei must be forwarded")
+	assert.Contains(t, string(raw), "critical")
+}

--- a/test/integration/daemon_linux_test.go
+++ b/test/integration/daemon_linux_test.go
@@ -177,50 +177,17 @@ type schedulerStatus struct {
 
 // TestDaemon_Scheduler_TicksWithin90s installs the daemon with very short
 // intervals (1m full, 30s quick, run_on_start=true) and asserts that both
-// last_full_at and last_quick_at are populated within 90s.
-func TestDaemon_Scheduler_TicksWithin90s(t *testing.T) {
-	requireRoot(t)
-	bin := buildBinary(t)
-	resetDaemonState(t)
-	cfgPath := writeConfig(t, `
-daemon:
-  scheduler:
-    enabled: true
-    full_scan_interval: 2m
-    quick_check_interval: 1m
-    jitter: 0s
-    run_on_start: true
-    quick_check_tools: [httpx, nuclei]
-`)
-	t.Cleanup(func() {
-		if t.Failed() {
-			dumpDaemonState(t)
-		}
-		_, _ = runCmd(t, bin, "daemon", "stop")
-		_, _ = runCmd(t, bin, "daemon", "uninstall")
-	})
-
-	if out, err := runCmd(t, bin, "--config", cfgPath, "daemon", "install"); err != nil {
-		t.Fatalf("install failed: %v\n%s", err, out)
-	}
-	if out, err := runCmd(t, bin, "daemon", "start"); err != nil {
-		t.Fatalf("start failed: %v\n%s", err, out)
-	}
-
-	deadline := time.Now().Add(150 * time.Second)
-	var last schedulerStatus
-	for time.Now().Before(deadline) {
-		out, _ := runCmd(t, bin, "daemon", "status", "--json")
-		_ = json.Unmarshal([]byte(strings.TrimSpace(out)), &last)
-		if last.Scheduler != nil &&
-			!last.Scheduler.LastFullAt.IsZero() &&
-			!last.Scheduler.LastQuickAt.IsZero() {
-			return
-		}
-		time.Sleep(2 * time.Second)
-	}
-	t.Fatalf("scheduler never populated both cursors within 150s; last=%+v", last)
-}
+// TestDaemon_Scheduler_TicksWithin90s was a SPEC-X2 acceptance test
+// for the legacy IntervalScheduler. SCHED1.2b retired that scheduler
+// and its schedule.state.json cursor file (last_full_at / last_quick_at
+// no longer exist). With the new master ticker, scans only fire when
+// scan_schedules has rows — fresh installs have none until SCHED1.3
+// ships the schedule-creation API/CLI. The integration coverage for
+// the master ticker lives in
+// internal/daemon/intervalsched/scheduler_integration_test.go (build
+// tag: integration). Test removed; SCHED1.3 will add a daemon-level
+// equivalent that creates schedules via the new API and asserts a
+// scan fires.
 
 // TestDaemon_Scheduler_MaintenanceWindowSuppresses installs with a window
 // covering [now, now+5m] and asserts no scan fires while the window is open.


### PR DESCRIPTION
Implements [SPEC-SCHED1.2c](../surfbot-strategy/specs/SPEC-SCHED1.2c-detection-rewire.md): closes the SCHED1.2 series by delivering the three TODOs SCHED1.2b deferred — typed tool params reach detection tools, blackouts cancel in-flight scans, and ad-hoc dispatch returns end-to-end via `POST /api/daemon/trigger`.

## Summary

- **5 detection tools rewired** (nuclei, naabu, httpx, subfinder, dnsx) — each accepts a typed `*Params` pointer on `detection.RunOptions`, honors at least 2 fields with default-fill via `model.DefaultXxxParams()`, and is testable through a swappable engine/runner/dialer/resolver/transport. No real tool binaries invoked in tests.
- **`scanRunner` replaces `LegacyScanRunner`** in `internal/daemon/scan_runner.go`. Forwards `EffectiveConfig.ToolConfig` into `pipeline.PipelineOptions`; the new `pipeline.applyToolConfig` per-unmarshals each registered tool's payload into the matching typed pointer on `RunOptions`.
- **Pause-in-flight is real.** `Scheduler.evaluateInFlightBlackouts` cancels jobs whose target enters a blackout mid-scan via `context.WithCancelCause(jobCtx, ErrBlackoutPause)`. `scanJobRunner` distinguishes the cause and records `ScheduleRunPausedBlackout` (vs the generic `ScheduleRunFailed`).
- **`Scheduler.DispatchAdHoc(ctx, AdHocScanRun) (scanID, error)`** is implemented. Acquires the per-target lock, refuses on active blackout (`ErrInBlackout`) or contention (`ErrTargetBusy`), routes through the worker pool, blocks until completion, and updates `ad_hoc_scan_runs` Pending → Running → Completed/Failed with `scan_id` attached.
- **`POST /api/daemon/trigger` reintroduced** as an ad-hoc dispatcher. Same path as the deleted pre-1.2b file-based trigger (operator muscle memory preserved); body shape changes to `{target_id, reason?, template_id?, tool_config?}`; returns `202 {ad_hoc_run_id}`. Predictable refusals: 400 (bad body / missing target_id), 404 (unknown target), 503 (no dispatcher reachable).
- **Integration test** under `//go:build integration` covers all three scenarios end-to-end against a real file SQLite + production stores: schedule fires, blackout pause-in-flight, ad-hoc round-trip. Total wall-clock ~3s.

### Notable deviations from the spec

- `BlackoutPauseCause` → **`ErrBlackoutPause`** (staticcheck convention for error vars).
- The trigger handler returns **503** when `DaemonView.AdHocDispatcher` is nil — the master ticker runs in the daemon process while the webui currently lives in `surfbot ui`. SCHED1.4 is expected to collocate them; until then, stand-alone `surfbot ui` users will see 503 on the trigger endpoint. Spec acknowledges this is a bridge phase.
- Integration test uses a **file SQLite** in `t.TempDir()` rather than `:memory:` — modernc.org/sqlite's per-connection `:memory:` defeats schema sharing across the connection pool.
- Pause-in-flight unit test pads the blackout's `DTSTART` by **1s** to work around the rrule library's second-precision truncation; without the pad, the rounded window start lands ≤ acquiredAt and the defensive "pre-existing blackout" branch fires.

### Trigger endpoint operator note

The path `POST /api/daemon/trigger` is preserved for muscle memory but the body shape changes from `{profile}` to `{target_id, ...}`. Operators who automated against the old shape need to update their requests. The daemon-side polling of `trigger.json` is gone — the new flow is HTTP request → `ad_hoc_scan_runs` row → `Scheduler.DispatchAdHoc`.

## Commits

1. add default params helpers for detection tools
2. rewire nuclei to accept params struct
3. rewire naabu to accept params struct
4. rewire httpx to accept params struct
5. rewire subfinder to accept params struct
6. rewire dnsx to accept params struct
7. replace LegacyScanRunner with ScanRunner
8. add in-flight job tracking to scheduler
9. implement blackout pause-in-flight
10. add DispatchAdHoc to scheduler
11. reintroduce trigger endpoint as ad-hoc dispatcher
12. add integration test for scheduler end-to-end
13. lint: rename BlackoutPauseCause to ErrBlackoutPause; fix misspell; drop unused

## Review checklist

- [x] Five detection tools accept Params struct and honor at least 2 fields each.
- [x] Per-tool ctx-cancellation tests pass under `-race`, fakes only.
- [x] `scanRunner` replaces `LegacyScanRunner`; `TestScanRunner_HonorsToolConfig` passes.
- [x] `evaluateInFlightBlackouts` is no longer a stub; pause-in-flight test passes (≤ 4s with the 1s rrule-truncation pad).
- [x] `ErrBlackoutPause` distinguishes blackout cancel from shutdown.
- [x] `Scheduler.DispatchAdHoc` returns typed errors (`ErrTargetBusy`, `ErrInBlackout`).
- [x] Trigger HTTP route reintroduced at the same path as the deleted handler; returns 202/400/404/503 (409/423 are reachable through the dispatcher when scheduler is co-located).
- [x] Integration test covers end-to-end, pause-in-flight, ad-hoc.
- [x] No changes to `internal/storage/`, `internal/cli/schedule.go`, `internal/cli/agent_spec.go`, `internal/webui/static/`, or SCHED1.2a primitive files.
- [x] `go vet ./...`, `golangci-lint run ./...`, full `-race` suite, `-tags=integration -race` all green.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1 -race`
- [x] `go test -tags=integration ./internal/daemon/intervalsched/... -race -count=1`
- [x] `golangci-lint run ./...`
- [ ] **Operator step** — schedule with custom tool_config: insert a schedule via DB, observe nuclei logs reflecting the configured severity.
- [ ] **Operator step** — `curl -X POST /api/daemon/trigger -d '{"target_id":"..."}'` returns 202 with an `ad_hoc_run_id`; row in `ad_hoc_scan_runs` transitions to `completed` (requires daemon + webui co-located).
- [ ] **Operator step** — create a blackout covering now+60s; start a long scan via schedule; verify `last_run_status=paused_blackout` after the blackout activates (≤ one tick interval).