### PR TITLE
SCHED1.3a: REST API for first-class schedules

### DIFF
--- a/internal/api/v1/adhoc.go
+++ b/internal/api/v1/adhoc.go
@@ -1,0 +1,146 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// CreateAdHocRequest is the POST /api/v1/scans/ad-hoc body. TargetID is
+// required; RequestedBy populates initiated_by on the persisted row so
+// audit trails survive process restarts.
+type CreateAdHocRequest struct {
+	TargetID           string                     `json:"target_id"`
+	TemplateID         *string                    `json:"template_id,omitempty"`
+	ToolConfigOverride map[string]json.RawMessage `json:"tool_config_override,omitempty"`
+	RequestedBy        string                     `json:"requested_by,omitempty"`
+	Reason             string                     `json:"reason,omitempty"`
+}
+
+// CreateAdHocResponse is the 202 body. ScanID is empty on the immediate
+// response — the caller polls ad_hoc_scan_runs by ad_hoc_run_id to
+// discover the scan ID once dispatch completes.
+type CreateAdHocResponse struct {
+	AdHocRunID string `json:"ad_hoc_run_id"`
+	ScanID     string `json:"scan_id,omitempty"`
+}
+
+func (h *handlers) routeAdHoc(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w, "POST")
+		return
+	}
+
+	var req CreateAdHocRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeProblem(w, http.StatusBadRequest, "/problems/invalid-json",
+			"Invalid JSON body", err.Error(), nil)
+		return
+	}
+	if strings.TrimSpace(req.TargetID) == "" {
+		writeProblem(w, http.StatusBadRequest, "/problems/validation",
+			"Required fields missing", "",
+			[]FieldError{{Field: "target_id", Message: "required"}})
+		return
+	}
+
+	// FK existence check: target must be real.
+	if h.deps.Store != nil {
+		if _, err := h.deps.Store.GetTarget(r.Context(), req.TargetID); err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+					"Target not found", "",
+					[]FieldError{{Field: "target_id", Message: "no target with that id"}})
+				return
+			}
+			writeProblem(w, http.StatusInternalServerError, "/problems/store",
+				"Loading target failed", err.Error(), nil)
+			return
+		}
+	}
+
+	// Tool config override validation.
+	if len(req.ToolConfigOverride) > 0 {
+		tc := model.ToolConfig(req.ToolConfigOverride)
+		if fe := validateToolConfigFields(tc, "tool_config_override"); len(fe) > 0 {
+			writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+				"Invalid tool_config_override", "", fe)
+			return
+		}
+	}
+
+	initiatedBy := req.RequestedBy
+	if initiatedBy == "" {
+		initiatedBy = "api:ad-hoc"
+	}
+	run := model.AdHocScanRun{
+		TargetID:    req.TargetID,
+		TemplateID:  req.TemplateID,
+		ToolConfig:  model.ToolConfig(req.ToolConfigOverride),
+		InitiatedBy: initiatedBy,
+		Reason:      req.Reason,
+		Status:      model.AdHocPending,
+		RequestedAt: time.Now().UTC(),
+	}
+	if h.deps.AdHocStore != nil {
+		if err := h.deps.AdHocStore.Create(r.Context(), &run); err != nil {
+			writeProblem(w, http.StatusInternalServerError, "/problems/store",
+				"Persisting ad-hoc run failed", err.Error(), nil)
+			return
+		}
+	}
+
+	h.dispatchAdHoc(w, r.Context(), run)
+}
+
+// dispatchAdHoc shares the typed-error translation between this canonical
+// endpoint and any future handler (e.g. bulk ad-hoc). Kept internal so
+// the existing `/api/daemon/trigger` stays untouched in 1.3a — that
+// endpoint's fire-and-forget semantics differ and will migrate to this
+// path in 1.3b.
+func (h *handlers) dispatchAdHoc(w http.ResponseWriter, ctx context.Context, run model.AdHocScanRun) {
+	if h.deps.Dispatcher == nil {
+		// Mirror the 1.2c trigger behavior: the master ticker is not
+		// reachable from this process. The row already says pending; flip
+		// it to failed so the audit trail is coherent without inventing
+		// a new status value.
+		if h.deps.AdHocStore != nil {
+			_ = h.deps.AdHocStore.UpdateStatus(context.Background(), run.ID, model.AdHocFailed, time.Now().UTC())
+		}
+		writeProblem(w, http.StatusServiceUnavailable, "/problems/dispatcher-unreachable",
+			"Scan dispatcher not reachable from this process",
+			"the master ticker runs inside `surfbot daemon run`; ad-hoc dispatch requires the same process",
+			nil)
+		return
+	}
+
+	scanID, err := h.deps.Dispatcher.DispatchAdHoc(ctx, run)
+	if err != nil {
+		switch {
+		case errors.Is(err, intervalsched.ErrTargetBusy):
+			writeProblem(w, http.StatusConflict, "/problems/target-busy",
+				"Target is currently running another scan", "", nil)
+			return
+		case errors.Is(err, intervalsched.ErrInBlackout):
+			writeProblem(w, http.StatusConflict, "/problems/in-blackout",
+				"Target is inside an active blackout window", "", nil)
+			return
+		default:
+			writeProblem(w, http.StatusInternalServerError, "/problems/dispatch-failed",
+				"Ad-hoc dispatch failed", err.Error(), nil)
+			return
+		}
+	}
+
+	writeJSON(w, http.StatusAccepted, CreateAdHocResponse{
+		AdHocRunID: run.ID,
+		ScanID:     scanID,
+	})
+}

--- a/internal/api/v1/adhoc_test.go
+++ b/internal/api/v1/adhoc_test.go
@@ -1,0 +1,134 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// stubDispatcher satisfies the Dispatcher interface for tests without
+// pulling in the full scheduler + worker pool.
+type stubDispatcher struct {
+	scanID string
+	err    error
+	calls  int32
+}
+
+func (s *stubDispatcher) DispatchAdHoc(ctx context.Context, run model.AdHocScanRun) (string, error) {
+	atomic.AddInt32(&s.calls, 1)
+	return s.scanID, s.err
+}
+
+func TestAdHocSuccess(t *testing.T) {
+	store := newTestStore(t)
+	targetID := seedTarget(t, store, "example.com")
+	disp := &stubDispatcher{scanID: "scan-abc"}
+	deps := defaultAPIDeps(store)
+	deps.Dispatcher = disp
+	srv := newTestAPI(t, deps)
+
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/scans/ad-hoc", CreateAdHocRequest{
+		TargetID:    targetID,
+		RequestedBy: "cli",
+	})
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+	var out CreateAdHocResponse
+	decode(t, raw, &out)
+	if out.ScanID != "scan-abc" || out.AdHocRunID == "" {
+		t.Fatalf("unexpected response: %+v", out)
+	}
+	if atomic.LoadInt32(&disp.calls) != 1 {
+		t.Fatalf("dispatcher not called")
+	}
+}
+
+func TestAdHocNilDispatcher503(t *testing.T) {
+	store := newTestStore(t)
+	targetID := seedTarget(t, store, "example.com")
+	srv := newTestAPI(t, defaultAPIDeps(store)) // Dispatcher left nil
+
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/scans/ad-hoc", CreateAdHocRequest{
+		TargetID: targetID,
+	})
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("nil dispatcher should 503, got %d body=%s", resp.StatusCode, raw)
+	}
+	var p ProblemResponse
+	decode(t, raw, &p)
+	if p.Type != "/problems/dispatcher-unreachable" {
+		t.Fatalf("wrong problem type: %s", p.Type)
+	}
+
+	// The persisted run should be marked failed so audit is coherent.
+	runs, err := store.AdHocScanRuns().ListByStatus(t.Context(), model.AdHocFailed)
+	if err != nil {
+		t.Fatalf("list adhoc: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 failed run after 503, got %d", len(runs))
+	}
+}
+
+func TestAdHocTargetBusy409(t *testing.T) {
+	store := newTestStore(t)
+	targetID := seedTarget(t, store, "example.com")
+	deps := defaultAPIDeps(store)
+	deps.Dispatcher = &stubDispatcher{err: intervalsched.ErrTargetBusy}
+	srv := newTestAPI(t, deps)
+
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/scans/ad-hoc", CreateAdHocRequest{
+		TargetID: targetID,
+	})
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+	var p ProblemResponse
+	decode(t, raw, &p)
+	if p.Type != "/problems/target-busy" {
+		t.Fatalf("wrong problem type: %s", p.Type)
+	}
+}
+
+func TestAdHocInBlackout409(t *testing.T) {
+	store := newTestStore(t)
+	targetID := seedTarget(t, store, "example.com")
+	deps := defaultAPIDeps(store)
+	deps.Dispatcher = &stubDispatcher{err: intervalsched.ErrInBlackout}
+	srv := newTestAPI(t, deps)
+
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/scans/ad-hoc", CreateAdHocRequest{
+		TargetID: targetID,
+	})
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+	var p ProblemResponse
+	decode(t, raw, &p)
+	if p.Type != "/problems/in-blackout" {
+		t.Fatalf("wrong problem type: %s", p.Type)
+	}
+}
+
+func TestAdHocUnknownTargetRejected(t *testing.T) {
+	store := newTestStore(t)
+	deps := defaultAPIDeps(store)
+	deps.Dispatcher = &stubDispatcher{}
+	srv := newTestAPI(t, deps)
+
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/scans/ad-hoc", CreateAdHocRequest{
+		TargetID: "does-not-exist",
+	})
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+}
+
+// Ensure errors package is always used.
+var _ = errors.Is

--- a/internal/api/v1/api_integration_test.go
+++ b/internal/api/v1/api_integration_test.go
@@ -1,0 +1,156 @@
+//go:build integration
+
+package v1
+
+// SCHED1.3a integration test (R10): exercises the REST API surface
+// end-to-end against a real SQLite file and a stub dispatcher. No real
+// scheduler / worker pool — the stub satisfies the Dispatcher interface
+// with enough behavior to validate the wiring.
+//
+// Run with: go test -tags=integration ./internal/api/v1/... -race -count=1
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// integDispatcher records calls and returns a scripted scan ID. Used
+// by the CanonicalAdHocWithStubDispatcher scenario so the API layer's
+// handshake with the scheduler can be verified without running one.
+type integDispatcher struct {
+	scanID string
+	err    error
+	calls  int32
+}
+
+func (d *integDispatcher) DispatchAdHoc(ctx context.Context, run model.AdHocScanRun) (string, error) {
+	atomic.AddInt32(&d.calls, 1)
+	return d.scanID, d.err
+}
+
+func TestIntegration_EndToEndCRUD(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+	targetID := seedTarget(t, store, "example.com")
+
+	// Create template.
+	_, raw := doJSON(t, srv, http.MethodPost, "/api/v1/templates", CreateTemplateRequest{
+		Name:  "nightly",
+		RRule: "FREQ=DAILY",
+	})
+	var tmpl TemplateResponse
+	decode(t, raw, &tmpl)
+
+	// Create schedule referencing the template.
+	_, raw = doJSON(t, srv, http.MethodPost, "/api/v1/schedules", CreateScheduleRequest{
+		TargetID: targetID, Name: "n", Timezone: "UTC",
+		TemplateID: &tmpl.ID,
+		RRule:      "FREQ=DAILY",
+		DTStart:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	var sched ScheduleResponse
+	decode(t, raw, &sched)
+
+	// List sees it.
+	_, raw = doJSON(t, srv, http.MethodGet, "/api/v1/schedules", nil)
+	var page PaginatedResponse[ScheduleResponse]
+	decode(t, raw, &page)
+	if page.Total != 1 {
+		t.Fatalf("list total=%d", page.Total)
+	}
+
+	// Pause; list with status=paused sees it.
+	resp, _ := doJSON(t, srv, http.MethodPost, "/api/v1/schedules/"+sched.ID+"/pause", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("pause status=%d", resp.StatusCode)
+	}
+	_, raw = doJSON(t, srv, http.MethodGet, "/api/v1/schedules?status=paused", nil)
+	var paused PaginatedResponse[ScheduleResponse]
+	decode(t, raw, &paused)
+	if paused.Total != 1 {
+		t.Fatalf("paused list total=%d", paused.Total)
+	}
+
+	// DELETE then GET 404.
+	resp, _ = doJSON(t, srv, http.MethodDelete, "/api/v1/schedules/"+sched.ID, nil)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete status=%d", resp.StatusCode)
+	}
+	resp, _ = doJSON(t, srv, http.MethodGet, "/api/v1/schedules/"+sched.ID, nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("after delete status=%d", resp.StatusCode)
+	}
+}
+
+func TestIntegration_CanonicalAdHocWithStubDispatcher(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	targetID := seedTarget(t, store, "example.com")
+	disp := &integDispatcher{scanID: "scan-42"}
+	deps := defaultAPIDeps(store)
+	deps.Dispatcher = disp
+	srv := newTestAPI(t, deps)
+
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/scans/ad-hoc", CreateAdHocRequest{
+		TargetID:    targetID,
+		RequestedBy: "integration-test",
+	})
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+	var out CreateAdHocResponse
+	decode(t, raw, &out)
+	if out.ScanID != "scan-42" || out.AdHocRunID == "" {
+		t.Fatalf("unexpected: %+v", out)
+	}
+	if atomic.LoadInt32(&disp.calls) != 1 {
+		t.Fatalf("dispatcher not called: %d", disp.calls)
+	}
+
+	// The ad_hoc_scan_runs row exists with the persisted initiated_by.
+	runs, err := store.AdHocScanRuns().ListByTarget(t.Context(), targetID, 10)
+	if err != nil {
+		t.Fatalf("list adhoc: %v", err)
+	}
+	if len(runs) != 1 || runs[0].InitiatedBy != "integration-test" {
+		t.Fatalf("persisted run not as expected: %+v", runs)
+	}
+}
+
+func TestIntegration_AdHocNoDispatcher503(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	targetID := seedTarget(t, store, "example.com")
+	srv := newTestAPI(t, defaultAPIDeps(store)) // Dispatcher left nil
+
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/scans/ad-hoc", CreateAdHocRequest{
+		TargetID:    targetID,
+		RequestedBy: "integration-test",
+	})
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("nil dispatcher should 503, got %d body=%s", resp.StatusCode, raw)
+	}
+	var p ProblemResponse
+	if err := json.Unmarshal(raw, &p); err != nil {
+		t.Fatalf("decode problem: %v", err)
+	}
+	if p.Type != "/problems/dispatcher-unreachable" {
+		t.Fatalf("wrong type: %s", p.Type)
+	}
+
+	// The persisted row is marked failed for audit.
+	runs, err := store.AdHocScanRuns().ListByStatus(t.Context(), model.AdHocFailed)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 failed run, got %d", len(runs))
+	}
+}

--- a/internal/api/v1/blackouts.go
+++ b/internal/api/v1/blackouts.go
@@ -1,0 +1,358 @@
+package v1
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	extrrule "github.com/teambition/rrule-go"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/rrule"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// maxBlackoutDurationSeconds caps blackout durations at 7 days so a
+// typo in a multi-day window doesn't permanently sideline scans. The
+// documented intent is per-window durations — if a stretch longer than
+// 7d is needed, encode it as recurring windows with a matching RRULE.
+const maxBlackoutDurationSeconds = 7 * 24 * 60 * 60
+
+// BlackoutResponse is the public shape of a blackout window.
+type BlackoutResponse struct {
+	ID              string              `json:"id"`
+	Scope           model.BlackoutScope `json:"scope"`
+	TargetID        *string             `json:"target_id,omitempty"`
+	Name            string              `json:"name"`
+	RRule           string              `json:"rrule"`
+	DurationSeconds int                 `json:"duration_seconds"`
+	Timezone        string              `json:"timezone"`
+	Enabled         bool                `json:"enabled"`
+	CreatedAt       time.Time           `json:"created_at"`
+	UpdatedAt       time.Time           `json:"updated_at"`
+}
+
+// CreateBlackoutRequest is the POST body. TargetID is required iff
+// scope == "target"; omitted otherwise. Scope defaults to "global".
+type CreateBlackoutRequest struct {
+	Scope           model.BlackoutScope `json:"scope"`
+	TargetID        *string             `json:"target_id,omitempty"`
+	Name            string              `json:"name"`
+	RRule           string              `json:"rrule"`
+	DurationSeconds int                 `json:"duration_seconds"`
+	Timezone        string              `json:"timezone,omitempty"`
+	Enabled         *bool               `json:"enabled,omitempty"`
+}
+
+// UpdateBlackoutRequest is the PUT body. Partial.
+type UpdateBlackoutRequest struct {
+	Scope           *model.BlackoutScope `json:"scope,omitempty"`
+	TargetID        *string              `json:"target_id,omitempty"`
+	ClearTarget     bool                 `json:"clear_target,omitempty"`
+	Name            *string              `json:"name,omitempty"`
+	RRule           *string              `json:"rrule,omitempty"`
+	DurationSeconds *int                 `json:"duration_seconds,omitempty"`
+	Timezone        *string              `json:"timezone,omitempty"`
+	Enabled         *bool                `json:"enabled,omitempty"`
+}
+
+func (h *handlers) routeBlackouts(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.listBlackouts(w, r)
+	case http.MethodPost:
+		h.createBlackout(w, r)
+	default:
+		methodNotAllowed(w, "GET, POST")
+	}
+}
+
+func (h *handlers) routeBlackoutByID(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/api/v1/blackouts/")
+	if id == "" || strings.Contains(id, "/") {
+		writeProblem(w, http.StatusNotFound, "/problems/not-found",
+			"Unknown blackout subresource", "", nil)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		h.getBlackout(w, r, id)
+	case http.MethodPut:
+		h.updateBlackout(w, r, id)
+	case http.MethodDelete:
+		h.deleteBlackout(w, r, id)
+	default:
+		methodNotAllowed(w, "GET, PUT, DELETE")
+	}
+}
+
+func (h *handlers) listBlackouts(w http.ResponseWriter, r *http.Request) {
+	all, err := h.deps.BlackoutStore.List(r.Context())
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Listing blackouts failed", err.Error(), nil)
+		return
+	}
+
+	if at := r.URL.Query().Get("active_at"); at != "" {
+		instant, perr := time.Parse(time.RFC3339, at)
+		if perr != nil {
+			writeProblem(w, http.StatusBadRequest, "/problems/invalid-query",
+				"Invalid active_at", "must be RFC3339", nil)
+			return
+		}
+		filtered := make([]model.BlackoutWindow, 0, len(all))
+		for _, b := range all {
+			if !b.Enabled {
+				continue
+			}
+			active, aerr := blackoutActiveAt(b, instant)
+			if aerr != nil {
+				continue
+			}
+			if active {
+				filtered = append(filtered, b)
+			}
+		}
+		all = filtered
+	}
+
+	total := int64(len(all))
+	p := ParsePagination(r, MaxLimit)
+	lo, hi := p.Offset, p.Offset+p.Limit
+	if lo > len(all) {
+		lo = len(all)
+	}
+	if hi > len(all) {
+		hi = len(all)
+	}
+	page := all[lo:hi]
+	out := make([]BlackoutResponse, 0, len(page))
+	for _, b := range page {
+		out = append(out, toBlackoutResponse(b))
+	}
+	writeJSON(w, http.StatusOK, PaginatedResponse[BlackoutResponse]{
+		Items:  out,
+		Total:  total,
+		Limit:  p.Limit,
+		Offset: p.Offset,
+	})
+}
+
+func (h *handlers) getBlackout(w http.ResponseWriter, r *http.Request, id string) {
+	b, err := h.deps.BlackoutStore.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeProblem(w, http.StatusNotFound, "/problems/not-found",
+				"Blackout not found", "", nil)
+			return
+		}
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Loading blackout failed", err.Error(), nil)
+		return
+	}
+	writeJSON(w, http.StatusOK, toBlackoutResponse(*b))
+}
+
+func (h *handlers) createBlackout(w http.ResponseWriter, r *http.Request) {
+	var req CreateBlackoutRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeProblem(w, http.StatusBadRequest, "/problems/invalid-json",
+			"Invalid JSON body", err.Error(), nil)
+		return
+	}
+
+	if req.Scope == "" {
+		req.Scope = model.BlackoutScopeGlobal
+	}
+	if fe := validateBlackoutCreate(&req); len(fe) > 0 {
+		writeProblem(w, http.StatusBadRequest, "/problems/validation",
+			"Required fields missing", "", fe)
+		return
+	}
+	if _, err := rrule.ValidateRRule(req.RRule); err != nil {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Invalid RRULE", err.Error(),
+			[]FieldError{{Field: "rrule", Message: err.Error()}})
+		return
+	}
+
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	tz := req.Timezone
+	if tz == "" {
+		tz = "UTC"
+	}
+	b := model.BlackoutWindow{
+		Scope:       req.Scope,
+		TargetID:    req.TargetID,
+		Name:        req.Name,
+		RRule:       req.RRule,
+		DurationSec: req.DurationSeconds,
+		Timezone:    tz,
+		Enabled:     enabled,
+	}
+	if err := h.deps.BlackoutStore.Create(r.Context(), &b); err != nil {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Create failed", err.Error(), nil)
+		return
+	}
+	writeJSON(w, http.StatusCreated, toBlackoutResponse(b))
+}
+
+func (h *handlers) updateBlackout(w http.ResponseWriter, r *http.Request, id string) {
+	var req UpdateBlackoutRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeProblem(w, http.StatusBadRequest, "/problems/invalid-json",
+			"Invalid JSON body", err.Error(), nil)
+		return
+	}
+	cur, err := h.deps.BlackoutStore.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeProblem(w, http.StatusNotFound, "/problems/not-found",
+				"Blackout not found", "", nil)
+			return
+		}
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Loading blackout failed", err.Error(), nil)
+		return
+	}
+
+	if req.Scope != nil {
+		cur.Scope = *req.Scope
+	}
+	if req.ClearTarget {
+		cur.TargetID = nil
+	} else if req.TargetID != nil {
+		cur.TargetID = req.TargetID
+	}
+	if req.Name != nil {
+		cur.Name = *req.Name
+	}
+	if req.RRule != nil {
+		cur.RRule = *req.RRule
+	}
+	if req.DurationSeconds != nil {
+		cur.DurationSec = *req.DurationSeconds
+	}
+	if req.Timezone != nil {
+		cur.Timezone = *req.Timezone
+	}
+	if req.Enabled != nil {
+		cur.Enabled = *req.Enabled
+	}
+
+	if cur.DurationSec <= 0 || cur.DurationSec > maxBlackoutDurationSeconds {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Invalid duration", "", []FieldError{
+				{Field: "duration_seconds", Message: "must be > 0 and <= 7 days"},
+			})
+		return
+	}
+	if _, err := rrule.ValidateRRule(cur.RRule); err != nil {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Invalid RRULE", err.Error(),
+			[]FieldError{{Field: "rrule", Message: err.Error()}})
+		return
+	}
+	if err := h.deps.BlackoutStore.Update(r.Context(), cur); err != nil {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Update failed", err.Error(), nil)
+		return
+	}
+	writeJSON(w, http.StatusOK, toBlackoutResponse(*cur))
+}
+
+func (h *handlers) deleteBlackout(w http.ResponseWriter, r *http.Request, id string) {
+	if err := h.deps.BlackoutStore.Delete(r.Context(), id); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeProblem(w, http.StatusNotFound, "/problems/not-found",
+				"Blackout not found", "", nil)
+			return
+		}
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Delete failed", err.Error(), nil)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func validateBlackoutCreate(req *CreateBlackoutRequest) []FieldError {
+	var fe []FieldError
+	if strings.TrimSpace(req.Name) == "" {
+		fe = append(fe, FieldError{Field: "name", Message: "required"})
+	}
+	if strings.TrimSpace(req.RRule) == "" {
+		fe = append(fe, FieldError{Field: "rrule", Message: "required"})
+	}
+	if req.DurationSeconds <= 0 || req.DurationSeconds > maxBlackoutDurationSeconds {
+		fe = append(fe, FieldError{Field: "duration_seconds", Message: "must be > 0 and <= 7 days"})
+	}
+	switch req.Scope {
+	case model.BlackoutScopeGlobal:
+		if req.TargetID != nil && *req.TargetID != "" {
+			fe = append(fe, FieldError{Field: "target_id", Message: "must be unset for global scope"})
+		}
+	case model.BlackoutScopeTarget:
+		if req.TargetID == nil || *req.TargetID == "" {
+			fe = append(fe, FieldError{Field: "target_id", Message: "required for target scope"})
+		}
+	default:
+		fe = append(fe, FieldError{Field: "scope", Message: "must be 'global' or 'target'"})
+	}
+	return fe
+}
+
+// blackoutActiveAt reports whether any occurrence of `b` covers `at`.
+// Deliberately self-contained (no intervalsched import for the active_at
+// filter) so the API layer doesn't depend on the evaluator's implicit
+// cache. Mirrors intervalsched.occurrenceCovers semantics.
+func blackoutActiveAt(b model.BlackoutWindow, at time.Time) (bool, error) {
+	loc, err := time.LoadLocation(b.Timezone)
+	if err != nil {
+		return false, err
+	}
+	opt, err := extrrule.StrToROption(b.RRule)
+	if err != nil {
+		return false, err
+	}
+	if opt.Dtstart.IsZero() {
+		opt.Dtstart = b.CreatedAt.In(loc)
+	} else {
+		opt.Dtstart = opt.Dtstart.In(loc)
+	}
+	rule, err := extrrule.NewRRule(*opt)
+	if err != nil {
+		return false, err
+	}
+	dur := time.Duration(b.DurationSec) * time.Second
+	atTZ := at.In(loc)
+	lower := atTZ.Add(-7 * 24 * time.Hour)
+	upper := atTZ.Add(time.Nanosecond)
+	for _, occ := range rule.Between(lower, upper, true) {
+		end := occ.Add(dur)
+		if (atTZ.Equal(occ) || atTZ.After(occ)) && atTZ.Before(end) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func toBlackoutResponse(b model.BlackoutWindow) BlackoutResponse {
+	return BlackoutResponse{
+		ID:              b.ID,
+		Scope:           b.Scope,
+		TargetID:        b.TargetID,
+		Name:            b.Name,
+		RRule:           b.RRule,
+		DurationSeconds: b.DurationSec,
+		Timezone:        b.Timezone,
+		Enabled:         b.Enabled,
+		CreatedAt:       b.CreatedAt,
+		UpdatedAt:       b.UpdatedAt,
+	}
+}

--- a/internal/api/v1/blackouts_test.go
+++ b/internal/api/v1/blackouts_test.go
@@ -1,0 +1,97 @@
+package v1
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+func TestBlackoutsCreateGlobal(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+
+	body := CreateBlackoutRequest{
+		Scope:           model.BlackoutScopeGlobal,
+		Name:            "weekends",
+		RRule:           "FREQ=WEEKLY;BYDAY=SA,SU",
+		DurationSeconds: 24 * 3600,
+		Timezone:        "UTC",
+	}
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/blackouts", body)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+	var b BlackoutResponse
+	decode(t, raw, &b)
+	if b.ID == "" || b.Scope != model.BlackoutScopeGlobal {
+		t.Fatalf("unexpected: %+v", b)
+	}
+}
+
+func TestBlackoutsRejectsOversizedDuration(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+
+	body := CreateBlackoutRequest{
+		Scope:           model.BlackoutScopeGlobal,
+		Name:            "too-long",
+		RRule:           "FREQ=YEARLY",
+		DurationSeconds: 8 * 24 * 3600,
+	}
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/blackouts", body)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+}
+
+func TestBlackoutsActiveAtFilter(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+
+	// Pad dtstart by 1s before `now` so the rrule's second-precision
+	// truncation doesn't defeat activity at the chosen instant.
+	now := time.Now().UTC().Truncate(time.Second)
+	past := now.Add(-10 * time.Second)
+
+	body := CreateBlackoutRequest{
+		Scope:           model.BlackoutScopeGlobal,
+		Name:            "always-on",
+		RRule:           "FREQ=DAILY;DTSTART=" + past.Format("20060102T150405Z"),
+		DurationSeconds: 48 * 3600,
+		Timezone:        "UTC",
+	}
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/blackouts", body)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", resp.StatusCode, raw)
+	}
+
+	// Active at now — should appear.
+	url := "/api/v1/blackouts?active_at=" + now.Format(time.RFC3339)
+	resp, raw = doJSON(t, srv, http.MethodGet, url, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", resp.StatusCode, raw)
+	}
+	var page PaginatedResponse[BlackoutResponse]
+	decode(t, raw, &page)
+	if page.Total != 1 {
+		t.Fatalf("active_at filter expected 1 match, got %d (body=%s)", page.Total, raw)
+	}
+}
+
+func TestBlackoutsTargetScopeRequiresTargetID(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+
+	body := CreateBlackoutRequest{
+		Scope:           model.BlackoutScopeTarget,
+		Name:            "t",
+		RRule:           "FREQ=DAILY",
+		DurationSeconds: 3600,
+	}
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/blackouts", body)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+}

--- a/internal/api/v1/bulk.go
+++ b/internal/api/v1/bulk.go
@@ -1,0 +1,203 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/rrule"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// BulkOperation enumerates the atomic operations the bulk endpoint
+// supports. Pause/resume/delete edit existing rows; clone creates new
+// rows from existing ones.
+type BulkOperation string
+
+const (
+	BulkPause   BulkOperation = "pause"
+	BulkResume  BulkOperation = "resume"
+	BulkDelete  BulkOperation = "delete"
+	BulkClone   BulkOperation = "clone"
+)
+
+// BulkScheduleRequest is the POST /api/v1/schedules/bulk body.
+//
+// ScheduleIDs names the rows to act on. For clone, CreateTemplate
+// supplies the name/rrule/dtstart/timezone of the new schedules; each
+// source schedule's target_id and tool_config carry over unchanged.
+type BulkScheduleRequest struct {
+	Operation      BulkOperation          `json:"operation"`
+	ScheduleIDs    []string               `json:"schedule_ids"`
+	CreateTemplate *CreateScheduleRequest `json:"create_template,omitempty"`
+}
+
+// BulkItemError reports a per-item failure from a bulk op.
+type BulkItemError struct {
+	ScheduleID string `json:"schedule_id"`
+	Error      string `json:"error"`
+}
+
+// BulkScheduleResponse is the success body. Succeeded holds the IDs
+// that completed; Failed reports per-item failures (e.g. id not
+// found). The tx commits if every existing-id operation succeeds —
+// not-found entries become per-item failures rather than transaction
+// aborts.
+type BulkScheduleResponse struct {
+	Operation BulkOperation   `json:"operation"`
+	Succeeded []string        `json:"succeeded"`
+	Failed    []BulkItemError `json:"failed"`
+}
+
+func (h *handlers) routeBulkSchedules(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w, "POST")
+		return
+	}
+	var req BulkScheduleRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeProblem(w, http.StatusBadRequest, "/problems/invalid-json",
+			"Invalid JSON body", err.Error(), nil)
+		return
+	}
+	if len(req.ScheduleIDs) == 0 {
+		writeProblem(w, http.StatusBadRequest, "/problems/validation",
+			"Empty schedule_ids", "", nil)
+		return
+	}
+
+	switch req.Operation {
+	case BulkPause, BulkResume, BulkDelete, BulkClone:
+	default:
+		writeProblem(w, http.StatusBadRequest, "/problems/validation",
+			"Unknown operation", "must be pause|resume|delete|clone", nil)
+		return
+	}
+
+	if req.Operation == BulkClone && req.CreateTemplate == nil {
+		writeProblem(w, http.StatusBadRequest, "/problems/validation",
+			"create_template required for clone", "", nil)
+		return
+	}
+
+	// Short-circuit clone-level validation before starting the tx so
+	// bad inputs don't poison partial work.
+	if req.Operation == BulkClone {
+		if _, err := rrule.ValidateRRule(req.CreateTemplate.RRule); err != nil {
+			writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+				"Invalid RRULE", err.Error(),
+				[]FieldError{{Field: "create_template.rrule", Message: err.Error()}})
+			return
+		}
+	}
+
+	succeeded := []string{}
+	failed := []BulkItemError{}
+	affectedTemplates := map[string]bool{}
+
+	err := h.deps.Store.Transact(r.Context(), func(ctx context.Context, ts storage.TxStores) error {
+		for _, id := range req.ScheduleIDs {
+			var ferr error
+			switch req.Operation {
+			case BulkPause:
+				ferr = bulkToggle(ctx, ts.Schedules, id, false, &affectedTemplates)
+			case BulkResume:
+				ferr = bulkToggle(ctx, ts.Schedules, id, true, &affectedTemplates)
+			case BulkDelete:
+				ferr = bulkDelete(ctx, ts.Schedules, id, &affectedTemplates)
+			case BulkClone:
+				ferr = bulkClone(ctx, ts.Schedules, id, req.CreateTemplate, &affectedTemplates)
+			}
+			if ferr == nil {
+				succeeded = append(succeeded, id)
+				continue
+			}
+			if errors.Is(ferr, storage.ErrNotFound) {
+				failed = append(failed, BulkItemError{ScheduleID: id, Error: "not found"})
+				continue
+			}
+			return fmt.Errorf("schedule %s: %w", id, ferr)
+		}
+		return nil
+	})
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "/problems/bulk-failed",
+			"Bulk operation failed, all changes rolled back", err.Error(), nil)
+		return
+	}
+
+	// Cascade recompute once per distinct affected template.
+	if h.deps.Expander != nil {
+		for tmplID := range affectedTemplates {
+			_, _ = intervalsched.RecomputeNextRunForTemplate(r.Context(), tmplID,
+				h.deps.ScheduleStore, h.deps.TemplateStore, h.deps.Expander)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, BulkScheduleResponse{
+		Operation: req.Operation,
+		Succeeded: succeeded,
+		Failed:    failed,
+	})
+}
+
+func bulkToggle(ctx context.Context, store storage.ScheduleStore, id string, enabled bool, templates *map[string]bool) error {
+	s, err := store.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	if s.TemplateID != nil && *s.TemplateID != "" {
+		(*templates)[*s.TemplateID] = true
+	}
+	if s.Enabled == enabled {
+		return nil
+	}
+	s.Enabled = enabled
+	return store.Update(ctx, s)
+}
+
+func bulkDelete(ctx context.Context, store storage.ScheduleStore, id string, templates *map[string]bool) error {
+	s, err := store.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	if s.TemplateID != nil && *s.TemplateID != "" {
+		(*templates)[*s.TemplateID] = true
+	}
+	return store.Delete(ctx, id)
+}
+
+func bulkClone(ctx context.Context, store storage.ScheduleStore, srcID string, tpl *CreateScheduleRequest, templates *map[string]bool) error {
+	src, err := store.Get(ctx, srcID)
+	if err != nil {
+		return err
+	}
+	clone := model.Schedule{
+		TargetID:          src.TargetID,
+		Name:              tpl.Name,
+		RRule:             tpl.RRule,
+		DTStart:           tpl.DTStart,
+		Timezone:          tpl.Timezone,
+		TemplateID:        src.TemplateID,
+		ToolConfig:        src.ToolConfig,
+		MaintenanceWindow: src.MaintenanceWindow,
+		Enabled:           true,
+		Overrides:         mergeOverrides(src.Overrides, tpl.RRule != "", tpl.Timezone != "", src.MaintenanceWindow != nil),
+	}
+	if clone.Name == "" {
+		clone.Name = src.Name + "-clone"
+	}
+	if clone.Timezone == "" {
+		clone.Timezone = src.Timezone
+	}
+	if clone.RRule == "" {
+		clone.RRule = src.RRule
+	}
+	if clone.TemplateID != nil && *clone.TemplateID != "" {
+		(*templates)[*clone.TemplateID] = true
+	}
+	return store.Create(ctx, &clone)
+}

--- a/internal/api/v1/bulk.go
+++ b/internal/api/v1/bulk.go
@@ -18,10 +18,10 @@ import (
 type BulkOperation string
 
 const (
-	BulkPause   BulkOperation = "pause"
-	BulkResume  BulkOperation = "resume"
-	BulkDelete  BulkOperation = "delete"
-	BulkClone   BulkOperation = "clone"
+	BulkPause  BulkOperation = "pause"
+	BulkResume BulkOperation = "resume"
+	BulkDelete BulkOperation = "delete"
+	BulkClone  BulkOperation = "clone"
 )
 
 // BulkScheduleRequest is the POST /api/v1/schedules/bulk body.

--- a/internal/api/v1/bulk_test.go
+++ b/internal/api/v1/bulk_test.go
@@ -1,0 +1,110 @@
+package v1
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestBulkPauseResume(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+	targetID := seedTarget(t, store, "example.com")
+
+	mk := func(name string, hour int) string {
+		_, raw := doJSON(t, srv, http.MethodPost, "/api/v1/schedules", CreateScheduleRequest{
+			TargetID: targetID, Name: name, Timezone: "UTC",
+			RRule:   "FREQ=WEEKLY;BYHOUR=" + itoa(hour) + ";BYMINUTE=0;BYSECOND=0",
+			DTStart: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		})
+		var s ScheduleResponse
+		decode(t, raw, &s)
+		return s.ID
+	}
+	a := mk("a", 1)
+	b := mk("b", 12)
+
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/schedules/bulk", BulkScheduleRequest{
+		Operation:   BulkPause,
+		ScheduleIDs: []string{a, b},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("bulk pause status=%d body=%s", resp.StatusCode, raw)
+	}
+	var out BulkScheduleResponse
+	decode(t, raw, &out)
+	if len(out.Succeeded) != 2 || len(out.Failed) != 0 {
+		t.Fatalf("bulk pause outcome: %+v", out)
+	}
+
+	// Verify both paused.
+	_, raw = doJSON(t, srv, http.MethodGet, "/api/v1/schedules/"+a, nil)
+	var got ScheduleResponse
+	decode(t, raw, &got)
+	if got.Status != "paused" {
+		t.Fatalf("a status=%q after bulk pause", got.Status)
+	}
+
+	// Resume one, leave the other paused.
+	resp, raw = doJSON(t, srv, http.MethodPost, "/api/v1/schedules/bulk", BulkScheduleRequest{
+		Operation:   BulkResume,
+		ScheduleIDs: []string{a},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("bulk resume status=%d body=%s", resp.StatusCode, raw)
+	}
+}
+
+func TestBulkDeleteMixedExistingAndMissing(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+	targetID := seedTarget(t, store, "example.com")
+
+	_, raw := doJSON(t, srv, http.MethodPost, "/api/v1/schedules", CreateScheduleRequest{
+		TargetID: targetID, Name: "a", Timezone: "UTC",
+		RRule: "FREQ=WEEKLY", DTStart: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	var s ScheduleResponse
+	decode(t, raw, &s)
+
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/schedules/bulk", BulkScheduleRequest{
+		Operation:   BulkDelete,
+		ScheduleIDs: []string{s.ID, "does-not-exist"},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("mixed-existing bulk should 200 with per-item failures, got %d body=%s", resp.StatusCode, raw)
+	}
+	var out BulkScheduleResponse
+	decode(t, raw, &out)
+	if len(out.Succeeded) != 1 || len(out.Failed) != 1 {
+		t.Fatalf("outcome: %+v", out)
+	}
+	if out.Succeeded[0] != s.ID {
+		t.Fatalf("wrong succeeded id: %+v", out)
+	}
+}
+
+func TestBulkRejectsUnknownOperation(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+
+	resp, _ := doJSON(t, srv, http.MethodPost, "/api/v1/schedules/bulk", BulkScheduleRequest{
+		Operation:   "lolwat",
+		ScheduleIDs: []string{"abc"},
+	})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("unknown op should 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestBulkEmptyIDs(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+
+	resp, _ := doJSON(t, srv, http.MethodPost, "/api/v1/schedules/bulk", BulkScheduleRequest{
+		Operation: BulkPause,
+	})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("empty ids should 400, got %d", resp.StatusCode)
+	}
+}

--- a/internal/api/v1/defaults.go
+++ b/internal/api/v1/defaults.go
@@ -1,0 +1,158 @@
+package v1
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// ScheduleDefaultsResponse is the public shape of the singleton
+// schedule_defaults row.
+type ScheduleDefaultsResponse struct {
+	DefaultTemplateID        *string                  `json:"default_template_id,omitempty"`
+	DefaultRRule             string                   `json:"default_rrule"`
+	DefaultTimezone          string                   `json:"default_timezone"`
+	DefaultToolConfig        model.ToolConfig         `json:"default_tool_config"`
+	DefaultMaintenanceWindow *model.MaintenanceWindow `json:"default_maintenance_window,omitempty"`
+	MaxConcurrentScans       int                      `json:"max_concurrent_scans"`
+	RunOnStart               bool                     `json:"run_on_start"`
+	JitterSeconds            int                      `json:"jitter_seconds"`
+	UpdatedAt                time.Time                `json:"updated_at"`
+}
+
+// DefaultDefaults is the shape returned by GET when the singleton row is
+// missing (e.g. on a fresh install where migration 0004 hasn't run).
+// The live row wins when present.
+var DefaultDefaults = ScheduleDefaultsResponse{
+	DefaultRRule:       "FREQ=DAILY;BYHOUR=2",
+	DefaultTimezone:    "UTC",
+	DefaultToolConfig:  model.ToolConfig{},
+	MaxConcurrentScans: 4,
+	RunOnStart:         false,
+	JitterSeconds:      60,
+}
+
+// UpdateScheduleDefaultsRequest mirrors the response shape. PUT is a
+// full replace — there is no PATCH semantics on a singleton row.
+type UpdateScheduleDefaultsRequest struct {
+	DefaultTemplateID        *string                  `json:"default_template_id,omitempty"`
+	DefaultRRule             string                   `json:"default_rrule"`
+	DefaultTimezone          string                   `json:"default_timezone"`
+	DefaultToolConfig        model.ToolConfig         `json:"default_tool_config,omitempty"`
+	DefaultMaintenanceWindow *model.MaintenanceWindow `json:"default_maintenance_window,omitempty"`
+	MaxConcurrentScans       int                      `json:"max_concurrent_scans"`
+	RunOnStart               bool                     `json:"run_on_start"`
+	JitterSeconds            int                      `json:"jitter_seconds"`
+}
+
+func (h *handlers) routeScheduleDefaults(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getScheduleDefaults(w, r)
+	case http.MethodPut:
+		h.putScheduleDefaults(w, r)
+	default:
+		methodNotAllowed(w, "GET, PUT")
+	}
+}
+
+func (h *handlers) getScheduleDefaults(w http.ResponseWriter, r *http.Request) {
+	d, err := h.deps.DefaultsStore.Get(r.Context())
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeJSON(w, http.StatusOK, DefaultDefaults)
+			return
+		}
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Loading defaults failed", err.Error(), nil)
+		return
+	}
+	writeJSON(w, http.StatusOK, toDefaultsResponse(*d))
+}
+
+func (h *handlers) putScheduleDefaults(w http.ResponseWriter, r *http.Request) {
+	var req UpdateScheduleDefaultsRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeProblem(w, http.StatusBadRequest, "/problems/invalid-json",
+			"Invalid JSON body", err.Error(), nil)
+		return
+	}
+	if fe := validateDefaultsRequest(&req); len(fe) > 0 {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Invalid defaults", "", fe)
+		return
+	}
+	if fe := validateToolConfigFields(req.DefaultToolConfig, "default_tool_config"); len(fe) > 0 {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Invalid default_tool_config", "", fe)
+		return
+	}
+
+	d := model.ScheduleDefaults{
+		DefaultTemplateID:        req.DefaultTemplateID,
+		DefaultRRule:             req.DefaultRRule,
+		DefaultTimezone:          req.DefaultTimezone,
+		DefaultToolConfig:        req.DefaultToolConfig,
+		DefaultMaintenanceWindow: req.DefaultMaintenanceWindow,
+		MaxConcurrentScans:       req.MaxConcurrentScans,
+		RunOnStart:               req.RunOnStart,
+		JitterSeconds:            req.JitterSeconds,
+	}
+	if err := h.deps.DefaultsStore.Update(r.Context(), &d); err != nil {
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Update failed", err.Error(), nil)
+		return
+	}
+
+	// Cascade: every schedule not overriding rrule/timezone/MW inherits
+	// from defaults (directly, when no template, or transitively via a
+	// template's empty field). Recompute next_run_at across all
+	// templates so the tick loop picks up the new values.
+	if h.deps.Expander != nil && h.deps.TemplateStore != nil {
+		if tmpls, lerr := h.deps.TemplateStore.List(r.Context()); lerr == nil {
+			for _, t := range tmpls {
+				_, _ = intervalsched.RecomputeNextRunForTemplate(r.Context(), t.ID,
+					h.deps.ScheduleStore, h.deps.TemplateStore, h.deps.Expander)
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, toDefaultsResponse(d))
+}
+
+func validateDefaultsRequest(req *UpdateScheduleDefaultsRequest) []FieldError {
+	var fe []FieldError
+	if req.MaxConcurrentScans < 1 {
+		fe = append(fe, FieldError{Field: "max_concurrent_scans", Message: "must be >= 1"})
+	}
+	if req.JitterSeconds < 0 {
+		fe = append(fe, FieldError{Field: "jitter_seconds", Message: "must be >= 0"})
+	}
+	if req.DefaultTimezone != "" {
+		if _, err := time.LoadLocation(req.DefaultTimezone); err != nil {
+			fe = append(fe, FieldError{Field: "default_timezone", Message: err.Error()})
+		}
+	}
+	return fe
+}
+
+func toDefaultsResponse(d model.ScheduleDefaults) ScheduleDefaultsResponse {
+	if d.DefaultToolConfig == nil {
+		d.DefaultToolConfig = model.ToolConfig{}
+	}
+	return ScheduleDefaultsResponse{
+		DefaultTemplateID:        d.DefaultTemplateID,
+		DefaultRRule:             d.DefaultRRule,
+		DefaultTimezone:          d.DefaultTimezone,
+		DefaultToolConfig:        d.DefaultToolConfig,
+		DefaultMaintenanceWindow: d.DefaultMaintenanceWindow,
+		MaxConcurrentScans:       d.MaxConcurrentScans,
+		RunOnStart:               d.RunOnStart,
+		JitterSeconds:            d.JitterSeconds,
+		UpdatedAt:                d.UpdatedAt,
+	}
+}

--- a/internal/api/v1/defaults_test.go
+++ b/internal/api/v1/defaults_test.go
@@ -1,0 +1,62 @@
+package v1
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestScheduleDefaultsGetSeededRow(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+
+	resp, raw := doJSON(t, srv, http.MethodGet, "/api/v1/schedule-defaults", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+	var d ScheduleDefaultsResponse
+	decode(t, raw, &d)
+	if d.DefaultRRule == "" || d.DefaultTimezone == "" {
+		t.Fatalf("defaults are empty: %+v", d)
+	}
+	if d.MaxConcurrentScans < 1 {
+		t.Fatalf("bad max_concurrent_scans: %+v", d)
+	}
+}
+
+func TestScheduleDefaultsPut(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+
+	body := UpdateScheduleDefaultsRequest{
+		DefaultRRule:       "FREQ=WEEKLY;BYDAY=SU",
+		DefaultTimezone:    "UTC",
+		MaxConcurrentScans: 6,
+		JitterSeconds:      30,
+	}
+	resp, raw := doJSON(t, srv, http.MethodPut, "/api/v1/schedule-defaults", body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PUT status=%d body=%s", resp.StatusCode, raw)
+	}
+
+	resp, raw = doJSON(t, srv, http.MethodGet, "/api/v1/schedule-defaults", nil)
+	var d ScheduleDefaultsResponse
+	decode(t, raw, &d)
+	if d.DefaultRRule != body.DefaultRRule || d.MaxConcurrentScans != 6 || d.JitterSeconds != 30 {
+		t.Fatalf("defaults not persisted: %+v", d)
+	}
+}
+
+func TestScheduleDefaultsRejectsBadBounds(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+
+	body := UpdateScheduleDefaultsRequest{
+		DefaultRRule:       "FREQ=DAILY",
+		DefaultTimezone:    "UTC",
+		MaxConcurrentScans: 0,
+	}
+	resp, raw := doJSON(t, srv, http.MethodPut, "/api/v1/schedule-defaults", body)
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("bad bounds should 422, got %d body=%s", resp.StatusCode, raw)
+	}
+}

--- a/internal/api/v1/defaults_test.go
+++ b/internal/api/v1/defaults_test.go
@@ -38,7 +38,7 @@ func TestScheduleDefaultsPut(t *testing.T) {
 		t.Fatalf("PUT status=%d body=%s", resp.StatusCode, raw)
 	}
 
-	resp, raw = doJSON(t, srv, http.MethodGet, "/api/v1/schedule-defaults", nil)
+	_, raw = doJSON(t, srv, http.MethodGet, "/api/v1/schedule-defaults", nil)
 	var d ScheduleDefaultsResponse
 	decode(t, raw, &d)
 	if d.DefaultRRule != body.DefaultRRule || d.MaxConcurrentScans != 6 || d.JitterSeconds != 30 {

--- a/internal/api/v1/dispatcher.go
+++ b/internal/api/v1/dispatcher.go
@@ -1,0 +1,20 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// Dispatcher is the narrow surface API handlers need from the master
+// ticker when they must fan out an ad-hoc scan request. The production
+// type is *intervalsched.Scheduler (satisfied via duck typing — no
+// scheduler change required); callers in a non-daemon process (e.g.
+// `surfbot ui` without an in-process ticker) pass nil and the dispatch
+// endpoints return 503.
+//
+// This is the only interface SPEC-SCHED1.3a introduces. Every other
+// dependency is consumed as a concrete type.
+type Dispatcher interface {
+	DispatchAdHoc(ctx context.Context, run model.AdHocScanRun) (scanID string, err error)
+}

--- a/internal/api/v1/harness_test.go
+++ b/internal/api/v1/harness_test.go
@@ -1,0 +1,105 @@
+package v1
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// newTestStore opens a file-backed SQLite store in t.TempDir. Per the
+// 1.2c lesson, modernc.org/sqlite's :memory: is per-connection and the
+// *sql.DB pool defeats schema sharing — file backing guarantees every
+// pool connection sees the same schema.
+func newTestStore(t *testing.T) *storage.SQLiteStore {
+	t.Helper()
+	s, err := storage.NewSQLiteStore(filepath.Join(t.TempDir(), "api.db"))
+	if err != nil {
+		t.Fatalf("opening store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// newTestAPI wires an http.ServeMux with every v1 route and the supplied
+// deps plugged in. Returned server is ready to serve requests; teardown
+// is automatic via t.Cleanup.
+func newTestAPI(t *testing.T, deps APIDeps) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, deps)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// defaultAPIDeps returns an APIDeps backed by `store` with every store
+// wired up. The Expander, Blackouts, and Dispatcher fields are left nil
+// so tests can exercise the fallback paths explicitly.
+func defaultAPIDeps(store *storage.SQLiteStore) APIDeps {
+	return APIDeps{
+		Store:         store,
+		ScheduleStore: store.Schedules(),
+		TemplateStore: store.Templates(),
+		BlackoutStore: store.Blackouts(),
+		DefaultsStore: store.ScheduleDefaults(),
+		AdHocStore:    store.AdHocScanRuns(),
+	}
+}
+
+// seedTarget inserts a target and returns its ID. Convenience for the
+// FK-required fields on schedules and ad-hoc runs.
+func seedTarget(t *testing.T, store *storage.SQLiteStore, value string) string {
+	t.Helper()
+	tgt := &model.Target{Value: value}
+	if err := store.CreateTarget(t.Context(), tgt); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	return tgt.ID
+}
+
+// doJSON wraps an httptest request lifecycle: marshals body, sets the
+// JSON content type, and returns the raw response + body. Body is
+// always closed so callers can ignore.
+func doJSON(t *testing.T, srv *httptest.Server, method, path string, body any) (*http.Response, []byte) {
+	t.Helper()
+	var rdr io.Reader
+	if body != nil {
+		buf := &bytes.Buffer{}
+		if err := json.NewEncoder(buf).Encode(body); err != nil {
+			t.Fatalf("encode body: %v", err)
+		}
+		rdr = buf
+	}
+	req, err := http.NewRequest(method, srv.URL+path, rdr)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp, respBody
+}
+
+// decode unmarshals a JSON body into v, failing the test on error.
+func decode(t *testing.T, body []byte, v any) {
+	t.Helper()
+	if err := json.Unmarshal(body, v); err != nil {
+		t.Fatalf("decode body: %v\nbody: %s", err, body)
+	}
+}

--- a/internal/api/v1/harness_test.go
+++ b/internal/api/v1/harness_test.go
@@ -88,7 +88,7 @@ func doJSON(t *testing.T, srv *httptest.Server, method, path string, body any) (
 	if err != nil {
 		t.Fatalf("do: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("read body: %v", err)

--- a/internal/api/v1/reflect_helper.go
+++ b/internal/api/v1/reflect_helper.go
@@ -1,0 +1,11 @@
+package v1
+
+import "reflect"
+
+// reflectTypeNew returns a pointer to a freshly allocated zero value of
+// the given reflect.Type. Used by validateToolConfigFields so that a
+// request's tool-config payload is decoded into the right *Params
+// struct without switch statements keyed on name.
+func reflectTypeNew(t reflect.Type) any {
+	return reflect.New(t).Interface()
+}

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -1,0 +1,52 @@
+package v1
+
+import (
+	"net/http"
+
+	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// APIDeps bundles everything RegisterRoutes wires into the handlers. The
+// struct is plain-typed so callers can audit what is exposed to the API
+// layer without following an interface jungle.
+//
+// Store is the SQLiteStore concrete; it exposes the Transact helper that
+// bulk ops use. The individual Store fields are the same objects Store
+// returns — supplying them directly keeps test setup terse and lets each
+// handler take just the dependency it needs.
+type APIDeps struct {
+	Store         *storage.SQLiteStore
+	ScheduleStore storage.ScheduleStore
+	TemplateStore storage.TemplateStore
+	BlackoutStore storage.BlackoutStore
+	DefaultsStore storage.ScheduleDefaultsStore
+	AdHocStore    storage.AdHocScanRunStore
+
+	// Expander and Blackouts power the /schedules/upcoming read path.
+	// Nil is valid; that endpoint then returns 503 with an explanatory
+	// problem body. Both are owned by the scheduler when available.
+	Expander  *intervalsched.RRuleExpander
+	Blackouts *intervalsched.BlackoutEvaluator
+
+	// Dispatcher may be nil in non-daemon processes. Endpoints needing
+	// it return 503 rather than 404 so the API surface is the same
+	// shape regardless of which process serves it.
+	Dispatcher Dispatcher
+}
+
+// RegisterRoutes installs every /api/v1/... handler onto mux. Subsequent
+// phases of SPEC-SCHED1.3a add more handlers — each one extends this
+// function. No existing routes are replaced; the API is additive.
+func RegisterRoutes(mux *http.ServeMux, deps APIDeps) {
+	_ = &handlers{deps: deps}
+	// Routes are registered as subsequent 1.3a commits land.
+}
+
+// handlers is the zero-LOC glue struct that binds APIDeps to every
+// route. Having a single receiver keeps the route dispatch functions
+// tiny and lets handlers call each other as methods without passing
+// deps around.
+type handlers struct {
+	deps APIDeps
+}

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -44,6 +44,10 @@ func RegisterRoutes(mux *http.ServeMux, deps APIDeps) {
 	// Schedules CRUD + pause/resume.
 	mux.HandleFunc("/api/v1/schedules", h.routeSchedules)
 	mux.HandleFunc("/api/v1/schedules/", h.routeSchedulesSubtree)
+
+	// Templates CRUD.
+	mux.HandleFunc("/api/v1/templates", h.routeTemplates)
+	mux.HandleFunc("/api/v1/templates/", h.routeTemplateByID)
 }
 
 // handlers is the zero-LOC glue struct that binds APIDeps to every

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -41,9 +41,11 @@ type APIDeps struct {
 func RegisterRoutes(mux *http.ServeMux, deps APIDeps) {
 	h := &handlers{deps: deps}
 
-	// Schedules CRUD + pause/resume.
+	// Schedules CRUD + pause/resume. Ordered so /upcoming and /bulk
+	// (registered below) take longest-prefix precedence.
 	mux.HandleFunc("/api/v1/schedules", h.routeSchedules)
 	mux.HandleFunc("/api/v1/schedules/", h.routeSchedulesSubtree)
+	mux.HandleFunc("/api/v1/schedules/upcoming", h.routeUpcoming)
 
 	// Templates CRUD.
 	mux.HandleFunc("/api/v1/templates", h.routeTemplates)

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -46,6 +46,7 @@ func RegisterRoutes(mux *http.ServeMux, deps APIDeps) {
 	mux.HandleFunc("/api/v1/schedules", h.routeSchedules)
 	mux.HandleFunc("/api/v1/schedules/", h.routeSchedulesSubtree)
 	mux.HandleFunc("/api/v1/schedules/upcoming", h.routeUpcoming)
+	mux.HandleFunc("/api/v1/schedules/bulk", h.routeBulkSchedules)
 
 	// Templates CRUD.
 	mux.HandleFunc("/api/v1/templates", h.routeTemplates)

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -39,8 +39,11 @@ type APIDeps struct {
 // phases of SPEC-SCHED1.3a add more handlers — each one extends this
 // function. No existing routes are replaced; the API is additive.
 func RegisterRoutes(mux *http.ServeMux, deps APIDeps) {
-	_ = &handlers{deps: deps}
-	// Routes are registered as subsequent 1.3a commits land.
+	h := &handlers{deps: deps}
+
+	// Schedules CRUD + pause/resume.
+	mux.HandleFunc("/api/v1/schedules", h.routeSchedules)
+	mux.HandleFunc("/api/v1/schedules/", h.routeSchedulesSubtree)
 }
 
 // handlers is the zero-LOC glue struct that binds APIDeps to every

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -48,6 +48,10 @@ func RegisterRoutes(mux *http.ServeMux, deps APIDeps) {
 	// Templates CRUD.
 	mux.HandleFunc("/api/v1/templates", h.routeTemplates)
 	mux.HandleFunc("/api/v1/templates/", h.routeTemplateByID)
+
+	// Blackouts CRUD.
+	mux.HandleFunc("/api/v1/blackouts", h.routeBlackouts)
+	mux.HandleFunc("/api/v1/blackouts/", h.routeBlackoutByID)
 }
 
 // handlers is the zero-LOC glue struct that binds APIDeps to every

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -52,6 +52,9 @@ func RegisterRoutes(mux *http.ServeMux, deps APIDeps) {
 	// Blackouts CRUD.
 	mux.HandleFunc("/api/v1/blackouts", h.routeBlackouts)
 	mux.HandleFunc("/api/v1/blackouts/", h.routeBlackoutByID)
+
+	// Singleton schedule defaults.
+	mux.HandleFunc("/api/v1/schedule-defaults", h.routeScheduleDefaults)
 }
 
 // handlers is the zero-LOC glue struct that binds APIDeps to every

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -55,6 +55,11 @@ func RegisterRoutes(mux *http.ServeMux, deps APIDeps) {
 
 	// Singleton schedule defaults.
 	mux.HandleFunc("/api/v1/schedule-defaults", h.routeScheduleDefaults)
+
+	// Canonical ad-hoc dispatch. Sibling endpoint /api/daemon/trigger
+	// (owned by the webui package) keeps its legacy shape for 1.3a;
+	// 1.3b migrates callers onto this path.
+	mux.HandleFunc("/api/v1/scans/ad-hoc", h.routeAdHoc)
 }
 
 // handlers is the zero-LOC glue struct that binds APIDeps to every

--- a/internal/api/v1/schedules.go
+++ b/internal/api/v1/schedules.go
@@ -1,0 +1,623 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/rrule"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// DefaultEstimatedDurationSeconds is the overlap-check window applied when
+// a CreateScheduleRequest omits estimated_duration_seconds. One hour is a
+// conservative default for a full scan on a medium target.
+const DefaultEstimatedDurationSeconds = 3600
+
+// overlapHorizon bounds the expansion window used by ValidateNoOverlap
+// when a new schedule is created. Seven days catches near-term conflicts
+// without ballooning the per-request compute budget.
+const overlapHorizon = 7 * 24 * time.Hour
+
+// ScheduleResponse mirrors model.Schedule but uses stable JSON tags with
+// ISO-8601 timestamps. Internal fields that are not part of the public
+// API (nothing today — kept explicit for future-proofing) are excluded
+// here rather than via a `-` tag on the model.
+type ScheduleResponse struct {
+	ID                string                    `json:"id"`
+	TargetID          string                    `json:"target_id"`
+	Name              string                    `json:"name"`
+	RRule             string                    `json:"rrule"`
+	DTStart           time.Time                 `json:"dtstart"`
+	Timezone          string                    `json:"timezone"`
+	TemplateID        *string                   `json:"template_id,omitempty"`
+	ToolConfig        model.ToolConfig          `json:"tool_config"`
+	Overrides         []string                  `json:"overrides"`
+	MaintenanceWindow *model.MaintenanceWindow  `json:"maintenance_window,omitempty"`
+	Status            string                    `json:"status"`
+	NextRunAt         *time.Time                `json:"next_run_at,omitempty"`
+	LastRunAt         *time.Time                `json:"last_run_at,omitempty"`
+	LastRunStatus     *model.ScheduleRunStatus  `json:"last_run_status,omitempty"`
+	LastScanID        *string                   `json:"last_scan_id,omitempty"`
+	CreatedAt         time.Time                 `json:"created_at"`
+	UpdatedAt         time.Time                 `json:"updated_at"`
+}
+
+// CreateScheduleRequest is the POST /api/v1/schedules body. TargetID,
+// RRule, DTStart, and Timezone are required. EstimatedDurationSeconds
+// is optional and drives the overlap check; it is NOT persisted (no
+// column exists for it in schema 0004).
+type CreateScheduleRequest struct {
+	TargetID                  string                    `json:"target_id"`
+	Name                      string                    `json:"name"`
+	RRule                     string                    `json:"rrule"`
+	DTStart                   time.Time                 `json:"dtstart"`
+	Timezone                  string                    `json:"timezone"`
+	TemplateID                *string                   `json:"template_id,omitempty"`
+	ToolConfig                model.ToolConfig          `json:"tool_config,omitempty"`
+	Overrides                 []string                  `json:"overrides,omitempty"`
+	MaintenanceWindow         *model.MaintenanceWindow  `json:"maintenance_window,omitempty"`
+	Enabled                   *bool                     `json:"enabled,omitempty"`
+	EstimatedDurationSeconds  int                       `json:"estimated_duration_seconds,omitempty"`
+}
+
+// UpdateScheduleRequest is the PUT /api/v1/schedules/{id} body. All
+// fields are optional — only those set overwrite the stored row. When
+// RRule or DTStart change, the RRULE is re-validated and (when the
+// effective rrule changes) the overlap check re-runs.
+type UpdateScheduleRequest struct {
+	Name                     *string                   `json:"name,omitempty"`
+	RRule                    *string                   `json:"rrule,omitempty"`
+	DTStart                  *time.Time                `json:"dtstart,omitempty"`
+	Timezone                 *string                   `json:"timezone,omitempty"`
+	TemplateID               *string                   `json:"template_id,omitempty"`
+	ClearTemplate            bool                      `json:"clear_template,omitempty"`
+	ToolConfig               model.ToolConfig          `json:"tool_config,omitempty"`
+	Overrides                []string                  `json:"overrides,omitempty"`
+	MaintenanceWindow        *model.MaintenanceWindow  `json:"maintenance_window,omitempty"`
+	ClearMaintenanceWindow   bool                      `json:"clear_maintenance_window,omitempty"`
+	Enabled                  *bool                     `json:"enabled,omitempty"`
+	EstimatedDurationSeconds int                       `json:"estimated_duration_seconds,omitempty"`
+}
+
+func (h *handlers) routeSchedules(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.listSchedules(w, r)
+	case http.MethodPost:
+		h.createSchedule(w, r)
+	default:
+		methodNotAllowed(w, "GET, POST")
+	}
+}
+
+// routeSchedulesSubtree dispatches /api/v1/schedules/{id}(/pause|/resume).
+// Subpaths handled by their own registrations (/upcoming, /bulk) take
+// precedence via ServeMux's longest-prefix match so this function only
+// sees the CRUD shapes.
+func (h *handlers) routeSchedulesSubtree(w http.ResponseWriter, r *http.Request) {
+	rest := strings.TrimPrefix(r.URL.Path, "/api/v1/schedules/")
+	if rest == "" {
+		writeProblem(w, http.StatusBadRequest, "/problems/missing-id",
+			"Missing schedule id", "", nil)
+		return
+	}
+	id, action, _ := strings.Cut(rest, "/")
+	switch action {
+	case "":
+		switch r.Method {
+		case http.MethodGet:
+			h.getSchedule(w, r, id)
+		case http.MethodPut:
+			h.updateSchedule(w, r, id)
+		case http.MethodDelete:
+			h.deleteSchedule(w, r, id)
+		default:
+			methodNotAllowed(w, "GET, PUT, DELETE")
+		}
+	case "pause":
+		if r.Method != http.MethodPost {
+			methodNotAllowed(w, "POST")
+			return
+		}
+		h.setScheduleEnabled(w, r, id, false)
+	case "resume":
+		if r.Method != http.MethodPost {
+			methodNotAllowed(w, "POST")
+			return
+		}
+		h.setScheduleEnabled(w, r, id, true)
+	default:
+		writeProblem(w, http.StatusNotFound, "/problems/not-found",
+			"Unknown subresource", "unknown action "+action, nil)
+	}
+}
+
+func (h *handlers) listSchedules(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	var (
+		schedules []model.Schedule
+		err       error
+	)
+	q := r.URL.Query()
+	switch {
+	case q.Get("template_id") != "":
+		schedules, err = h.deps.ScheduleStore.ListByTemplate(ctx, q.Get("template_id"))
+	case q.Get("target_id") != "":
+		schedules, err = h.deps.ScheduleStore.ListByTarget(ctx, q.Get("target_id"))
+	default:
+		schedules, err = h.deps.ScheduleStore.ListAll(ctx)
+	}
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Listing schedules failed", err.Error(), nil)
+		return
+	}
+
+	// Client-side filter for status (active|paused).
+	if s := q.Get("status"); s != "" {
+		want := s == "active"
+		if s != "active" && s != "paused" {
+			writeProblem(w, http.StatusBadRequest, "/problems/invalid-query",
+				"Invalid status filter", "status must be 'active' or 'paused'", nil)
+			return
+		}
+		filtered := make([]model.Schedule, 0, len(schedules))
+		for _, s := range schedules {
+			if s.Enabled == want {
+				filtered = append(filtered, s)
+			}
+		}
+		schedules = filtered
+	}
+
+	total := int64(len(schedules))
+	p := ParsePagination(r, MaxLimit)
+	lo, hi := p.Offset, p.Offset+p.Limit
+	if lo > len(schedules) {
+		lo = len(schedules)
+	}
+	if hi > len(schedules) {
+		hi = len(schedules)
+	}
+	page := schedules[lo:hi]
+
+	items := make([]ScheduleResponse, 0, len(page))
+	for _, s := range page {
+		items = append(items, toScheduleResponse(s))
+	}
+	writeJSON(w, http.StatusOK, PaginatedResponse[ScheduleResponse]{
+		Items:  items,
+		Total:  total,
+		Limit:  p.Limit,
+		Offset: p.Offset,
+	})
+}
+
+func (h *handlers) getSchedule(w http.ResponseWriter, r *http.Request, id string) {
+	s, err := h.deps.ScheduleStore.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeProblem(w, http.StatusNotFound, "/problems/not-found",
+				"Schedule not found", "", nil)
+			return
+		}
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Loading schedule failed", err.Error(), nil)
+		return
+	}
+	writeJSON(w, http.StatusOK, toScheduleResponse(*s))
+}
+
+func (h *handlers) createSchedule(w http.ResponseWriter, r *http.Request) {
+	var req CreateScheduleRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeProblem(w, http.StatusBadRequest, "/problems/invalid-json",
+			"Invalid JSON body", err.Error(), nil)
+		return
+	}
+
+	if fe := validateCreateScheduleRequest(&req); len(fe) > 0 {
+		writeProblem(w, http.StatusBadRequest, "/problems/validation",
+			"Required fields missing", "", fe)
+		return
+	}
+
+	if _, err := rrule.ValidateRRule(req.RRule); err != nil {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Invalid RRULE", err.Error(),
+			[]FieldError{{Field: "rrule", Message: err.Error()}})
+		return
+	}
+
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	// Auto-mark rrule/timezone/maintenance_window as overridden when the
+	// caller supplied explicit values. The cascade resolver otherwise
+	// falls through to template/defaults, which would silently discard
+	// the caller's intent — a confusing UX for anyone not steeped in the
+	// SCHED1 override model.
+	overrides := mergeOverrides(req.Overrides, req.RRule != "", req.Timezone != "", req.MaintenanceWindow != nil)
+	sched := model.Schedule{
+		TargetID:          req.TargetID,
+		Name:              req.Name,
+		RRule:             req.RRule,
+		DTStart:           req.DTStart,
+		Timezone:          req.Timezone,
+		TemplateID:        req.TemplateID,
+		ToolConfig:        req.ToolConfig,
+		Overrides:         overrides,
+		MaintenanceWindow: req.MaintenanceWindow,
+		Enabled:           enabled,
+	}
+
+	// FK existence checks. target must exist; template if supplied.
+	if _, err := h.deps.Store.GetTarget(r.Context(), req.TargetID); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+				"Target not found", "",
+				[]FieldError{{Field: "target_id", Message: "no target with that id"}})
+			return
+		}
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Loading target failed", err.Error(), nil)
+		return
+	}
+	var tmpl *model.Template
+	if req.TemplateID != nil && *req.TemplateID != "" {
+		t, err := h.deps.TemplateStore.Get(r.Context(), *req.TemplateID)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+					"Template not found", "",
+					[]FieldError{{Field: "template_id", Message: "no template with that id"}})
+				return
+			}
+			writeProblem(w, http.StatusInternalServerError, "/problems/store",
+				"Loading template failed", err.Error(), nil)
+			return
+		}
+		tmpl = t
+	}
+
+	// Overlap check against existing schedules for the same target.
+	if fe, err := h.overlapCheck(r.Context(), sched, tmpl, req.EstimatedDurationSeconds); err != nil {
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Overlap check failed", err.Error(), nil)
+		return
+	} else if len(fe) > 0 {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/overlap",
+			"Schedule overlaps with existing schedules", "", fe)
+		return
+	}
+
+	if err := h.deps.ScheduleStore.Create(r.Context(), &sched); err != nil {
+		if errors.Is(err, storage.ErrAlreadyExists) {
+			writeProblem(w, http.StatusConflict, "/problems/already-exists",
+				"Schedule with that name already exists for the target", "", nil)
+			return
+		}
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Create failed", err.Error(), nil)
+		return
+	}
+
+	// Best-effort next-run computation and cascade refresh.
+	h.refreshNextRun(r.Context(), &sched, tmpl)
+	h.cascadeForTemplate(r.Context(), sched.TemplateID)
+
+	writeJSON(w, http.StatusCreated, toScheduleResponse(sched))
+}
+
+func (h *handlers) updateSchedule(w http.ResponseWriter, r *http.Request, id string) {
+	var req UpdateScheduleRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeProblem(w, http.StatusBadRequest, "/problems/invalid-json",
+			"Invalid JSON body", err.Error(), nil)
+		return
+	}
+
+	cur, err := h.deps.ScheduleStore.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeProblem(w, http.StatusNotFound, "/problems/not-found",
+				"Schedule not found", "", nil)
+			return
+		}
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Loading schedule failed", err.Error(), nil)
+		return
+	}
+
+	// Apply partial updates.
+	if req.Name != nil {
+		cur.Name = *req.Name
+	}
+	if req.RRule != nil {
+		cur.RRule = *req.RRule
+	}
+	if req.DTStart != nil {
+		cur.DTStart = *req.DTStart
+	}
+	if req.Timezone != nil {
+		cur.Timezone = *req.Timezone
+	}
+	if req.ClearTemplate {
+		cur.TemplateID = nil
+	} else if req.TemplateID != nil {
+		cur.TemplateID = req.TemplateID
+	}
+	if req.ToolConfig != nil {
+		cur.ToolConfig = req.ToolConfig
+	}
+	if req.Overrides != nil {
+		cur.Overrides = req.Overrides
+	}
+	if req.ClearMaintenanceWindow {
+		cur.MaintenanceWindow = nil
+	} else if req.MaintenanceWindow != nil {
+		cur.MaintenanceWindow = req.MaintenanceWindow
+	}
+	if req.Enabled != nil {
+		cur.Enabled = *req.Enabled
+	}
+
+	if _, err := rrule.ValidateRRule(cur.RRule); err != nil {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Invalid RRULE", err.Error(),
+			[]FieldError{{Field: "rrule", Message: err.Error()}})
+		return
+	}
+
+	var tmpl *model.Template
+	if cur.TemplateID != nil && *cur.TemplateID != "" {
+		t, terr := h.deps.TemplateStore.Get(r.Context(), *cur.TemplateID)
+		if terr != nil {
+			if errors.Is(terr, storage.ErrNotFound) {
+				writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+					"Template not found", "",
+					[]FieldError{{Field: "template_id", Message: "no template with that id"}})
+				return
+			}
+			writeProblem(w, http.StatusInternalServerError, "/problems/store",
+				"Loading template failed", terr.Error(), nil)
+			return
+		}
+		tmpl = t
+	}
+
+	if fe, oerr := h.overlapCheck(r.Context(), *cur, tmpl, req.EstimatedDurationSeconds); oerr != nil {
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Overlap check failed", oerr.Error(), nil)
+		return
+	} else if len(fe) > 0 {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/overlap",
+			"Schedule overlaps with existing schedules", "", fe)
+		return
+	}
+
+	if err := h.deps.ScheduleStore.Update(r.Context(), cur); err != nil {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Update failed", err.Error(), nil)
+		return
+	}
+	h.refreshNextRun(r.Context(), cur, tmpl)
+	h.cascadeForTemplate(r.Context(), cur.TemplateID)
+
+	writeJSON(w, http.StatusOK, toScheduleResponse(*cur))
+}
+
+func (h *handlers) deleteSchedule(w http.ResponseWriter, r *http.Request, id string) {
+	// Schema 0004 has no `deleted_at` column on scan_schedules — the
+	// storage layer does a hard delete. When a soft-delete column lands
+	// this handler is the only one that changes.
+	cur, err := h.deps.ScheduleStore.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeProblem(w, http.StatusNotFound, "/problems/not-found",
+				"Schedule not found", "", nil)
+			return
+		}
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Loading schedule failed", err.Error(), nil)
+		return
+	}
+	if err := h.deps.ScheduleStore.Delete(r.Context(), id); err != nil {
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Delete failed", err.Error(), nil)
+		return
+	}
+	h.cascadeForTemplate(r.Context(), cur.TemplateID)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *handlers) setScheduleEnabled(w http.ResponseWriter, r *http.Request, id string, enabled bool) {
+	// Pause/resume are idempotent — calling pause twice on a paused
+	// schedule returns 200 with the same body rather than an error.
+	cur, err := h.deps.ScheduleStore.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeProblem(w, http.StatusNotFound, "/problems/not-found",
+				"Schedule not found", "", nil)
+			return
+		}
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Loading schedule failed", err.Error(), nil)
+		return
+	}
+	if cur.Enabled != enabled {
+		cur.Enabled = enabled
+		if err := h.deps.ScheduleStore.Update(r.Context(), cur); err != nil {
+			writeProblem(w, http.StatusInternalServerError, "/problems/store",
+				"Pause/resume failed", err.Error(), nil)
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, toScheduleResponse(*cur))
+}
+
+// overlapCheck re-runs ValidateNoOverlap against the other schedules
+// already attached to the same target. When deps.Store is nil (only in
+// ad-hoc tests that exercise a single handler) the check is skipped.
+func (h *handlers) overlapCheck(ctx context.Context, cand model.Schedule, candTmpl *model.Template, estDuration int) ([]FieldError, error) {
+	if h.deps.ScheduleStore == nil {
+		return nil, nil
+	}
+	existing, err := h.deps.ScheduleStore.ListByTarget(ctx, cand.TargetID)
+	if err != nil {
+		return nil, err
+	}
+	tmpls := map[string]model.Template{}
+	if h.deps.TemplateStore != nil {
+		for _, s := range existing {
+			if s.TemplateID == nil || *s.TemplateID == "" {
+				continue
+			}
+			if _, ok := tmpls[*s.TemplateID]; ok {
+				continue
+			}
+			t, terr := h.deps.TemplateStore.Get(ctx, *s.TemplateID)
+			if terr == nil && t != nil {
+				tmpls[*s.TemplateID] = *t
+			}
+		}
+	}
+	defaults := model.ScheduleDefaults{}
+	if h.deps.DefaultsStore != nil {
+		if d, derr := h.deps.DefaultsStore.Get(ctx); derr == nil && d != nil {
+			defaults = *d
+		}
+	}
+	dur := time.Duration(estDuration) * time.Second
+	if estDuration <= 0 {
+		dur = time.Duration(DefaultEstimatedDurationSeconds) * time.Second
+	}
+	conflicts, err := intervalsched.ValidateNoOverlap(cand, candTmpl, existing, tmpls, defaults, overlapHorizon, dur)
+	if err != nil {
+		return nil, err
+	}
+	if len(conflicts) == 0 {
+		return nil, nil
+	}
+	fe := make([]FieldError, 0, len(conflicts))
+	for _, c := range conflicts {
+		fe = append(fe, FieldError{
+			Field: "rrule",
+			Message: fmt.Sprintf("overlaps schedule %s at %s vs %s",
+				c.ScheduleID, c.OccurrenceA.Format(time.RFC3339), c.OccurrenceB.Format(time.RFC3339)),
+		})
+	}
+	return fe, nil
+}
+
+// refreshNextRun updates scan_schedules.next_run_at for `s` when an
+// Expander is configured. Failure is logged via the problem response
+// path but doesn't block the 2xx — the master ticker's next RecordRun
+// recomputes regardless.
+func (h *handlers) refreshNextRun(ctx context.Context, s *model.Schedule, tmpl *model.Template) {
+	if h.deps.Expander == nil || !s.Enabled {
+		return
+	}
+	next, err := h.deps.Expander.ComputeNextRunAt(*s, tmpl)
+	if err != nil {
+		return
+	}
+	_ = h.deps.ScheduleStore.SetNextRunAt(ctx, s.ID, next)
+	s.NextRunAt = next
+}
+
+// cascadeForTemplate refreshes next_run_at for every schedule attached
+// to templateID. No-op when the template pointer is nil or the expander
+// isn't configured (tests without a scheduler skip the cascade).
+func (h *handlers) cascadeForTemplate(ctx context.Context, templateID *string) {
+	if templateID == nil || *templateID == "" || h.deps.Expander == nil {
+		return
+	}
+	_, _ = intervalsched.RecomputeNextRunForTemplate(ctx, *templateID,
+		h.deps.ScheduleStore, h.deps.TemplateStore, h.deps.Expander)
+}
+
+// mergeOverrides adds the override flag for any non-empty field supplied
+// by the caller. Callers that already listed a field in explicit
+// Overrides see no duplicate — the set is deduped.
+func mergeOverrides(explicit []string, rrule, timezone, maintenance bool) []string {
+	set := map[string]bool{}
+	for _, o := range explicit {
+		set[o] = true
+	}
+	if rrule {
+		set["rrule"] = true
+	}
+	if timezone {
+		set["timezone"] = true
+	}
+	if maintenance {
+		set["maintenance_window"] = true
+	}
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	return out
+}
+
+func validateCreateScheduleRequest(req *CreateScheduleRequest) []FieldError {
+	var fe []FieldError
+	if strings.TrimSpace(req.TargetID) == "" {
+		fe = append(fe, FieldError{Field: "target_id", Message: "required"})
+	}
+	if strings.TrimSpace(req.RRule) == "" {
+		fe = append(fe, FieldError{Field: "rrule", Message: "required"})
+	}
+	if strings.TrimSpace(req.Timezone) == "" {
+		fe = append(fe, FieldError{Field: "timezone", Message: "required"})
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		fe = append(fe, FieldError{Field: "name", Message: "required"})
+	}
+	return fe
+}
+
+func toScheduleResponse(s model.Schedule) ScheduleResponse {
+	status := "active"
+	if !s.Enabled {
+		status = "paused"
+	}
+	if s.ToolConfig == nil {
+		s.ToolConfig = model.ToolConfig{}
+	}
+	if s.Overrides == nil {
+		s.Overrides = []string{}
+	}
+	return ScheduleResponse{
+		ID:                s.ID,
+		TargetID:          s.TargetID,
+		Name:              s.Name,
+		RRule:             s.RRule,
+		DTStart:           s.DTStart,
+		Timezone:          s.Timezone,
+		TemplateID:        s.TemplateID,
+		ToolConfig:        s.ToolConfig,
+		Overrides:         s.Overrides,
+		MaintenanceWindow: s.MaintenanceWindow,
+		Status:            status,
+		NextRunAt:         s.NextRunAt,
+		LastRunAt:         s.LastRunAt,
+		LastRunStatus:     s.LastRunStatus,
+		LastScanID:        s.LastScanID,
+		CreatedAt:         s.CreatedAt,
+		UpdatedAt:         s.UpdatedAt,
+	}
+}
+
+// Ensure json import is always used even if marshaling helpers are
+// refactored away in a future commit.
+var _ = json.Marshal

--- a/internal/api/v1/schedules.go
+++ b/internal/api/v1/schedules.go
@@ -30,23 +30,23 @@ const overlapHorizon = 7 * 24 * time.Hour
 // API (nothing today — kept explicit for future-proofing) are excluded
 // here rather than via a `-` tag on the model.
 type ScheduleResponse struct {
-	ID                string                    `json:"id"`
-	TargetID          string                    `json:"target_id"`
-	Name              string                    `json:"name"`
-	RRule             string                    `json:"rrule"`
-	DTStart           time.Time                 `json:"dtstart"`
-	Timezone          string                    `json:"timezone"`
-	TemplateID        *string                   `json:"template_id,omitempty"`
-	ToolConfig        model.ToolConfig          `json:"tool_config"`
-	Overrides         []string                  `json:"overrides"`
-	MaintenanceWindow *model.MaintenanceWindow  `json:"maintenance_window,omitempty"`
-	Status            string                    `json:"status"`
-	NextRunAt         *time.Time                `json:"next_run_at,omitempty"`
-	LastRunAt         *time.Time                `json:"last_run_at,omitempty"`
-	LastRunStatus     *model.ScheduleRunStatus  `json:"last_run_status,omitempty"`
-	LastScanID        *string                   `json:"last_scan_id,omitempty"`
-	CreatedAt         time.Time                 `json:"created_at"`
-	UpdatedAt         time.Time                 `json:"updated_at"`
+	ID                string                   `json:"id"`
+	TargetID          string                   `json:"target_id"`
+	Name              string                   `json:"name"`
+	RRule             string                   `json:"rrule"`
+	DTStart           time.Time                `json:"dtstart"`
+	Timezone          string                   `json:"timezone"`
+	TemplateID        *string                  `json:"template_id,omitempty"`
+	ToolConfig        model.ToolConfig         `json:"tool_config"`
+	Overrides         []string                 `json:"overrides"`
+	MaintenanceWindow *model.MaintenanceWindow `json:"maintenance_window,omitempty"`
+	Status            string                   `json:"status"`
+	NextRunAt         *time.Time               `json:"next_run_at,omitempty"`
+	LastRunAt         *time.Time               `json:"last_run_at,omitempty"`
+	LastRunStatus     *model.ScheduleRunStatus `json:"last_run_status,omitempty"`
+	LastScanID        *string                  `json:"last_scan_id,omitempty"`
+	CreatedAt         time.Time                `json:"created_at"`
+	UpdatedAt         time.Time                `json:"updated_at"`
 }
 
 // CreateScheduleRequest is the POST /api/v1/schedules body. TargetID,
@@ -54,17 +54,17 @@ type ScheduleResponse struct {
 // is optional and drives the overlap check; it is NOT persisted (no
 // column exists for it in schema 0004).
 type CreateScheduleRequest struct {
-	TargetID                  string                    `json:"target_id"`
-	Name                      string                    `json:"name"`
-	RRule                     string                    `json:"rrule"`
-	DTStart                   time.Time                 `json:"dtstart"`
-	Timezone                  string                    `json:"timezone"`
-	TemplateID                *string                   `json:"template_id,omitempty"`
-	ToolConfig                model.ToolConfig          `json:"tool_config,omitempty"`
-	Overrides                 []string                  `json:"overrides,omitempty"`
-	MaintenanceWindow         *model.MaintenanceWindow  `json:"maintenance_window,omitempty"`
-	Enabled                   *bool                     `json:"enabled,omitempty"`
-	EstimatedDurationSeconds  int                       `json:"estimated_duration_seconds,omitempty"`
+	TargetID                 string                   `json:"target_id"`
+	Name                     string                   `json:"name"`
+	RRule                    string                   `json:"rrule"`
+	DTStart                  time.Time                `json:"dtstart"`
+	Timezone                 string                   `json:"timezone"`
+	TemplateID               *string                  `json:"template_id,omitempty"`
+	ToolConfig               model.ToolConfig         `json:"tool_config,omitempty"`
+	Overrides                []string                 `json:"overrides,omitempty"`
+	MaintenanceWindow        *model.MaintenanceWindow `json:"maintenance_window,omitempty"`
+	Enabled                  *bool                    `json:"enabled,omitempty"`
+	EstimatedDurationSeconds int                      `json:"estimated_duration_seconds,omitempty"`
 }
 
 // UpdateScheduleRequest is the PUT /api/v1/schedules/{id} body. All
@@ -72,18 +72,18 @@ type CreateScheduleRequest struct {
 // RRule or DTStart change, the RRULE is re-validated and (when the
 // effective rrule changes) the overlap check re-runs.
 type UpdateScheduleRequest struct {
-	Name                     *string                   `json:"name,omitempty"`
-	RRule                    *string                   `json:"rrule,omitempty"`
-	DTStart                  *time.Time                `json:"dtstart,omitempty"`
-	Timezone                 *string                   `json:"timezone,omitempty"`
-	TemplateID               *string                   `json:"template_id,omitempty"`
-	ClearTemplate            bool                      `json:"clear_template,omitempty"`
-	ToolConfig               model.ToolConfig          `json:"tool_config,omitempty"`
-	Overrides                []string                  `json:"overrides,omitempty"`
-	MaintenanceWindow        *model.MaintenanceWindow  `json:"maintenance_window,omitempty"`
-	ClearMaintenanceWindow   bool                      `json:"clear_maintenance_window,omitempty"`
-	Enabled                  *bool                     `json:"enabled,omitempty"`
-	EstimatedDurationSeconds int                       `json:"estimated_duration_seconds,omitempty"`
+	Name                     *string                  `json:"name,omitempty"`
+	RRule                    *string                  `json:"rrule,omitempty"`
+	DTStart                  *time.Time               `json:"dtstart,omitempty"`
+	Timezone                 *string                  `json:"timezone,omitempty"`
+	TemplateID               *string                  `json:"template_id,omitempty"`
+	ClearTemplate            bool                     `json:"clear_template,omitempty"`
+	ToolConfig               model.ToolConfig         `json:"tool_config,omitempty"`
+	Overrides                []string                 `json:"overrides,omitempty"`
+	MaintenanceWindow        *model.MaintenanceWindow `json:"maintenance_window,omitempty"`
+	ClearMaintenanceWindow   bool                     `json:"clear_maintenance_window,omitempty"`
+	Enabled                  *bool                    `json:"enabled,omitempty"`
+	EstimatedDurationSeconds int                      `json:"estimated_duration_seconds,omitempty"`
 }
 
 func (h *handlers) routeSchedules(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/v1/schedules_test.go
+++ b/internal/api/v1/schedules_test.go
@@ -1,0 +1,207 @@
+package v1
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func itoa(n int) string { return strconv.Itoa(n) }
+
+func TestSchedulesCreateAndList(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+	targetID := seedTarget(t, store, "example.com")
+
+	// Happy-path create.
+	body := CreateScheduleRequest{
+		TargetID: targetID,
+		Name:     "nightly",
+		RRule:    "FREQ=DAILY;BYHOUR=2",
+		DTStart:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Timezone: "UTC",
+	}
+	resp, rawBody := doJSON(t, srv, http.MethodPost, "/api/v1/schedules", body)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("POST /schedules status=%d body=%s", resp.StatusCode, rawBody)
+	}
+	var created ScheduleResponse
+	decode(t, rawBody, &created)
+	if created.ID == "" || created.TargetID != targetID {
+		t.Fatalf("created response missing fields: %+v", created)
+	}
+	if created.Status != "active" {
+		t.Fatalf("new schedule status=%q, want active", created.Status)
+	}
+
+	// List.
+	resp, rawBody = doJSON(t, srv, http.MethodGet, "/api/v1/schedules", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /schedules status=%d body=%s", resp.StatusCode, rawBody)
+	}
+	var page PaginatedResponse[ScheduleResponse]
+	decode(t, rawBody, &page)
+	if page.Total != 1 || len(page.Items) != 1 || page.Items[0].ID != created.ID {
+		t.Fatalf("unexpected list page: %+v", page)
+	}
+}
+
+func TestSchedulesValidationMissingFields(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+
+	resp, body := doJSON(t, srv, http.MethodPost, "/api/v1/schedules", CreateScheduleRequest{})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("missing fields should 400, got %d body=%s", resp.StatusCode, body)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != ProblemContentType {
+		t.Fatalf("content-type=%q, want %q", ct, ProblemContentType)
+	}
+	var p ProblemResponse
+	decode(t, body, &p)
+	if len(p.FieldErrors) == 0 {
+		t.Fatalf("expected field errors, got none: %+v", p)
+	}
+}
+
+func TestSchedulesInvalidRRule(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+	targetID := seedTarget(t, store, "example.com")
+
+	req := CreateScheduleRequest{
+		TargetID: targetID,
+		Name:     "bad",
+		RRule:    "FREQ=SECONDLY",
+		DTStart:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Timezone: "UTC",
+	}
+	resp, body := doJSON(t, srv, http.MethodPost, "/api/v1/schedules", req)
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("SECONDLY should 422, got %d body=%s", resp.StatusCode, body)
+	}
+	var p ProblemResponse
+	decode(t, body, &p)
+	if len(p.FieldErrors) == 0 || p.FieldErrors[0].Field != "rrule" {
+		t.Fatalf("expected rrule field error, got %+v", p.FieldErrors)
+	}
+}
+
+func TestSchedulesPauseResumeIdempotent(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+	targetID := seedTarget(t, store, "example.com")
+
+	resp, body := doJSON(t, srv, http.MethodPost, "/api/v1/schedules", CreateScheduleRequest{
+		TargetID: targetID, Name: "n", RRule: "FREQ=DAILY", Timezone: "UTC",
+		DTStart: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", resp.StatusCode, body)
+	}
+	var created ScheduleResponse
+	decode(t, body, &created)
+
+	// Pause.
+	resp, body = doJSON(t, srv, http.MethodPost, "/api/v1/schedules/"+created.ID+"/pause", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("pause status=%d body=%s", resp.StatusCode, body)
+	}
+	var paused ScheduleResponse
+	decode(t, body, &paused)
+	if paused.Status != "paused" {
+		t.Fatalf("after pause status=%q", paused.Status)
+	}
+	// Pause again — idempotent.
+	resp, body = doJSON(t, srv, http.MethodPost, "/api/v1/schedules/"+created.ID+"/pause", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("pause twice status=%d body=%s", resp.StatusCode, body)
+	}
+	// Resume.
+	resp, body = doJSON(t, srv, http.MethodPost, "/api/v1/schedules/"+created.ID+"/resume", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("resume status=%d body=%s", resp.StatusCode, body)
+	}
+	var resumed ScheduleResponse
+	decode(t, body, &resumed)
+	if resumed.Status != "active" {
+		t.Fatalf("after resume status=%q", resumed.Status)
+	}
+}
+
+func TestSchedulesUpdateAndDelete(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+	targetID := seedTarget(t, store, "example.com")
+
+	_, body := doJSON(t, srv, http.MethodPost, "/api/v1/schedules", CreateScheduleRequest{
+		TargetID: targetID, Name: "n", RRule: "FREQ=DAILY", Timezone: "UTC",
+		DTStart: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	var created ScheduleResponse
+	decode(t, body, &created)
+
+	newName := "updated"
+	resp, body := doJSON(t, srv, http.MethodPut, "/api/v1/schedules/"+created.ID, UpdateScheduleRequest{
+		Name: &newName,
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PUT status=%d body=%s", resp.StatusCode, body)
+	}
+	var updated ScheduleResponse
+	decode(t, body, &updated)
+	if updated.Name != "updated" {
+		t.Fatalf("name after update=%q", updated.Name)
+	}
+
+	// DELETE returns 204; subsequent GET 404.
+	resp, body = doJSON(t, srv, http.MethodDelete, "/api/v1/schedules/"+created.ID, nil)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("DELETE status=%d body=%s", resp.StatusCode, body)
+	}
+	resp, body = doJSON(t, srv, http.MethodGet, "/api/v1/schedules/"+created.ID, nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("after delete GET status=%d body=%s", resp.StatusCode, body)
+	}
+}
+
+func TestSchedulesListFilters(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+	targetID := seedTarget(t, store, "example.com")
+	other := seedTarget(t, store, "other.com")
+
+	// Use distinct BYHOUR values so schedules on the same target don't
+	// overlap within the 1h default estimated duration.
+	mk := func(targetID, name string, hour int) string {
+		_, body := doJSON(t, srv, http.MethodPost, "/api/v1/schedules", CreateScheduleRequest{
+			TargetID: targetID, Name: name,
+			RRule:    "FREQ=WEEKLY;BYHOUR=" + itoa(hour) + ";BYMINUTE=0;BYSECOND=0",
+			Timezone: "UTC",
+			DTStart:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		})
+		var r ScheduleResponse
+		decode(t, body, &r)
+		return r.ID
+	}
+	mk(targetID, "a", 1)
+	mk(targetID, "b", 12)
+	mk(other, "c", 2)
+
+	_, body := doJSON(t, srv, http.MethodGet, "/api/v1/schedules?target_id="+targetID, nil)
+	var page PaginatedResponse[ScheduleResponse]
+	decode(t, body, &page)
+	if page.Total != 2 {
+		t.Fatalf("target filter total=%d, want 2", page.Total)
+	}
+
+	// Pause one, then list with status=paused.
+	doJSON(t, srv, http.MethodPost, "/api/v1/schedules/"+page.Items[0].ID+"/pause", nil)
+	_, body = doJSON(t, srv, http.MethodGet, "/api/v1/schedules?status=paused", nil)
+	var p2 PaginatedResponse[ScheduleResponse]
+	decode(t, body, &p2)
+	if p2.Total != 1 {
+		t.Fatalf("status=paused total=%d, want 1", p2.Total)
+	}
+}

--- a/internal/api/v1/templates.go
+++ b/internal/api/v1/templates.go
@@ -1,0 +1,369 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/rrule"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// maxDependentIDsInFieldError bounds the number of dependent schedule IDs
+// echoed in the 409 response body when a template DELETE without ?force
+// refuses to proceed. Anything beyond this is summarized as "... and N
+// more" so the payload stays small.
+const maxDependentIDsInFieldError = 10
+
+// TemplateResponse mirrors model.Template with ISO-8601 timestamps and
+// a stable JSON shape.
+type TemplateResponse struct {
+	ID                string                   `json:"id"`
+	Name              string                   `json:"name"`
+	Description       string                   `json:"description"`
+	RRule             string                   `json:"rrule"`
+	Timezone          string                   `json:"timezone"`
+	ToolConfig        model.ToolConfig         `json:"tool_config"`
+	MaintenanceWindow *model.MaintenanceWindow `json:"maintenance_window,omitempty"`
+	IsSystem          bool                     `json:"is_system"`
+	CreatedAt         time.Time                `json:"created_at"`
+	UpdatedAt         time.Time                `json:"updated_at"`
+}
+
+// CreateTemplateRequest is the POST /api/v1/templates body.
+type CreateTemplateRequest struct {
+	Name              string                   `json:"name"`
+	Description       string                   `json:"description,omitempty"`
+	RRule             string                   `json:"rrule"`
+	Timezone          string                   `json:"timezone,omitempty"`
+	ToolConfig        model.ToolConfig         `json:"tool_config,omitempty"`
+	MaintenanceWindow *model.MaintenanceWindow `json:"maintenance_window,omitempty"`
+}
+
+// UpdateTemplateRequest is the PUT body. Partial — only non-nil pointer
+// fields overwrite; ClearMaintenanceWindow removes the window entirely.
+type UpdateTemplateRequest struct {
+	Name                   *string                  `json:"name,omitempty"`
+	Description            *string                  `json:"description,omitempty"`
+	RRule                  *string                  `json:"rrule,omitempty"`
+	Timezone               *string                  `json:"timezone,omitempty"`
+	ToolConfig             model.ToolConfig         `json:"tool_config,omitempty"`
+	MaintenanceWindow      *model.MaintenanceWindow `json:"maintenance_window,omitempty"`
+	ClearMaintenanceWindow bool                     `json:"clear_maintenance_window,omitempty"`
+}
+
+func (h *handlers) routeTemplates(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.listTemplates(w, r)
+	case http.MethodPost:
+		h.createTemplate(w, r)
+	default:
+		methodNotAllowed(w, "GET, POST")
+	}
+}
+
+func (h *handlers) routeTemplateByID(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/api/v1/templates/")
+	if id == "" || strings.Contains(id, "/") {
+		writeProblem(w, http.StatusNotFound, "/problems/not-found",
+			"Unknown template subresource", "", nil)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		h.getTemplate(w, r, id)
+	case http.MethodPut:
+		h.updateTemplate(w, r, id)
+	case http.MethodDelete:
+		h.deleteTemplate(w, r, id)
+	default:
+		methodNotAllowed(w, "GET, PUT, DELETE")
+	}
+}
+
+func (h *handlers) listTemplates(w http.ResponseWriter, r *http.Request) {
+	items, err := h.deps.TemplateStore.List(r.Context())
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Listing templates failed", err.Error(), nil)
+		return
+	}
+	total := int64(len(items))
+	p := ParsePagination(r, MaxLimit)
+	lo, hi := p.Offset, p.Offset+p.Limit
+	if lo > len(items) {
+		lo = len(items)
+	}
+	if hi > len(items) {
+		hi = len(items)
+	}
+	page := items[lo:hi]
+	out := make([]TemplateResponse, 0, len(page))
+	for _, t := range page {
+		out = append(out, toTemplateResponse(t))
+	}
+	writeJSON(w, http.StatusOK, PaginatedResponse[TemplateResponse]{
+		Items:  out,
+		Total:  total,
+		Limit:  p.Limit,
+		Offset: p.Offset,
+	})
+}
+
+func (h *handlers) getTemplate(w http.ResponseWriter, r *http.Request, id string) {
+	t, err := h.deps.TemplateStore.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeProblem(w, http.StatusNotFound, "/problems/not-found",
+				"Template not found", "", nil)
+			return
+		}
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Loading template failed", err.Error(), nil)
+		return
+	}
+	writeJSON(w, http.StatusOK, toTemplateResponse(*t))
+}
+
+func (h *handlers) createTemplate(w http.ResponseWriter, r *http.Request) {
+	var req CreateTemplateRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeProblem(w, http.StatusBadRequest, "/problems/invalid-json",
+			"Invalid JSON body", err.Error(), nil)
+		return
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		writeProblem(w, http.StatusBadRequest, "/problems/validation",
+			"Required fields missing", "",
+			[]FieldError{{Field: "name", Message: "required"}})
+		return
+	}
+	if strings.TrimSpace(req.RRule) == "" {
+		writeProblem(w, http.StatusBadRequest, "/problems/validation",
+			"Required fields missing", "",
+			[]FieldError{{Field: "rrule", Message: "required"}})
+		return
+	}
+	if _, err := rrule.ValidateRRule(req.RRule); err != nil {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Invalid RRULE", err.Error(),
+			[]FieldError{{Field: "rrule", Message: err.Error()}})
+		return
+	}
+	if fe := validateToolConfigFields(req.ToolConfig, "tool_config"); len(fe) > 0 {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Invalid tool_config", "", fe)
+		return
+	}
+
+	timezone := req.Timezone
+	if timezone == "" {
+		timezone = "UTC"
+	}
+	tmpl := model.Template{
+		Name:              req.Name,
+		Description:       req.Description,
+		RRule:             req.RRule,
+		Timezone:          timezone,
+		ToolConfig:        req.ToolConfig,
+		MaintenanceWindow: req.MaintenanceWindow,
+	}
+	if err := h.deps.TemplateStore.Create(r.Context(), &tmpl); err != nil {
+		if errors.Is(err, storage.ErrAlreadyExists) {
+			writeProblem(w, http.StatusConflict, "/problems/already-exists",
+				"Template name taken", "", nil)
+			return
+		}
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Create failed", err.Error(), nil)
+		return
+	}
+	writeJSON(w, http.StatusCreated, toTemplateResponse(tmpl))
+}
+
+func (h *handlers) updateTemplate(w http.ResponseWriter, r *http.Request, id string) {
+	var req UpdateTemplateRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeProblem(w, http.StatusBadRequest, "/problems/invalid-json",
+			"Invalid JSON body", err.Error(), nil)
+		return
+	}
+	cur, err := h.deps.TemplateStore.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeProblem(w, http.StatusNotFound, "/problems/not-found",
+				"Template not found", "", nil)
+			return
+		}
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Loading template failed", err.Error(), nil)
+		return
+	}
+
+	if req.Name != nil {
+		cur.Name = *req.Name
+	}
+	if req.Description != nil {
+		cur.Description = *req.Description
+	}
+	if req.RRule != nil {
+		cur.RRule = *req.RRule
+	}
+	if req.Timezone != nil {
+		cur.Timezone = *req.Timezone
+	}
+	if req.ToolConfig != nil {
+		cur.ToolConfig = req.ToolConfig
+	}
+	if req.ClearMaintenanceWindow {
+		cur.MaintenanceWindow = nil
+	} else if req.MaintenanceWindow != nil {
+		cur.MaintenanceWindow = req.MaintenanceWindow
+	}
+
+	if _, err := rrule.ValidateRRule(cur.RRule); err != nil {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Invalid RRULE", err.Error(),
+			[]FieldError{{Field: "rrule", Message: err.Error()}})
+		return
+	}
+	if fe := validateToolConfigFields(cur.ToolConfig, "tool_config"); len(fe) > 0 {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Invalid tool_config", "", fe)
+		return
+	}
+
+	if err := h.deps.TemplateStore.Update(r.Context(), cur); err != nil {
+		writeProblem(w, http.StatusUnprocessableEntity, "/problems/validation",
+			"Update failed", err.Error(), nil)
+		return
+	}
+
+	// Cascade: refresh next_run_at for every schedule pointing at this
+	// template so the recomputed rrule takes effect on the next tick.
+	if h.deps.Expander != nil {
+		_, _ = intervalsched.RecomputeNextRunForTemplate(r.Context(), cur.ID,
+			h.deps.ScheduleStore, h.deps.TemplateStore, h.deps.Expander)
+	}
+	writeJSON(w, http.StatusOK, toTemplateResponse(*cur))
+}
+
+// deleteTemplate refuses to delete a template that any schedule still
+// references unless ?force=true, in which case the dependent schedules
+// are deleted atomically along with the template.
+func (h *handlers) deleteTemplate(w http.ResponseWriter, r *http.Request, id string) {
+	dependents, err := h.deps.ScheduleStore.ListByTemplate(r.Context(), id)
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Listing dependents failed", err.Error(), nil)
+		return
+	}
+	force := r.URL.Query().Get("force") == "true"
+	if len(dependents) > 0 && !force {
+		fe := make([]FieldError, 0, len(dependents))
+		for i, s := range dependents {
+			if i >= maxDependentIDsInFieldError {
+				fe = append(fe, FieldError{
+					Field:   "dependents",
+					Message: fmt.Sprintf("... and %d more", len(dependents)-i),
+				})
+				break
+			}
+			fe = append(fe, FieldError{Field: "dependents", Message: s.ID})
+		}
+		writeProblem(w, http.StatusConflict, "/problems/template-in-use",
+			"Template is still referenced by schedules; pass ?force=true to cascade delete",
+			"", fe)
+		return
+	}
+
+	if force && len(dependents) > 0 {
+		// Cascade delete inside a transaction so either everything goes
+		// or nothing does.
+		err := h.deps.Store.Transact(r.Context(), func(ctx context.Context, ts storage.TxStores) error {
+			for _, s := range dependents {
+				if err := ts.Schedules.Delete(ctx, s.ID); err != nil {
+					return err
+				}
+			}
+			return ts.Templates.Delete(ctx, id)
+		})
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				writeProblem(w, http.StatusNotFound, "/problems/not-found",
+					"Template not found", "", nil)
+				return
+			}
+			writeProblem(w, http.StatusInternalServerError, "/problems/store",
+				"Cascade delete failed", err.Error(), nil)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	if err := h.deps.TemplateStore.Delete(r.Context(), id); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeProblem(w, http.StatusNotFound, "/problems/not-found",
+				"Template not found", "", nil)
+			return
+		}
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Delete failed", err.Error(), nil)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// validateToolConfigFields decodes each tool entry into its registered
+// params struct. Unknown tool names and malformed payloads produce
+// field-level errors pointing at "prefix.toolname".
+func validateToolConfigFields(tc model.ToolConfig, prefix string) []FieldError {
+	if tc == nil {
+		return nil
+	}
+	var fe []FieldError
+	for name, raw := range tc {
+		typ, ok := model.RegisteredToolParams[name]
+		if !ok {
+			fe = append(fe, FieldError{
+				Field:   prefix + "." + name,
+				Message: "unknown tool",
+			})
+			continue
+		}
+		instance := reflectTypeNew(typ)
+		if err := json.Unmarshal(raw, instance); err != nil {
+			fe = append(fe, FieldError{
+				Field:   prefix + "." + name,
+				Message: err.Error(),
+			})
+		}
+	}
+	return fe
+}
+
+func toTemplateResponse(t model.Template) TemplateResponse {
+	if t.ToolConfig == nil {
+		t.ToolConfig = model.ToolConfig{}
+	}
+	return TemplateResponse{
+		ID:                t.ID,
+		Name:              t.Name,
+		Description:       t.Description,
+		RRule:             t.RRule,
+		Timezone:          t.Timezone,
+		ToolConfig:        t.ToolConfig,
+		MaintenanceWindow: t.MaintenanceWindow,
+		IsSystem:          t.IsSystem,
+		CreatedAt:         t.CreatedAt,
+		UpdatedAt:         t.UpdatedAt,
+	}
+}

--- a/internal/api/v1/templates_test.go
+++ b/internal/api/v1/templates_test.go
@@ -1,0 +1,114 @@
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+func TestTemplatesCreateAndGet(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+
+	body := CreateTemplateRequest{
+		Name:     "nightly",
+		RRule:    "FREQ=DAILY",
+		Timezone: "UTC",
+	}
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/templates", body)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("POST status=%d body=%s", resp.StatusCode, raw)
+	}
+	var created TemplateResponse
+	decode(t, raw, &created)
+	if created.ID == "" {
+		t.Fatalf("missing id")
+	}
+
+	resp, raw = doJSON(t, srv, http.MethodGet, "/api/v1/templates/"+created.ID, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET status=%d body=%s", resp.StatusCode, raw)
+	}
+}
+
+func TestTemplatesRejectUnknownToolKey(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+
+	body := CreateTemplateRequest{
+		Name:  "bad",
+		RRule: "FREQ=DAILY",
+		ToolConfig: model.ToolConfig{
+			"amass": json.RawMessage(`{}`),
+		},
+	}
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/templates", body)
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("unknown tool should 422, got %d body=%s", resp.StatusCode, raw)
+	}
+	var p ProblemResponse
+	decode(t, raw, &p)
+	if len(p.FieldErrors) == 0 || p.FieldErrors[0].Field != "tool_config.amass" {
+		t.Fatalf("expected field error on tool_config.amass, got %+v", p.FieldErrors)
+	}
+}
+
+func TestTemplatesRejectMalformedToolPayload(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+
+	body := CreateTemplateRequest{
+		Name:  "bad2",
+		RRule: "FREQ=DAILY",
+		ToolConfig: model.ToolConfig{
+			"nuclei": json.RawMessage(`{"rate_limit": "not-an-int"}`),
+		},
+	}
+	resp, raw := doJSON(t, srv, http.MethodPost, "/api/v1/templates", body)
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("malformed should 422, got %d body=%s", resp.StatusCode, raw)
+	}
+}
+
+func TestTemplatesDeleteRefusesWithDependents(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+	targetID := seedTarget(t, store, "example.com")
+
+	// Create template then a schedule that references it.
+	_, raw := doJSON(t, srv, http.MethodPost, "/api/v1/templates", CreateTemplateRequest{
+		Name: "tmpl", RRule: "FREQ=DAILY", Timezone: "UTC",
+	})
+	var tmpl TemplateResponse
+	decode(t, raw, &tmpl)
+
+	_, raw = doJSON(t, srv, http.MethodPost, "/api/v1/schedules", CreateScheduleRequest{
+		TargetID: targetID, Name: "sched", RRule: "FREQ=DAILY", Timezone: "UTC",
+		TemplateID: &tmpl.ID,
+	})
+	var sched ScheduleResponse
+	decode(t, raw, &sched)
+
+	resp, raw := doJSON(t, srv, http.MethodDelete, "/api/v1/templates/"+tmpl.ID, nil)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("delete with dependents should 409, got %d body=%s", resp.StatusCode, raw)
+	}
+	var p ProblemResponse
+	decode(t, raw, &p)
+	if len(p.FieldErrors) == 0 {
+		t.Fatalf("expected dependent ids in field errors")
+	}
+
+	// Force delete cascades.
+	resp, raw = doJSON(t, srv, http.MethodDelete, "/api/v1/templates/"+tmpl.ID+"?force=true", nil)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("force delete status=%d body=%s", resp.StatusCode, raw)
+	}
+	// Dependent schedule is gone.
+	resp, _ = doJSON(t, srv, http.MethodGet, "/api/v1/schedules/"+sched.ID, nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("dependent schedule still present after cascade delete: status=%d", resp.StatusCode)
+	}
+}

--- a/internal/api/v1/types.go
+++ b/internal/api/v1/types.go
@@ -1,0 +1,126 @@
+// Package v1 implements the versioned REST API for first-class schedules
+// introduced by SPEC-SCHED1. Handlers live in this package and are
+// registered via RegisterRoutes against an *http.ServeMux. All error
+// responses use the RFC 7807 problem+json shape defined below.
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+)
+
+// ProblemContentType is the RFC 7807 media type used for error responses.
+const ProblemContentType = "application/problem+json"
+
+// ProblemResponse is the RFC 7807 problem-details shape every error
+// response uses. Type is a URI-reference that identifies the problem
+// class; handlers use /problems/<slug> relative URIs. FieldErrors is a
+// non-standard extension — callers that want structured per-field
+// validation errors read it off the body.
+type ProblemResponse struct {
+	Type        string       `json:"type"`
+	Title       string       `json:"title"`
+	Status      int          `json:"status"`
+	Detail      string       `json:"detail,omitempty"`
+	FieldErrors []FieldError `json:"field_errors,omitempty"`
+}
+
+// FieldError names a single invalid field in a request body. Field uses
+// dotted JSON paths (e.g. tool_config.nuclei.severity).
+type FieldError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+// Pagination carries parsed ?limit=&offset= query parameters.
+type Pagination struct {
+	Limit  int
+	Offset int
+}
+
+// Default pagination bounds. Handlers pick their own max via
+// ParsePagination's maxLimit parameter.
+const (
+	DefaultLimit = 50
+	MaxLimit     = 500
+)
+
+// PaginatedResponse is the shape list endpoints return. Items is always
+// an allocated slice (never nil) so clients don't have to special-case
+// empty pages.
+type PaginatedResponse[T any] struct {
+	Items  []T   `json:"items"`
+	Total  int64 `json:"total"`
+	Limit  int   `json:"limit"`
+	Offset int   `json:"offset"`
+}
+
+// ParsePagination reads ?limit and ?offset from the request with sane
+// defaults. An invalid limit falls back to DefaultLimit; an invalid
+// offset falls back to 0. limit is clamped to [1, maxLimit]; pass 0 to
+// use MaxLimit.
+func ParsePagination(r *http.Request, maxLimit int) Pagination {
+	if maxLimit <= 0 {
+		maxLimit = MaxLimit
+	}
+	p := Pagination{Limit: DefaultLimit, Offset: 0}
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			if n > maxLimit {
+				n = maxLimit
+			}
+			p.Limit = n
+		}
+	}
+	if v := r.URL.Query().Get("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			p.Offset = n
+		}
+	}
+	return p
+}
+
+// writeProblem emits a problem+json error response. status and title are
+// required; detail and fieldErrors are optional. problemType is the
+// relative URI identifying the problem class.
+func writeProblem(w http.ResponseWriter, status int, problemType, title, detail string, fieldErrors []FieldError) {
+	p := ProblemResponse{
+		Type:        problemType,
+		Title:       title,
+		Status:      status,
+		Detail:      detail,
+		FieldErrors: fieldErrors,
+	}
+	w.Header().Set("Content-Type", ProblemContentType)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(p)
+}
+
+// writeJSON emits a standard JSON response with the given status and
+// body. Kept local to this package so handlers have a single entry
+// point independent of the webui helper.
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if body != nil {
+		_ = json.NewEncoder(w).Encode(body)
+	}
+}
+
+// decodeJSON reads and decodes the request body into v with a 1 MiB
+// size cap. Returns a non-nil error on unreadable body or malformed
+// JSON — callers translate to a 400 ProblemResponse.
+func decodeJSON(r *http.Request, v any) error {
+	r.Body = http.MaxBytesReader(nil, r.Body, 1<<20)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	return dec.Decode(v)
+}
+
+// methodNotAllowed writes a 405 problem response with an Allow header.
+func methodNotAllowed(w http.ResponseWriter, allow string) {
+	w.Header().Set("Allow", allow)
+	writeProblem(w, http.StatusMethodNotAllowed, "/problems/method-not-allowed",
+		"Method Not Allowed", "method "+allow+" required", nil)
+}

--- a/internal/api/v1/types_test.go
+++ b/internal/api/v1/types_test.go
@@ -79,12 +79,11 @@ func TestMethodNotAllowedSetsHeader(t *testing.T) {
 	}
 }
 
-func TestRegisterRoutesNoop(t *testing.T) {
-	// R1 ships the scaffold; later commits add handlers.
+func TestRegisterRoutesHandlesUnknownPath(t *testing.T) {
 	mux := http.NewServeMux()
 	RegisterRoutes(mux, APIDeps{})
-	// A path not yet registered should 404 via the default mux behavior.
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/schedules", nil)
+	// A path outside the registered tree 404s via the mux default.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/does-not-exist", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusNotFound {

--- a/internal/api/v1/types_test.go
+++ b/internal/api/v1/types_test.go
@@ -1,0 +1,93 @@
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestProblemResponseShape(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeProblem(rec, http.StatusUnprocessableEntity, "/problems/validation",
+		"Validation Failed", "rrule is invalid", []FieldError{
+			{Field: "rrule", Message: "missing FREQ"},
+		})
+
+	if got := rec.Header().Get("Content-Type"); got != ProblemContentType {
+		t.Fatalf("content-type = %q, want %q", got, ProblemContentType)
+	}
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnprocessableEntity)
+	}
+	var p ProblemResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &p); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if p.Type == "" || p.Title == "" || p.Status == 0 {
+		t.Fatalf("required RFC 7807 fields missing: %+v", p)
+	}
+	if len(p.FieldErrors) != 1 || p.FieldErrors[0].Field != "rrule" {
+		t.Fatalf("field errors not serialized: %+v", p.FieldErrors)
+	}
+}
+
+func TestParsePaginationDefaults(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	p := ParsePagination(req, 0)
+	if p.Limit != DefaultLimit || p.Offset != 0 {
+		t.Fatalf("defaults = %+v, want limit=%d offset=0", p, DefaultLimit)
+	}
+}
+
+func TestParsePaginationClamps(t *testing.T) {
+	cases := []struct {
+		q          string
+		maxLimit   int
+		wantLimit  int
+		wantOffset int
+	}{
+		{"limit=10&offset=5", 0, 10, 5},
+		{"limit=9999", 500, 500, 0},
+		{"limit=-1", 0, DefaultLimit, 0},
+		{"limit=abc&offset=xyz", 0, DefaultLimit, 0},
+		{"offset=-5", 0, DefaultLimit, 0},
+	}
+	for _, tc := range cases {
+		u, _ := url.Parse("/x?" + tc.q)
+		req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+		p := ParsePagination(req, tc.maxLimit)
+		if p.Limit != tc.wantLimit || p.Offset != tc.wantOffset {
+			t.Fatalf("?%s -> %+v, want limit=%d offset=%d", tc.q, p, tc.wantLimit, tc.wantOffset)
+		}
+	}
+}
+
+func TestMethodNotAllowedSetsHeader(t *testing.T) {
+	rec := httptest.NewRecorder()
+	methodNotAllowed(rec, "GET")
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Header().Get("Allow"); got != "GET" {
+		t.Fatalf("Allow = %q", got)
+	}
+	if !strings.Contains(rec.Body.String(), "method-not-allowed") {
+		t.Fatalf("body missing problem type: %s", rec.Body.String())
+	}
+}
+
+func TestRegisterRoutesNoop(t *testing.T) {
+	// R1 ships the scaffold; later commits add handlers.
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, APIDeps{})
+	// A path not yet registered should 404 via the default mux behavior.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/schedules", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unregistered path should 404, got %d", rec.Code)
+	}
+}

--- a/internal/api/v1/upcoming.go
+++ b/internal/api/v1/upcoming.go
@@ -1,0 +1,236 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	extrrule "github.com/teambition/rrule-go"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+const (
+	defaultUpcomingHorizon = 24 * time.Hour
+	maxUpcomingHorizon     = 30 * 24 * time.Hour
+	defaultUpcomingLimit   = 100
+	maxUpcomingLimit       = 1000
+)
+
+// UpcomingFiring describes a single scheduled run in the horizon window.
+type UpcomingFiring struct {
+	ScheduleID string    `json:"schedule_id"`
+	TargetID   string    `json:"target_id"`
+	TemplateID *string   `json:"template_id,omitempty"`
+	FiresAt    time.Time `json:"fires_at"`
+}
+
+// UpcomingBlackout is a single occurrence of a blackout window that
+// intersects the horizon. Emitted so UIs can render shaded regions in
+// the calendar without re-expanding the rrule client-side.
+type UpcomingBlackout struct {
+	BlackoutID string    `json:"blackout_id"`
+	StartsAt   time.Time `json:"starts_at"`
+	EndsAt     time.Time `json:"ends_at"`
+}
+
+// UpcomingResponse is the GET /api/v1/schedules/upcoming body.
+type UpcomingResponse struct {
+	Items              []UpcomingFiring   `json:"items"`
+	HorizonEnd         time.Time          `json:"horizon_end"`
+	BlackoutsInHorizon []UpcomingBlackout `json:"blackouts_in_horizon"`
+}
+
+func (h *handlers) routeUpcoming(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, "GET")
+		return
+	}
+
+	q := r.URL.Query()
+	horizon := defaultUpcomingHorizon
+	if v := q.Get("horizon"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil || d <= 0 {
+			writeProblem(w, http.StatusBadRequest, "/problems/invalid-query",
+				"Invalid horizon", "must be a positive duration", nil)
+			return
+		}
+		if d > maxUpcomingHorizon {
+			d = maxUpcomingHorizon
+		}
+		horizon = d
+	}
+
+	limit := defaultUpcomingLimit
+	p := ParsePagination(r, maxUpcomingLimit)
+	if p.Limit > 0 {
+		limit = p.Limit
+	}
+
+	now := time.Now().UTC()
+	end := now.Add(horizon)
+
+	defaults := model.ScheduleDefaults{}
+	if h.deps.DefaultsStore != nil {
+		if d, err := h.deps.DefaultsStore.Get(r.Context()); err == nil && d != nil {
+			defaults = *d
+		}
+	}
+
+	var schedules []model.Schedule
+	var err error
+	if tgt := q.Get("target_id"); tgt != "" {
+		schedules, err = h.deps.ScheduleStore.ListByTarget(r.Context(), tgt)
+	} else {
+		schedules, err = h.deps.ScheduleStore.ListAll(r.Context())
+	}
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "/problems/store",
+			"Listing schedules failed", err.Error(), nil)
+		return
+	}
+
+	// Collect all firings. Paused schedules are skipped.
+	var firings []UpcomingFiring
+	for _, s := range schedules {
+		if !s.Enabled {
+			continue
+		}
+		tmpl := h.loadUpcomingTemplate(r.Context(), s.TemplateID)
+		occs, err := expandScheduleBetween(s, tmpl, defaults, now, end)
+		if err != nil {
+			continue
+		}
+		for _, occ := range occs {
+			firings = append(firings, UpcomingFiring{
+				ScheduleID: s.ID,
+				TargetID:   s.TargetID,
+				TemplateID: s.TemplateID,
+				FiresAt:    occ.UTC(),
+			})
+		}
+	}
+
+	sort.Slice(firings, func(i, j int) bool {
+		return firings[i].FiresAt.Before(firings[j].FiresAt)
+	})
+	if len(firings) > limit {
+		firings = firings[:limit]
+	}
+
+	// Blackouts inside the horizon.
+	blackouts := []UpcomingBlackout{}
+	if h.deps.BlackoutStore != nil {
+		all, berr := h.deps.BlackoutStore.List(r.Context())
+		if berr == nil {
+			for _, b := range all {
+				if !b.Enabled {
+					continue
+				}
+				occs, oerr := blackoutOccurrencesIn(b, now, end)
+				if oerr != nil {
+					continue
+				}
+				blackouts = append(blackouts, occs...)
+			}
+		}
+	}
+	sort.Slice(blackouts, func(i, j int) bool {
+		return blackouts[i].StartsAt.Before(blackouts[j].StartsAt)
+	})
+
+	if firings == nil {
+		firings = []UpcomingFiring{}
+	}
+	writeJSON(w, http.StatusOK, UpcomingResponse{
+		Items:              firings,
+		HorizonEnd:         end,
+		BlackoutsInHorizon: blackouts,
+	})
+}
+
+func (h *handlers) loadUpcomingTemplate(ctx context.Context, id *string) *model.Template {
+	if id == nil || *id == "" || h.deps.TemplateStore == nil {
+		return nil
+	}
+	t, err := h.deps.TemplateStore.Get(ctx, *id)
+	if err != nil {
+		return nil
+	}
+	return t
+}
+
+// expandScheduleBetween enumerates all occurrences of `s` between `from`
+// and `to` using the effective rrule / timezone from the cascade. A
+// thin re-implementation of intervalsched.expandSchedule (which is
+// private); duplicating the ~15 LOC is cheaper than elevating it.
+func expandScheduleBetween(s model.Schedule, tmpl *model.Template, defaults model.ScheduleDefaults, from, to time.Time) ([]time.Time, error) {
+	eff, err := model.ResolveEffectiveConfig(s, tmpl, defaults)
+	if err != nil {
+		return nil, err
+	}
+	loc, err := time.LoadLocation(eff.Timezone)
+	if err != nil {
+		return nil, fmt.Errorf("tz: %w", err)
+	}
+	opt, err := extrrule.StrToROption(eff.RRule)
+	if err != nil {
+		return nil, fmt.Errorf("rrule: %w", err)
+	}
+	if !s.DTStart.IsZero() {
+		opt.Dtstart = s.DTStart.In(loc)
+	} else if !opt.Dtstart.IsZero() {
+		opt.Dtstart = opt.Dtstart.In(loc)
+	} else {
+		opt.Dtstart = from.In(loc)
+	}
+	rule, err := extrrule.NewRRule(*opt)
+	if err != nil {
+		return nil, err
+	}
+	return rule.Between(from, to, true), nil
+}
+
+func blackoutOccurrencesIn(b model.BlackoutWindow, from, to time.Time) ([]UpcomingBlackout, error) {
+	loc, err := time.LoadLocation(b.Timezone)
+	if err != nil {
+		return nil, err
+	}
+	opt, err := extrrule.StrToROption(b.RRule)
+	if err != nil {
+		return nil, err
+	}
+	if opt.Dtstart.IsZero() {
+		opt.Dtstart = b.CreatedAt.In(loc)
+	} else {
+		opt.Dtstart = opt.Dtstart.In(loc)
+	}
+	rule, err := extrrule.NewRRule(*opt)
+	if err != nil {
+		return nil, err
+	}
+	dur := time.Duration(b.DurationSec) * time.Second
+	// Start the scan blackoutHorizonPast before `from` so an in-progress
+	// window whose start precedes the horizon still shows up.
+	lower := from.Add(-7 * 24 * time.Hour)
+	occs := rule.Between(lower, to, true)
+	out := make([]UpcomingBlackout, 0, len(occs))
+	for _, occ := range occs {
+		endAt := occ.Add(dur)
+		if endAt.Before(from) {
+			continue
+		}
+		if occ.After(to) {
+			break
+		}
+		out = append(out, UpcomingBlackout{
+			BlackoutID: b.ID,
+			StartsAt:   occ.UTC(),
+			EndsAt:     endAt.UTC(),
+		})
+	}
+	return out, nil
+}

--- a/internal/api/v1/upcoming_test.go
+++ b/internal/api/v1/upcoming_test.go
@@ -1,0 +1,91 @@
+package v1
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestUpcomingEmpty(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+
+	resp, raw := doJSON(t, srv, http.MethodGet, "/api/v1/schedules/upcoming", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+	var u UpcomingResponse
+	decode(t, raw, &u)
+	if u.Items == nil {
+		t.Fatalf("items must be non-nil slice, got nil")
+	}
+	if len(u.Items) != 0 {
+		t.Fatalf("expected 0 items on empty, got %d", len(u.Items))
+	}
+	if u.BlackoutsInHorizon == nil {
+		t.Fatalf("blackouts must be non-nil slice, got nil")
+	}
+}
+
+func TestUpcomingWithSchedule(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+	targetID := seedTarget(t, store, "example.com")
+
+	// A minutely schedule starting just before now — should produce
+	// many firings inside the default 24h horizon.
+	dtstart := time.Now().UTC().Add(-2 * time.Minute).Truncate(time.Second)
+	_, raw := doJSON(t, srv, http.MethodPost, "/api/v1/schedules", CreateScheduleRequest{
+		TargetID: targetID, Name: "every", Timezone: "UTC",
+		RRule:   "FREQ=HOURLY",
+		DTStart: dtstart,
+	})
+	var s ScheduleResponse
+	decode(t, raw, &s)
+
+	resp, raw := doJSON(t, srv, http.MethodGet, "/api/v1/schedules/upcoming?horizon=3h&limit=10", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+	var u UpcomingResponse
+	decode(t, raw, &u)
+	if len(u.Items) == 0 {
+		t.Fatalf("expected at least one firing in 3h horizon, got none (body=%s)", raw)
+	}
+	if u.Items[0].ScheduleID != s.ID {
+		t.Fatalf("wrong schedule id: %+v", u.Items[0])
+	}
+}
+
+func TestUpcomingSkipsPaused(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+	targetID := seedTarget(t, store, "example.com")
+
+	dtstart := time.Now().UTC().Add(-2 * time.Minute).Truncate(time.Second)
+	_, raw := doJSON(t, srv, http.MethodPost, "/api/v1/schedules", CreateScheduleRequest{
+		TargetID: targetID, Name: "x", Timezone: "UTC",
+		RRule: "FREQ=HOURLY", DTStart: dtstart,
+	})
+	var s ScheduleResponse
+	decode(t, raw, &s)
+
+	doJSON(t, srv, http.MethodPost, "/api/v1/schedules/"+s.ID+"/pause", nil)
+
+	_, raw = doJSON(t, srv, http.MethodGet, "/api/v1/schedules/upcoming?horizon=3h", nil)
+	var u UpcomingResponse
+	decode(t, raw, &u)
+	if len(u.Items) != 0 {
+		t.Fatalf("paused schedule should not appear; got %+v", u.Items)
+	}
+}
+
+func TestUpcomingRejectsInvalidHorizon(t *testing.T) {
+	store := newTestStore(t)
+	srv := newTestAPI(t, defaultAPIDeps(store))
+
+	resp, _ := doJSON(t, srv, http.MethodGet, "/api/v1/schedules/upcoming?horizon=-5m", nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("negative horizon should 400, got %d", resp.StatusCode)
+	}
+}

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	apiv1 "github.com/surfbot-io/surfbot-agent/internal/api/v1"
 	"github.com/surfbot-io/surfbot-agent/internal/detection"
 	"github.com/surfbot-io/surfbot-agent/internal/storage"
 )
@@ -93,6 +94,11 @@ func NewServer(store *storage.SQLiteStore, opts ServerOptions) (*http.Server, ne
 
 	// Schedule: GET config, PUT config
 	mux.HandleFunc("/api/v1/schedule", h.handleSchedule)
+
+	// SPEC-SCHED1.3a: REST API for first-class schedules. Registered
+	// before /api/v1/scans/ so the more specific /api/v1/scans/ad-hoc
+	// handler (from apiv1) takes precedence for that path.
+	registerV1Routes(mux, store, opts.Daemon)
 
 	// Scans: GET list, GET detail, POST trigger
 	mux.HandleFunc("/api/v1/scans", func(w http.ResponseWriter, r *http.Request) {
@@ -176,6 +182,29 @@ func NewServer(store *storage.SQLiteStore, opts ServerOptions) (*http.Server, ne
 	}
 
 	return srv, ln, nil
+}
+
+// registerV1Routes wires the SPEC-SCHED1.3a REST API onto mux. The
+// dispatcher slot is populated only when the caller plugged a live
+// AdHocDispatcher into the DaemonView — otherwise POST /scans/ad-hoc
+// returns 503 with the dispatcher-unreachable problem type, mirroring
+// the 1.2c /api/daemon/trigger fallback.
+func registerV1Routes(mux *http.ServeMux, store *storage.SQLiteStore, view *DaemonView) {
+	deps := apiv1.APIDeps{
+		Store:         store,
+		ScheduleStore: store.Schedules(),
+		TemplateStore: store.Templates(),
+		BlackoutStore: store.Blackouts(),
+		DefaultsStore: store.ScheduleDefaults(),
+		AdHocStore:    store.AdHocScanRuns(),
+	}
+	if view != nil && view.AdHocDispatcher != nil {
+		// webui.AdHocDispatcher and apiv1.Dispatcher have identical
+		// method sets; direct assignment wires the scheduler through
+		// without an adapter type.
+		deps.Dispatcher = view.AdHocDispatcher
+	}
+	apiv1.RegisterRoutes(mux, deps)
 }
 
 // isAssetPath reports whether a request path lives under one of the


### PR DESCRIPTION
## Summary

Implements SPEC-SCHED1.3a — the versioned REST API for first-class schedules. Ten commits, new package `internal/api/v1` with handlers for schedules / templates / blackouts / schedule-defaults / ad-hoc / upcoming / bulk. Routes registered in the webui HTTP mux. Additive only — existing endpoints (`/api/daemon/trigger`, `/api/v1/schedule`, etc.) untouched.

## What shipped

- **R1** — package scaffold: `ProblemResponse`, `PaginatedResponse[T]`, `APIDeps`, `Dispatcher` interface, `RegisterRoutes`.
- **R2** — schedules: `GET/POST/PUT/DELETE /api/v1/schedules[/{id}]`, `POST /schedules/{id}/pause|resume`, RRULE + overlap validation.
- **R3** — templates: CRUD + cascade recompute on update + 409-with-dependents vs `?force=true` cascade delete.
- **R4** — blackouts: CRUD + `?active_at=<rfc3339>` filter.
- **R5** — singleton schedule-defaults: `GET/PUT`.
- **R6** — canonical ad-hoc: `POST /api/v1/scans/ad-hoc` + `Dispatcher` interface + typed-error → Problem translation (busy/blackout/unreachable).
- **R7** — upcoming: `GET /api/v1/schedules/upcoming?horizon=&limit=&target_id=`, returns chronological firings + intersecting blackouts.
- **R8** — bulk: `POST /api/v1/schedules/bulk` with pause/resume/delete/clone atomicity via `storage.Transact`.
- **R9** — webui mux wiring: `registerV1Routes` in `internal/webui/server.go` plumbs `AdHocDispatcher` through when present, else `Dispatcher: nil` (503 path).
- **R10** — build-tagged integration test covering end-to-end CRUD, ad-hoc with stub dispatcher, and 503-when-no-dispatcher.

## Deviations from spec

1. **No separate daemon HTTP server.** The spec imagined a `internal/daemon/http.go` that the trigger endpoint lived in; the actual repo has no daemon-process HTTP mux — `internal/webui/server.go` is the only `*http.ServeMux`, and it is spun up by `surfbot ui` (non-daemon process) or the future combined UI+daemon process. I wired the v1 routes into the webui mux only. When `surfbot ui` runs without a live scheduler (the current default), the `Dispatcher` is nil and `POST /scans/ad-hoc` returns 503 with the `/problems/dispatcher-unreachable` problem type — matching the 1.2c `/api/daemon/trigger` fallback.
2. **Trigger endpoint untouched.** The 1.2c endpoint lives at `/api/daemon/trigger` (not `/api/v1/trigger` as the spec R6 text said). Left unmodified per the stop rule; 1.3b migrates CLI callers onto `/api/v1/scans/ad-hoc`.
3. **Hard delete, not soft delete.** Schema 0004 has no `deleted_at` column on `scan_schedules`. `DELETE` does a hard delete via the existing store. A soft-delete column is a future-compatible addition.
4. **Pause/resume map to `enabled`.** The model has `Enabled bool`, not `status + paused_at`. Response body exposes `status: "active"|"paused"` derived from `enabled`.
5. **OQ1 target_filter shape.** `CreateBlackoutRequest` exposes `target_id` (singular) per the 1.1 schema; no JSON `target_filter`. Rich filtering deferred to a future spec.
6. **OQ2 pagination.** Default `limit=50`, max `limit=500` (applies to most list endpoints; `upcoming` uses its own 100/1000 bounds).
7. **OQ3 webui ad-hoc routing.** Registered with 503 fallback (not 404) so the API shape is uniform across processes.
8. **Override auto-population.** `POST /schedules` with an explicit `rrule`/`timezone`/`maintenance_window` automatically adds the corresponding override to `Overrides[]`. Without this the CSS-cascade resolver would silently discard the caller's intent when the schedule has no template — a surprising UX. Explicit caller-supplied `overrides` are still honored (union).
9. **Next-run + cascade recompute only when `APIDeps.Expander` is non-nil.** In the webui process today the expander isn't wired; the master ticker computes `next_run_at` naturally after it observes the row. This is a pragmatic choice to keep the API layer independent of the scheduler's construction.

## Operator smoke (not blocking merge)

1. `curl -X POST localhost:8470/api/v1/templates -d '{"name":"t","rrule":"FREQ=DAILY"}'` — expect 201 with `id`; verify via `GET /api/v1/templates`.
2. Create a minutely schedule, wait ≤ 1 minute, check `scan_runs` via CLI.
3. `POST /api/v1/scans/ad-hoc` from a process with scheduler → 202; from `surfbot ui` alone → 503 with `/problems/dispatcher-unreachable`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -race`
- [x] `go test -tags=integration ./... -race`
- [x] `golangci-lint run`
- [ ] Operator smoke (listed above; PR merge doesn't block on it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)