### PR TITLE
SCHED1.4b: ui write flows + bulk ops + ad-hoc dispatcher

### DIFF
--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -1373,6 +1373,86 @@ tr.finding-detail-row td.finding-detail-cell {
 .error-banner ul { margin: 6px 0 0 18px; color: var(--text-secondary); font-size: 12px; }
 .error-banner .mono { color: var(--sev-critical); font-weight: 600; }
 
+/* SPEC-SCHED1.4b: form fields + inline errors. */
+.form-field { margin-bottom: 14px; }
+.form-label {
+  display: block;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+.form-required { color: var(--sev-critical); margin-left: 2px; }
+.form-help { font-size: 12px; color: var(--text-muted); margin-top: 4px; }
+.form-input-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+.field-error {
+  font-size: 12px;
+  color: var(--sev-critical);
+  margin-top: 4px;
+}
+
+/* Modal dialog (SCHED1.4b). */
+.modal-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.6);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 1000;
+}
+body.modal-open { overflow: hidden; }
+.modal {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 10px 30px rgba(0,0,0,0.4);
+  width: 100%;
+  max-width: 540px;
+  max-height: 90vh;
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.modal-lg { max-width: 780px; }
+.modal-sm { max-width: 420px; }
+.modal-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+}
+.modal-header h3 { margin: 0; font-size: 15px; }
+.modal-close {
+  background: transparent; border: 0; color: var(--text-secondary);
+  font-size: 20px; line-height: 1; cursor: pointer; padding: 4px 8px;
+}
+.modal-close:hover { color: var(--text-primary); }
+.modal-body { padding: 18px; overflow: auto; flex: 1; }
+.modal-footer {
+  display: flex; justify-content: flex-end; gap: 8px;
+  padding: 12px 18px;
+  border-top: 1px solid var(--border);
+}
+
+/* Bulk actions bar (SCHED1.4b). */
+.bulk-actions-bar {
+  position: sticky;
+  bottom: 0;
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border);
+  padding: 10px 14px;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px;
+  margin-top: 12px;
+  border-radius: var(--radius);
+  z-index: 10;
+}
+.bulk-actions-bar.hidden { display: none; }
+.bulk-actions-count { font-size: 13px; color: var(--text-secondary); }
+.bulk-actions-count strong { color: var(--text-primary); }
+.bulk-actions-buttons { display: flex; gap: 8px; }
+tr.row-selected { background: rgba(0,229,153,0.06); }
+
 /* Schedule/template/blackout detail grids reuse .detail-grid but the
  * rrule/JSON blocks benefit from a fixed-height scroll. */
 .json-block {

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -61,6 +61,7 @@
         </a></li>
       </ul>
       <div class="sidebar-footer">
+        <button type="button" class="btn btn-accent" id="nav-adhoc-btn" style="width:100%;margin-bottom:8px">Run scan now</button>
         <span class="agent-version" id="agent-version"></span>
       </div>
     </nav>
@@ -82,6 +83,7 @@
   <script src="/js/pages/templates.js"></script>
   <script src="/js/pages/blackouts.js"></script>
   <script src="/js/pages/settings_defaults.js"></script>
+  <script src="/js/pages/adhoc.js"></script>
   <script src="/js/app.js"></script>
 </body>
 </html>

--- a/internal/webui/static/js/api.js
+++ b/internal/webui/static/js/api.js
@@ -14,16 +14,7 @@ const API = {
 
   async get(path) {
     const resp = await fetch('/api/v1' + path, { headers: this._headers() });
-    if (!resp.ok) {
-      const err = await resp.json().catch(() => ({ error: resp.statusText }));
-      // SPEC-SCHED1.3a uses RFC 7807 problem+json (title/detail/type/
-      // field_errors); legacy handlers still return {error:"..."}. The
-      // thrown Error carries both shapes so callers can render either.
-      const e = new Error(err.error || err.title || err.detail || 'Request failed');
-      e.status = resp.status;
-      e.problem = err;
-      throw e;
-    }
+    if (!resp.ok) throw await makeAPIError(resp);
     return resp.json();
   },
 
@@ -31,11 +22,11 @@ const API = {
     const resp = await fetch('/api/v1' + path, {
       method: 'POST',
       headers: this._headers({ 'Content-Type': 'application/json' }),
-      body: JSON.stringify(body),
+      body: body == null ? undefined : JSON.stringify(body),
     });
-    const data = await resp.json().catch(() => ({ error: resp.statusText }));
-    if (!resp.ok) throw new Error(data.error || 'Request failed');
-    return data;
+    if (!resp.ok) throw await makeAPIError(resp);
+    if (resp.status === 204) return null;
+    return resp.json().catch(() => null);
   },
 
   async patch(path, body) {
@@ -44,9 +35,9 @@ const API = {
       headers: this._headers({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
     });
-    const data = await resp.json().catch(() => ({ error: resp.statusText }));
-    if (!resp.ok) throw new Error(data.error || 'Request failed');
-    return data;
+    if (!resp.ok) throw await makeAPIError(resp);
+    if (resp.status === 204) return null;
+    return resp.json().catch(() => null);
   },
 
   async put(path, body) {
@@ -55,16 +46,16 @@ const API = {
       headers: this._headers({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
     });
-    const data = await resp.json().catch(() => ({ error: resp.statusText }));
-    if (!resp.ok) throw new Error(data.error || data.errors ? JSON.stringify(data.errors) : 'Request failed');
-    return data;
+    if (!resp.ok) throw await makeAPIError(resp);
+    if (resp.status === 204) return null;
+    return resp.json().catch(() => null);
   },
 
   async del(path) {
     const resp = await fetch('/api/v1' + path, { method: 'DELETE', headers: this._headers() });
-    const data = await resp.json().catch(() => ({ error: resp.statusText }));
-    if (!resp.ok) throw new Error(data.error || 'Request failed');
-    return data;
+    if (!resp.ok) throw await makeAPIError(resp);
+    if (resp.status === 204) return null;
+    return resp.json().catch(() => null);
   },
 
   // Read endpoints
@@ -91,7 +82,36 @@ const API = {
   getBlackout(id)       { return this.get('/blackouts/' + encodeURIComponent(id)); },
   getScheduleDefaults() { return this.get('/schedule-defaults'); },
 
-  // Write endpoints
+  // --- SPEC-SCHED1.4b write methods ---
+  // Every method throws an APIError on 4xx/5xx (see makeAPIError below).
+  // Callers read .status / .code / .fieldErrors / .problem and render
+  // inline via Components.applyFieldErrors, or as a banner via
+  // Components.errorBanner. The .code field is set for Problem types the
+  // ad-hoc dispatcher modal wants to react to specifically.
+
+  createSchedule(body)      { return this.post('/schedules', body); },
+  updateSchedule(id, body)  { return this.put('/schedules/' + encodeURIComponent(id), body); },
+  deleteSchedule(id)        { return this.del('/schedules/' + encodeURIComponent(id)); },
+  pauseSchedule(id)         { return this.post('/schedules/' + encodeURIComponent(id) + '/pause'); },
+  resumeSchedule(id)        { return this.post('/schedules/' + encodeURIComponent(id) + '/resume'); },
+  bulkSchedules(body)       { return this.post('/schedules/bulk', body); },
+
+  createTemplate(body)      { return this.post('/templates', body); },
+  updateTemplate(id, body)  { return this.put('/templates/' + encodeURIComponent(id), body); },
+  deleteTemplate(id, opts)  {
+    const q = opts && opts.force ? '?force=true' : '';
+    return this.del('/templates/' + encodeURIComponent(id) + q);
+  },
+
+  createBlackout(body)      { return this.post('/blackouts', body); },
+  updateBlackout(id, body)  { return this.put('/blackouts/' + encodeURIComponent(id), body); },
+  deleteBlackout(id)        { return this.del('/blackouts/' + encodeURIComponent(id)); },
+
+  updateDefaults(body)      { return this.put('/schedule-defaults', body); },
+
+  createAdHocScan(body)     { return this.post('/scans/ad-hoc', body); },
+
+  // Legacy write endpoints (non-schedule resources).
   createTarget(value, type, scope) {
     return this.post('/targets', { value, type: type || '', scope: scope || 'external' });
   },
@@ -126,4 +146,39 @@ function toQuery(params) {
   const entries = Object.entries(params).filter(([, v]) => v != null && v !== '');
   if (entries.length === 0) return '';
   return '?' + entries.map(([k, v]) => encodeURIComponent(k) + '=' + encodeURIComponent(v)).join('&');
+}
+
+// makeAPIError parses a failed Response into a rich Error object. The
+// 1.3a API returns RFC 7807 application/problem+json with title/detail/
+// type/field_errors; 1.4a legacy handlers and non-v1 routes may still
+// return {error:"..."}. The thrown object has:
+//   .message       — best human-readable line
+//   .status        — HTTP status
+//   .problem       — the parsed body (either shape)
+//   .fieldErrors   — alias for problem.field_errors (array of {field,message})
+//   .code          — symbolic code derived from problem.type for the
+//                    handful of dispatcher/bulk scenarios the UI cares
+//                    about (DISPATCHER_UNREACHABLE / TARGET_BUSY /
+//                    IN_BLACKOUT / VALIDATION / NOT_FOUND / CONFLICT)
+async function makeAPIError(resp) {
+  const body = await resp.json().catch(() => ({ error: resp.statusText }));
+  const e = new Error(body.title || body.error || body.detail || ('HTTP ' + resp.status));
+  e.status = resp.status;
+  e.problem = body;
+  e.fieldErrors = body.field_errors || [];
+  e.code = codeFromProblem(body, resp.status);
+  return e;
+}
+
+function codeFromProblem(body, status) {
+  const type = (body && body.type) || '';
+  if (type === '/problems/dispatcher-unreachable' || status === 503) return 'DISPATCHER_UNREACHABLE';
+  if (type === '/problems/target-busy') return 'TARGET_BUSY';
+  if (type === '/problems/in-blackout') return 'IN_BLACKOUT';
+  if (type === '/problems/template-in-use') return 'TEMPLATE_IN_USE';
+  if (type === '/problems/overlap') return 'OVERLAP';
+  if (type === '/problems/validation' || status === 422) return 'VALIDATION';
+  if (type === '/problems/not-found' || status === 404) return 'NOT_FOUND';
+  if (type === '/problems/already-exists' || status === 409) return 'CONFLICT';
+  return '';
 }

--- a/internal/webui/static/js/app.js
+++ b/internal/webui/static/js/app.js
@@ -79,4 +79,12 @@ window.addEventListener('hashchange', () => Router.navigate());
 document.addEventListener('DOMContentLoaded', () => {
   Router.navigate();
   loadSidebarBadge();
+
+  // SPEC-SCHED1.4b R9: "Run scan now" opens the ad-hoc dispatcher
+  // modal. The button is in the sidebar footer; wired once at load so
+  // it works across all hash routes without re-binding on navigate.
+  const adhocBtn = document.getElementById('nav-adhoc-btn');
+  if (adhocBtn && typeof AdHocPage !== 'undefined') {
+    adhocBtn.addEventListener('click', () => AdHocPage.open());
+  }
 });

--- a/internal/webui/static/js/components.js
+++ b/internal/webui/static/js/components.js
@@ -197,7 +197,309 @@ const Components = {
     const cls = status === 'active' ? 'badge-info' : 'badge-muted';
     return `<span class="badge ${cls}">${escapeHtml(status || '-')}</span>`;
   },
+
+  // --- SPEC-SCHED1.4b: form, modal, confirm, bulk helpers ---
+  //
+  // Field renderers return HTML strings to match the existing Components
+  // convention. modal() and confirmDialog() own DOM because they mount
+  // outside the #app container and need lifecycle control.
+  //
+  // Form fields carry a dedicated .field-error sibling selected by name=
+  // so applyFieldErrors can populate per-field messages from a 1.3a
+  // ProblemResponse without the caller threading them through render.
+
+  formInput({ label, name, type, value, error, required, placeholder, help }) {
+    const reqMark = required ? ' <span class="form-required">*</span>' : '';
+    const v = value == null ? '' : String(value);
+    const helpHtml = help ? `<div class="form-help">${escapeHtml(help)}</div>` : '';
+    return `<div class="form-field" data-field="${escapeHtml(name)}">
+      <label class="form-label" for="f-${escapeHtml(name)}">${escapeHtml(label)}${reqMark}</label>
+      <input class="form-input" id="f-${escapeHtml(name)}" name="${escapeHtml(name)}"
+        type="${escapeHtml(type || 'text')}"
+        ${required ? 'required' : ''}
+        ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ''}
+        value="${escapeHtml(v)}">
+      ${helpHtml}
+      <div class="field-error" data-field-error="${escapeHtml(name)}" style="display:${error ? 'block' : 'none'}">${escapeHtml(error || '')}</div>
+    </div>`;
+  },
+
+  formSelect({ label, name, options, value, error, required }) {
+    const reqMark = required ? ' <span class="form-required">*</span>' : '';
+    const opts = (options || []).map(o => {
+      const val = typeof o === 'string' ? o : o.value;
+      const lab = typeof o === 'string' ? o : (o.label || o.value);
+      const sel = String(val) === String(value || '') ? ' selected' : '';
+      return `<option value="${escapeHtml(val)}"${sel}>${escapeHtml(lab)}</option>`;
+    }).join('');
+    return `<div class="form-field" data-field="${escapeHtml(name)}">
+      <label class="form-label" for="f-${escapeHtml(name)}">${escapeHtml(label)}${reqMark}</label>
+      <select class="filter-select" id="f-${escapeHtml(name)}" name="${escapeHtml(name)}" ${required ? 'required' : ''}>
+        ${opts}
+      </select>
+      <div class="field-error" data-field-error="${escapeHtml(name)}" style="display:${error ? 'block' : 'none'}">${escapeHtml(error || '')}</div>
+    </div>`;
+  },
+
+  formTextarea({ label, name, value, rows, error, monospace, help, placeholder }) {
+    const cls = 'form-input' + (monospace ? ' form-input-mono' : '');
+    const helpHtml = help ? `<div class="form-help">${escapeHtml(help)}</div>` : '';
+    return `<div class="form-field" data-field="${escapeHtml(name)}">
+      <label class="form-label" for="f-${escapeHtml(name)}">${escapeHtml(label)}</label>
+      <textarea class="${cls}" id="f-${escapeHtml(name)}" name="${escapeHtml(name)}"
+        rows="${rows || 4}"
+        ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ''}
+      >${escapeHtml(value == null ? '' : String(value))}</textarea>
+      ${helpHtml}
+      <div class="field-error" data-field-error="${escapeHtml(name)}" style="display:${error ? 'block' : 'none'}">${escapeHtml(error || '')}</div>
+    </div>`;
+  },
+
+  // formDatetime accepts a value in either ISO-8601 (API shape) or the
+  // native datetime-local format ("YYYY-MM-DDTHH:MM"). On submit callers
+  // convert the field's value to ISO via `new Date(val).toISOString()`.
+  formDatetime({ label, name, value, error, required }) {
+    const local = toDatetimeLocal(value);
+    return Components.formInput({
+      label, name,
+      type: 'datetime-local',
+      value: local,
+      error, required,
+    });
+  },
+
+  // rruleField wraps formInput with a non-blocking client-side syntax
+  // check. The server's 422 is the source of truth; the warning just
+  // catches obvious typos before the round-trip.
+  rruleField({ label, name, value, error }) {
+    const html = Components.formInput({
+      label, name, type: 'text', value, error,
+      required: true,
+      placeholder: 'FREQ=DAILY;BYHOUR=2',
+    });
+    // The inline warning span is revealed by rruleAttachBlurCheck when
+    // the form is mounted. Named by convention (rrule-warning-<name>).
+    return html + `<div class="rrule-warning" data-rrule-warning-for="${escapeHtml(name)}" style="display:none;font-size:12px;color:var(--sev-medium);margin-top:4px">RRULE syntax looks off — server will validate.</div>`;
+  },
+
+  // rruleAttachBlurCheck wires the client-side check after the form is
+  // in the DOM. Call once per form in the modal onOpen callback.
+  rruleAttachBlurCheck(formEl, fieldName) {
+    if (!formEl) return;
+    const input = formEl.querySelector(`input[name="${fieldName}"]`);
+    const warn = formEl.querySelector(`[data-rrule-warning-for="${fieldName}"]`);
+    if (!input || !warn) return;
+    input.addEventListener('blur', () => {
+      const v = input.value.trim();
+      if (!v) { warn.style.display = 'none'; return; }
+      const ok = /FREQ=(SECONDLY|MINUTELY|HOURLY|DAILY|WEEKLY|MONTHLY|YEARLY)\b/.test(v);
+      warn.style.display = ok ? 'none' : 'block';
+    });
+  },
+
+  // modal mounts a dialog as a direct child of <body> with a backdrop.
+  // Returns { close } so the caller can dismiss programmatically on
+  // successful submit. primaryAction / secondaryAction accept
+  // { label, onClick, danger }; onClick may return a Promise for a
+  // loading spinner. Esc key and backdrop click dismiss the modal and
+  // invoke onClose with reason='dismiss'.
+  modal({ title, body, primaryAction, secondaryAction, onClose, size }) {
+    const root = document.createElement('div');
+    root.className = 'modal-backdrop';
+    root.tabIndex = -1;
+    root.innerHTML = `
+      <div class="modal modal-${size || 'md'}" role="dialog" aria-modal="true" aria-label="${escapeHtml(title || '')}">
+        <div class="modal-header">
+          <h3>${escapeHtml(title || '')}</h3>
+          <button type="button" class="modal-close" aria-label="Close">&times;</button>
+        </div>
+        <div class="modal-body">${body || ''}</div>
+        <div class="modal-footer">
+          ${secondaryAction ? `<button type="button" class="btn btn-ghost" data-modal-secondary>${escapeHtml(secondaryAction.label)}</button>` : ''}
+          ${primaryAction ? `<button type="button" class="btn ${primaryAction.danger ? 'btn-danger' : 'btn-primary'}" data-modal-primary>${escapeHtml(primaryAction.label)}</button>` : ''}
+        </div>
+      </div>
+    `;
+    document.body.appendChild(root);
+    document.body.classList.add('modal-open');
+
+    let closed = false;
+    function close(reason) {
+      if (closed) return;
+      closed = true;
+      document.body.classList.remove('modal-open');
+      document.removeEventListener('keydown', onKey);
+      root.remove();
+      if (typeof onClose === 'function') onClose(reason || 'close');
+    }
+    function onKey(e) {
+      if (e.key === 'Escape') close('dismiss');
+    }
+    document.addEventListener('keydown', onKey);
+
+    root.addEventListener('click', (e) => {
+      if (e.target === root) close('dismiss');
+    });
+    root.querySelector('.modal-close').addEventListener('click', () => close('dismiss'));
+
+    const secBtn = root.querySelector('[data-modal-secondary]');
+    if (secBtn && secondaryAction) {
+      secBtn.addEventListener('click', async () => {
+        try {
+          const r = secondaryAction.onClick ? secondaryAction.onClick({ close, root }) : undefined;
+          if (r && typeof r.then === 'function') await r;
+        } finally {
+          // Secondary defaults to "just close" unless onClick kept it
+          // open explicitly by not calling close.
+          if (!secondaryAction.keepOpen) close('secondary');
+        }
+      });
+    }
+
+    const primBtn = root.querySelector('[data-modal-primary]');
+    if (primBtn && primaryAction) {
+      primBtn.addEventListener('click', async () => {
+        primBtn.disabled = true;
+        const origLabel = primBtn.textContent;
+        primBtn.textContent = '…';
+        try {
+          const r = primaryAction.onClick ? primaryAction.onClick({ close, root }) : undefined;
+          if (r && typeof r.then === 'function') await r;
+        } catch (_) {
+          // onClick is responsible for showing errors in the body.
+        } finally {
+          primBtn.disabled = false;
+          primBtn.textContent = origLabel;
+        }
+      });
+    }
+
+    // Autofocus the first input in the body, if any.
+    setTimeout(() => {
+      const first = root.querySelector('input,select,textarea,button[data-modal-primary]');
+      if (first) first.focus();
+    }, 0);
+
+    return { close, root };
+  },
+
+  // confirmDialog wraps modal for destructive yes/no prompts. Resolves
+  // true when primary is clicked, false on dismiss / secondary.
+  confirmDialog({ title, message, confirmLabel, danger }) {
+    return new Promise((resolve) => {
+      let decided = false;
+      const m = Components.modal({
+        title: title || 'Confirm',
+        body: `<p>${escapeHtml(message || '')}</p>`,
+        primaryAction: {
+          label: confirmLabel || 'Confirm',
+          danger: !!danger,
+          onClick: ({ close }) => {
+            decided = true;
+            resolve(true);
+            close('confirm');
+          },
+        },
+        secondaryAction: { label: 'Cancel' },
+        onClose: (reason) => {
+          if (!decided) resolve(false);
+        },
+      });
+      void m;
+    });
+  },
+
+  // applyFieldErrors clears every .field-error inside the form, then
+  // writes each problem.field_errors entry into the matching name=
+  // field's error span. Unknown field names surface in a generic
+  // banner at the top of the form (data-field-error="__general__").
+  applyFieldErrors(formEl, fieldErrors) {
+    if (!formEl) return;
+    formEl.querySelectorAll('.field-error').forEach(el => {
+      el.textContent = '';
+      el.style.display = 'none';
+    });
+    if (!fieldErrors || !fieldErrors.length) return;
+    const general = [];
+    fieldErrors.forEach(fe => {
+      const span = formEl.querySelector(`[data-field-error="${cssEscape(fe.field)}"]`);
+      if (span) {
+        span.textContent = fe.message;
+        span.style.display = 'block';
+      } else {
+        general.push(`${fe.field}: ${fe.message}`);
+      }
+    });
+    if (general.length) {
+      const gen = formEl.querySelector('[data-field-error="__general__"]');
+      if (gen) {
+        gen.textContent = general.join('; ');
+        gen.style.display = 'block';
+      }
+    }
+  },
+
+  // bulkActionsBar renders a sticky bottom bar with a selection count
+  // and action buttons. The caller mounts it once and toggles visibility
+  // via .hidden based on selection state.
+  bulkActionsBar({ selectedCount, actions }) {
+    const hidden = selectedCount > 0 ? '' : ' hidden';
+    const btns = (actions || []).map((a, i) => {
+      const cls = a.danger ? 'btn btn-danger' : 'btn btn-ghost';
+      return `<button type="button" class="${cls}" data-bulk-action="${i}">${escapeHtml(a.label)}</button>`;
+    }).join(' ');
+    return `<div class="bulk-actions-bar${hidden}">
+      <span class="bulk-actions-count"><strong>${selectedCount}</strong> selected</span>
+      <span class="bulk-actions-buttons">${btns}</span>
+    </div>`;
+  },
 };
+
+// toDatetimeLocal converts an ISO-8601 / Date value to the native
+// datetime-local format ("YYYY-MM-DDTHH:MM") the input expects. Returns
+// an empty string if `v` is nullish or unparseable.
+function toDatetimeLocal(v) {
+  if (!v) return '';
+  const d = new Date(v);
+  if (isNaN(d.getTime())) return typeof v === 'string' ? v : '';
+  const pad = (n) => String(n).padStart(2, '0');
+  return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate())
+    + 'T' + pad(d.getHours()) + ':' + pad(d.getMinutes());
+}
+
+// cssEscape quotes a string for use in a CSS attribute selector. Light
+// polyfill for CSS.escape; sufficient for dotted tool_config.* paths.
+function cssEscape(s) {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') return CSS.escape(s);
+  return String(s).replace(/(["\\])/g, '\\$1');
+}
+
+// Demo — invocation shapes for the 1.4b helpers. Not executed; kept as
+// a human-readable quick reference so the next maintainer doesn't have
+// to chase call sites.
+//
+//   Components.formInput({label:'Name', name:'name', required:true})
+//   Components.formSelect({label:'Status', name:'status',
+//     options:[{value:'active',label:'Active'},{value:'paused',label:'Paused'}],
+//     value:'active'})
+//   Components.formTextarea({label:'Tool config', name:'tool_config',
+//     monospace:true, rows:8})
+//   Components.formDatetime({label:'Starts at', name:'dtstart', required:true})
+//   Components.rruleField({label:'RRULE', name:'rrule', value:'FREQ=DAILY'})
+//   const m = Components.modal({
+//     title:'New schedule',
+//     body:'<form id="f">...</form>',
+//     primaryAction:{label:'Create', onClick: async ({close}) => {
+//       try { await API.createSchedule(body); close(); }
+//       catch (err) { Components.applyFieldErrors(document.getElementById('f'), err.fieldErrors); }
+//     }},
+//     secondaryAction:{label:'Cancel'},
+//   })
+//   const ok = await Components.confirmDialog({
+//     title:'Delete schedule?', message:'Cannot be undone.', danger:true})
+//   Components.bulkActionsBar({selectedCount:2, actions:[
+//     {label:'Pause', onClick: ...},
+//     {label:'Delete', danger:true, onClick: ...}]})
 
 function toggleTreeNode(el) {
   const children = el.nextElementSibling;

--- a/internal/webui/static/js/pages/adhoc.js
+++ b/internal/webui/static/js/pages/adhoc.js
@@ -1,0 +1,186 @@
+// SPEC-SCHED1.4b R9: Ad-hoc dispatcher modal.
+//
+// Triggered by the "Run scan now" button in the sidebar. The modal hits
+// POST /api/v1/scans/ad-hoc with {target_id, reason?, tool_config_override?}
+// and renders either the 202 success view (with the returned scan_id) or
+// a typed error message derived from the Problem `type` (TARGET_BUSY,
+// IN_BLACKOUT, DISPATCHER_UNREACHABLE). Target picker is free-text —
+// targets-page integration lands in 1.4c (spec non-goal N3).
+
+const AdHocPage = {
+  open() {
+    const body = this.formBody({});
+    const m = Components.modal({
+      title: 'Run scan now',
+      body,
+      size: 'md',
+      primaryAction: {
+        label: 'Dispatch',
+        onClick: async ({ close, root }) => {
+          const form = root.querySelector('#adhoc-form');
+          const data = readAdHocForm(form);
+          if (!data) return;
+          try {
+            const resp = await API.createAdHocScan(data);
+            swapToSuccessView(root, resp);
+          } catch (err) {
+            showAdHocFormError(root, form, err);
+          }
+        },
+      },
+      secondaryAction: { label: 'Close' },
+    });
+    return m;
+  },
+
+  // formBody is exported so the success view's "Run another" button can
+  // restore the original form markup after a successful dispatch.
+  formBody(preset) {
+    const p = preset || {};
+    return `
+      <form id="adhoc-form" novalidate>
+        <div class="field-error" data-field-error="__general__" style="display:none;margin-bottom:12px;padding:8px 12px;background:var(--sev-critical-bg);border-radius:var(--radius)"></div>
+        ${Components.formInput({
+          label: 'Target ID', name: 'target_id', value: p.target_id || '', required: true,
+          placeholder: 'UUID from /targets',
+          help: 'Free-text target ID. Picker ships in 1.4c.',
+        })}
+        ${Components.formInput({ label: 'Template ID', name: 'template_id', value: p.template_id || '',
+          help: 'Optional. If set, the template\'s tool_config is used (overlaid with the override below).' })}
+        ${Components.formInput({ label: 'Reason', name: 'reason', value: p.reason || '',
+          placeholder: 'e.g. manual re-run after infra change' })}
+        ${Components.formTextarea({
+          label: 'Tool config override (JSON)', name: 'tool_config_override',
+          value: p.tool_config_override || '', rows: 6, monospace: true,
+          help: 'Optional. Leave blank to let the server auto-populate from the target/template.',
+        })}
+      </form>
+    `;
+  },
+};
+
+function readAdHocForm(form) {
+  if (!form) return null;
+  const fd = new FormData(form);
+  const out = {
+    target_id: (fd.get('target_id') || '').toString().trim(),
+    reason: (fd.get('reason') || '').toString().trim(),
+  };
+  if (!out.target_id) {
+    Components.applyFieldErrors(form, [{ field: 'target_id', message: 'required' }]);
+    return null;
+  }
+  if (!out.reason) delete out.reason;
+  const tmpl = (fd.get('template_id') || '').toString().trim();
+  if (tmpl) out.template_id = tmpl;
+
+  const rawOverride = (fd.get('tool_config_override') || '').toString().trim();
+  if (rawOverride) {
+    let parsed;
+    try { parsed = JSON.parse(rawOverride); }
+    catch (err) {
+      Components.applyFieldErrors(form, [{ field: 'tool_config_override', message: 'Invalid JSON: ' + err.message }]);
+      return null;
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      Components.applyFieldErrors(form, [{ field: 'tool_config_override', message: 'Must be a JSON object' }]);
+      return null;
+    }
+    out.tool_config_override = parsed;
+  }
+  return out;
+}
+
+// showAdHocFormError maps code → tailored message; non-typed errors fall
+// back to the generic field-error / banner path.
+function showAdHocFormError(root, form, err) {
+  // Typed problem types get their own body swap so the operator sees a
+  // clear message instead of a generic banner.
+  if (err && err.code === 'DISPATCHER_UNREACHABLE') {
+    showAdHocBanner(root, form, 'Daemon dispatcher is not reachable. Is the daemon running?');
+    return;
+  }
+  if (err && err.code === 'TARGET_BUSY') {
+    showAdHocBanner(root, form, 'Target is already being scanned. Try again when the current scan finishes.');
+    return;
+  }
+  if (err && err.code === 'IN_BLACKOUT') {
+    showAdHocBanner(root, form, 'Target is inside an active blackout window. Try again later.');
+    return;
+  }
+  if (err && err.fieldErrors && err.fieldErrors.length) {
+    Components.applyFieldErrors(form, err.fieldErrors);
+    return;
+  }
+  const general = form.querySelector('[data-field-error="__general__"]');
+  if (general) {
+    const title = (err && err.problem && err.problem.title) || (err && err.message) || 'Request failed';
+    const detail = err && err.problem && err.problem.detail ? ' — ' + err.problem.detail : '';
+    general.textContent = title + detail;
+    general.style.display = 'block';
+  }
+}
+
+function showAdHocBanner(root, form, message) {
+  const general = form.querySelector('[data-field-error="__general__"]');
+  if (general) {
+    general.textContent = message;
+    general.style.display = 'block';
+  }
+}
+
+function swapToSuccessView(root, resp) {
+  const body = root.querySelector('.modal-body');
+  if (!body) return;
+  const scanHtml = resp.scan_id
+    ? `<div><span class="detail-label">Scan ID</span><br><span class="mono">${escapeHtml(resp.scan_id)}</span></div>`
+    : '<div class="text-muted">Scan ID pending — poll <code class="mono">ad_hoc_scan_runs</code> by the run ID below.</div>';
+  body.innerHTML = `
+    <div class="card" style="border-color:var(--success)">
+      <div class="card-label" style="color:var(--success)">Dispatched ✓</div>
+      <div style="margin-top:8px">
+        <span class="detail-label">Ad-hoc run ID</span><br>
+        <span class="mono">${escapeHtml(resp.ad_hoc_run_id)}</span>
+      </div>
+      <div style="margin-top:12px">${scanHtml}</div>
+    </div>
+    <button type="button" class="btn btn-ghost" id="adhoc-run-another" style="margin-top:12px">Run another</button>
+  `;
+  // Replace primary button with Close so the "Dispatch" spinner state
+  // doesn't linger on the success view.
+  const footer = root.querySelector('.modal-footer');
+  if (footer) {
+    const primary = footer.querySelector('[data-modal-primary]');
+    if (primary) primary.remove();
+  }
+  const another = body.querySelector('#adhoc-run-another');
+  if (another) another.addEventListener('click', () => {
+    body.innerHTML = AdHocPage.formBody({});
+    // Re-add the Dispatch button.
+    if (footer && !footer.querySelector('[data-modal-primary]')) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'btn btn-primary';
+      btn.dataset.modalPrimary = '';
+      btn.textContent = 'Dispatch';
+      footer.appendChild(btn);
+      btn.addEventListener('click', async () => {
+        btn.disabled = true; btn.textContent = '…';
+        try {
+          const form = document.getElementById('adhoc-form');
+          const data = readAdHocForm(form);
+          if (!data) { btn.disabled = false; btn.textContent = 'Dispatch'; return; }
+          try {
+            const resp2 = await API.createAdHocScan(data);
+            swapToSuccessView(root, resp2);
+          } catch (err) {
+            showAdHocFormError(root, form, err);
+            btn.disabled = false; btn.textContent = 'Dispatch';
+          }
+        } catch (_) {
+          btn.disabled = false; btn.textContent = 'Dispatch';
+        }
+      });
+    }
+  });
+}

--- a/internal/webui/static/js/pages/blackouts.js
+++ b/internal/webui/static/js/pages/blackouts.js
@@ -46,12 +46,17 @@ const BlackoutsPage = {
       </form>
     `;
 
+    const headerActions = '<div style="margin-left:auto"><button type="button" class="btn btn-primary" id="blackouts-new">New blackout</button></div>';
+
     if (items.length === 0) {
       const hint = f.activeOnly
         ? 'No blackouts are active right now.'
-        : 'No blackout windows defined. Create one via CLI: <code class="mono">surfbot blackout create --name \'...\' --rrule \'...\' --duration 3600</code>';
+        : 'No blackout windows defined. Click <strong>New blackout</strong> above or use <code class="mono">surfbot blackout create</code>.';
       return `
-        <div class="page-header"><h2>Blackout windows</h2></div>
+        <div class="page-header">
+          <h2>Blackout windows</h2>
+          ${headerActions}
+        </div>
         ${filterBar}
         ${Components.emptyState('No blackouts', hint)}
       `;
@@ -84,6 +89,7 @@ const BlackoutsPage = {
       <div class="page-header">
         <h2>Blackout windows</h2>
         <p>${total} window${total === 1 ? '' : 's'}${f.activeOnly ? ' active at ' + escapeHtml(nowIso) : ''}</p>
+        ${headerActions}
       </div>
       ${filterBar}
       ${Components.table(
@@ -115,12 +121,15 @@ const BlackoutsPage = {
 
   bindEvents() {
     const form = document.getElementById('blackouts-filters');
-    if (!form) return;
-    form.addEventListener('submit', (e) => {
-      e.preventDefault();
-      const activeOnly = document.getElementById('filter-active-only').checked;
-      location.hash = activeOnly ? '#/blackouts?active_only=1' : '#/blackouts';
-    });
+    if (form) {
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const activeOnly = document.getElementById('filter-active-only').checked;
+        location.hash = activeOnly ? '#/blackouts?active_only=1' : '#/blackouts';
+      });
+    }
+    const newBtn = document.getElementById('blackouts-new');
+    if (newBtn) newBtn.addEventListener('click', () => this.openCreateForm());
   },
 
   // --- Blackout detail ---
@@ -133,12 +142,21 @@ const BlackoutsPage = {
     try {
       const b = await API.getBlackout(id);
       app.innerHTML = this.detailTemplate(b);
+      this.bindDetailActions(app, b);
     } catch (err) {
       app.innerHTML = `
         ${Components.backLink('#/blackouts', 'Back to blackouts')}
         ${Components.errorBanner(err)}
       `;
     }
+  },
+
+  bindDetailActions(app, b) {
+    const editBtn = document.getElementById('blackout-edit-btn');
+    if (editBtn) editBtn.addEventListener('click', () => this.openEditForm(app, b));
+
+    const delBtn = document.getElementById('blackout-delete-btn');
+    if (delBtn) delBtn.addEventListener('click', () => this.confirmDelete(app, b));
   },
 
   detailTemplate(b) {
@@ -154,7 +172,12 @@ const BlackoutsPage = {
             <h2>${escapeHtml(b.name || b.id)}</h2>
             <span class="badge badge-muted">${escapeHtml(b.scope || '-')}</span>
             ${b.enabled ? '<span style="color:var(--success);margin-left:8px">enabled</span>' : '<span class="text-muted" style="margin-left:8px">disabled</span>'}
+            <div style="margin-left:auto;display:flex;gap:8px">
+              <button type="button" class="btn btn-ghost" id="blackout-edit-btn">Edit</button>
+              <button type="button" class="btn btn-danger" id="blackout-delete-btn">Delete</button>
+            </div>
           </div>
+          <div id="blackout-action-error" style="margin-top:8px"></div>
           <div class="detail-grid" style="margin-top:12px">
             <span class="detail-label">ID</span><span class="detail-value mono">${escapeHtml(b.id)}</span>
             <span class="detail-label">Scope</span><span class="detail-value mono">${escapeHtml(b.scope || '-')}</span>
@@ -178,4 +201,163 @@ const BlackoutsPage = {
       </div>
     `;
   },
+
+  // --- SPEC-SCHED1.4b: blackout create / edit / delete ---
+  //
+  // The 1.3a API (OQ3) carries a `scope` ("global"|"target") plus a
+  // single optional `target_id` — NOT a `target_ids` array as the 1.4b
+  // spec draft implied. To target multiple IDs the operator creates
+  // multiple blackouts. Duration is rendered as hours + minutes +
+  // seconds inputs and serialized to a single `duration_seconds`.
+
+  openCreateForm() {
+    this.openForm({
+      mode: 'create',
+      onSaved: () => BlackoutsPage.render(document.getElementById('app'), {}),
+    });
+  },
+
+  openEditForm(app, b) {
+    this.openForm({
+      mode: 'edit',
+      blackout: b,
+      onSaved: () => BlackoutsPage.renderDetail(app, b.id),
+    });
+  },
+
+  openForm({ mode, blackout, onSaved }) {
+    const b = blackout || {};
+    const secs = Math.max(0, b.duration_seconds || 0);
+    const hours = Math.floor(secs / 3600);
+    const mins = Math.floor((secs % 3600) / 60);
+    const remSecs = secs % 60;
+
+    const body = `
+      <form id="blackout-form" novalidate>
+        <div class="field-error" data-field-error="__general__" style="display:none;margin-bottom:12px;padding:8px 12px;background:var(--sev-critical-bg);border-radius:var(--radius)"></div>
+        ${Components.formInput({ label: 'Name', name: 'name', value: b.name, required: true })}
+        ${Components.formSelect({
+          label: 'Scope', name: 'scope',
+          options: [{ value: 'global', label: 'Global (all targets)' }, { value: 'target', label: 'Single target' }],
+          value: b.scope || 'global',
+          required: true,
+        })}
+        ${Components.formInput({
+          label: 'Target ID', name: 'target_id', value: b.target_id || '',
+          help: 'Required when scope is "Single target"; ignored when scope is "Global".',
+        })}
+        ${Components.rruleField({ label: 'RRULE', name: 'rrule', value: b.rrule })}
+        ${Components.formInput({ label: 'Timezone', name: 'timezone', value: b.timezone || 'UTC' })}
+        <div class="form-field" data-field="duration_seconds">
+          <label class="form-label">Duration <span class="form-required">*</span></label>
+          <div style="display:flex;gap:8px">
+            <input class="form-input" name="dur_h" type="number" min="0" value="${hours}" placeholder="h" style="flex:1">
+            <input class="form-input" name="dur_m" type="number" min="0" max="59" value="${mins}" placeholder="m" style="flex:1">
+            <input class="form-input" name="dur_s" type="number" min="0" max="59" value="${remSecs}" placeholder="s" style="flex:1">
+          </div>
+          <div class="form-help">Hours / minutes / seconds — serialized as a single <code>duration_seconds</code> value. Max 7 days.</div>
+          <div class="field-error" data-field-error="duration_seconds" style="display:none"></div>
+        </div>
+        ${mode === 'edit' ? Components.formSelect({
+          label: 'Enabled', name: 'enabled',
+          options: [{ value: 'true', label: 'Enabled' }, { value: 'false', label: 'Disabled' }],
+          value: b.enabled === false ? 'false' : 'true',
+        }) : ''}
+      </form>
+    `;
+
+    const m = Components.modal({
+      title: mode === 'create' ? 'New blackout' : 'Edit blackout',
+      body,
+      size: 'md',
+      primaryAction: {
+        label: mode === 'create' ? 'Create' : 'Save',
+        onClick: async ({ close }) => {
+          const form = document.getElementById('blackout-form');
+          const data = readBlackoutForm(form, mode);
+          if (!data) return;
+          try {
+            if (mode === 'create') await API.createBlackout(data);
+            else await API.updateBlackout(b.id, data);
+            if (onSaved) onSaved();
+            close('saved');
+          } catch (err) {
+            showBlackoutFormError(form, err);
+          }
+        },
+      },
+      secondaryAction: { label: 'Cancel' },
+    });
+    Components.rruleAttachBlurCheck(m.root.querySelector('#blackout-form'), 'rrule');
+  },
+
+  async confirmDelete(app, b) {
+    const ok = await Components.confirmDialog({
+      title: 'Delete blackout?',
+      message: `Delete blackout "${b.name || b.id}"? This cannot be undone.`,
+      confirmLabel: 'Delete',
+      danger: true,
+    });
+    if (!ok) return;
+    try {
+      await API.deleteBlackout(b.id);
+      location.hash = '#/blackouts';
+      BlackoutsPage.render(app, {});
+    } catch (err) {
+      const box = document.getElementById('blackout-action-error');
+      if (box) box.innerHTML = Components.errorBanner(err);
+    }
+  },
 };
+
+function readBlackoutForm(form, mode) {
+  if (!form) return null;
+  const fd = new FormData(form);
+  const scope = (fd.get('scope') || 'global').toString();
+  const targetId = (fd.get('target_id') || '').toString().trim();
+  const out = {
+    scope,
+    name: (fd.get('name') || '').toString().trim(),
+    rrule: (fd.get('rrule') || '').toString().trim(),
+    timezone: (fd.get('timezone') || '').toString().trim() || 'UTC',
+  };
+  if (scope === 'target') {
+    if (!targetId) {
+      Components.applyFieldErrors(form, [{ field: 'target_id', message: 'required when scope is "target"' }]);
+      return null;
+    }
+    out.target_id = targetId;
+  } else if (mode === 'edit' && !targetId) {
+    // Switching back from target → global: ask the API to clear the fk.
+    out.clear_target = true;
+  }
+  const h = parseInt((fd.get('dur_h') || '0').toString(), 10) || 0;
+  const m = parseInt((fd.get('dur_m') || '0').toString(), 10) || 0;
+  const s = parseInt((fd.get('dur_s') || '0').toString(), 10) || 0;
+  const seconds = h * 3600 + m * 60 + s;
+  if (seconds <= 0) {
+    Components.applyFieldErrors(form, [{ field: 'duration_seconds', message: 'must be greater than zero' }]);
+    return null;
+  }
+  out.duration_seconds = seconds;
+  if (mode === 'edit') {
+    const en = (fd.get('enabled') || 'true').toString();
+    out.enabled = en === 'true';
+  }
+  return out;
+}
+
+function showBlackoutFormError(form, err) {
+  if (!form) return;
+  if (err && err.fieldErrors && err.fieldErrors.length) {
+    Components.applyFieldErrors(form, err.fieldErrors);
+    return;
+  }
+  const general = form.querySelector('[data-field-error="__general__"]');
+  if (general) {
+    const title = (err && err.problem && err.problem.title) || (err && err.message) || 'Request failed';
+    const detail = err && err.problem && err.problem.detail ? ' — ' + err.problem.detail : '';
+    general.textContent = title + detail;
+    general.style.display = 'block';
+  }
+}

--- a/internal/webui/static/js/pages/schedules.js
+++ b/internal/webui/static/js/pages/schedules.js
@@ -63,9 +63,14 @@ const SchedulesPage = {
     if (items.length === 0) {
       const hint = (f.status || f.target_id || f.template_id)
         ? 'No schedules match the current filters.'
-        : 'No schedules yet. Create one via CLI: <code class="mono">surfbot schedule create --target &lt;id&gt; --template &lt;id&gt; --rrule \'...\' --dtstart \'...\'</code>';
+        : 'No schedules yet. Click <strong>New schedule</strong> above or use <code class="mono">surfbot schedule create</code>.';
       return `
-        <div class="page-header"><h2>Schedules</h2></div>
+        <div class="page-header">
+          <h2>Schedules</h2>
+          <div style="margin-left:auto">
+            <button type="button" class="btn btn-primary" id="schedules-new">New schedule</button>
+          </div>
+        </div>
         ${filterBar}
         ${Components.emptyState('No schedules', hint)}
       `;
@@ -89,6 +94,9 @@ const SchedulesPage = {
       <div class="page-header">
         <h2>Schedules</h2>
         <p>${total} schedule${total === 1 ? '' : 's'}</p>
+        <div style="margin-left:auto">
+          <button type="button" class="btn btn-primary" id="schedules-new">New schedule</button>
+        </div>
       </div>
       ${filterBar}
       ${Components.table(
@@ -127,18 +135,93 @@ const SchedulesPage = {
 
   bindEvents(app, f) {
     const form = document.getElementById('schedules-filters');
-    if (!form) return;
-    form.addEventListener('submit', (e) => {
-      e.preventDefault();
-      const next = {
-        status: document.getElementById('filter-status').value,
-        target_id: document.getElementById('filter-target').value.trim(),
-        template_id: document.getElementById('filter-template').value.trim(),
-        limit: f.limit,
-        offset: 0,
-      };
-      location.hash = this.hashFor(next, 0);
+    if (form) {
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const next = {
+          status: document.getElementById('filter-status').value,
+          target_id: document.getElementById('filter-target').value.trim(),
+          template_id: document.getElementById('filter-template').value.trim(),
+          limit: f.limit,
+          offset: 0,
+        };
+        location.hash = this.hashFor(next, 0);
+      });
+    }
+    const newBtn = document.getElementById('schedules-new');
+    if (newBtn) newBtn.addEventListener('click', () => this.openCreateForm(app, f));
+  },
+
+  // --- SPEC-SCHED1.4b: create / edit form modal ---
+
+  openCreateForm(app, listFilters) {
+    this.openForm({
+      mode: 'create',
+      onSaved: () => SchedulesPage.render(app, listFilters || {}),
     });
+  },
+
+  openEditForm(app, schedule) {
+    this.openForm({
+      mode: 'edit',
+      schedule,
+      onSaved: () => SchedulesPage.renderDetail(app, schedule.id),
+    });
+  },
+
+  openForm({ mode, schedule, onSaved }) {
+    const s = schedule || {};
+    const body = `
+      <form id="schedule-form" novalidate>
+        <div class="field-error" data-field-error="__general__" style="display:none;margin-bottom:12px;padding:8px 12px;background:var(--sev-critical-bg);border-radius:var(--radius)"></div>
+        ${Components.formInput({ label: 'Name', name: 'name', value: s.name, required: true })}
+        ${Components.formInput({
+          label: 'Target ID', name: 'target_id', value: s.target_id, required: true,
+          placeholder: 'UUID from /targets',
+          help: mode === 'edit' ? 'Target cannot be changed after creation.' : '',
+        })}
+        ${Components.formInput({ label: 'Template ID', name: 'template_id', value: s.template_id || '',
+          help: 'Optional. Omit to run with tool_config directly.' })}
+        ${Components.rruleField({ label: 'RRULE', name: 'rrule', value: s.rrule })}
+        ${Components.formDatetime({ label: 'DTSTART', name: 'dtstart', value: s.dtstart, required: true })}
+        ${Components.formInput({ label: 'Timezone', name: 'timezone', value: s.timezone || 'UTC', required: true })}
+        ${Components.formInput({
+          label: 'Estimated duration (seconds)', name: 'estimated_duration_seconds',
+          type: 'number', value: '',
+          help: 'Used for overlap checks at create/update time. Leave blank to use the server default (3600s).',
+        })}
+        ${mode === 'edit' ? Components.formSelect({
+          label: 'Status', name: 'status',
+          options: [{ value: 'active', label: 'Active' }, { value: 'paused', label: 'Paused' }],
+          value: s.status || 'active',
+        }) : ''}
+      </form>
+    `;
+
+    const m = Components.modal({
+      title: mode === 'create' ? 'New schedule' : 'Edit schedule',
+      body,
+      size: 'md',
+      primaryAction: {
+        label: mode === 'create' ? 'Create' : 'Save',
+        onClick: async ({ close }) => {
+          const form = document.getElementById('schedule-form');
+          const data = readScheduleForm(form, mode);
+          if (!data) return;
+          try {
+            if (mode === 'create') await API.createSchedule(data);
+            else await API.updateSchedule(schedule.id, data);
+            if (onSaved) onSaved();
+            close('saved');
+          } catch (err) {
+            showFormError(form, err);
+          }
+        },
+      },
+      secondaryAction: { label: 'Cancel' },
+    });
+    // Non-blocking RRULE syntax warning wires after the DOM is in place.
+    Components.rruleAttachBlurCheck(m.root.querySelector('#schedule-form'), 'rrule');
   },
 
   // --- Schedule detail ---
@@ -161,12 +244,18 @@ const SchedulesPage = {
         upcoming = [];
       }
       app.innerHTML = this.detailTemplate(s, upcoming);
+      this.bindDetailActions(app, s);
     } catch (err) {
       app.innerHTML = `
         ${Components.backLink('#/schedules', 'Back to schedules')}
         ${Components.errorBanner(err)}
       `;
     }
+  },
+
+  bindDetailActions(app, s) {
+    const editBtn = document.getElementById('schedule-edit-btn');
+    if (editBtn) editBtn.addEventListener('click', () => this.openEditForm(app, s));
   },
 
   detailTemplate(s, upcoming) {
@@ -193,6 +282,9 @@ const SchedulesPage = {
           <div class="detail-header">
             <h2>${escapeHtml(s.name || s.id)}</h2>
             ${Components.scheduleStatusBadge(s.status)}
+            <div style="margin-left:auto;display:flex;gap:8px" id="schedule-detail-actions">
+              <button type="button" class="btn btn-ghost" id="schedule-edit-btn">Edit</button>
+            </div>
           </div>
           <div class="detail-grid" style="margin-top:12px">
             <span class="detail-label">ID</span><span class="detail-value mono">${escapeHtml(s.id)}</span>
@@ -232,3 +324,73 @@ const SchedulesPage = {
     `;
   },
 };
+
+// readScheduleForm serializes the schedule form into the API shape.
+// DTSTART is converted from "datetime-local" ("YYYY-MM-DDTHH:MM") to a
+// UTC ISO string; empty template_id is submitted as "" so the server
+// treats it as "no template" (edit flow uses clear_template when the
+// caller wants to explicitly drop the link, but the UI doesn't surface
+// that nuance yet — 1.4c may expose a dedicated "clear template" ticker).
+// Returns null after surfacing field errors when the form is syntactically
+// bad at the client level.
+function readScheduleForm(form, mode) {
+  if (!form) return null;
+  const fd = new FormData(form);
+  const out = {
+    name: (fd.get('name') || '').toString().trim(),
+    target_id: (fd.get('target_id') || '').toString().trim(),
+    template_id: (fd.get('template_id') || '').toString().trim(),
+    rrule: (fd.get('rrule') || '').toString().trim(),
+    timezone: (fd.get('timezone') || '').toString().trim() || 'UTC',
+  };
+  const dtLocal = (fd.get('dtstart') || '').toString().trim();
+  if (dtLocal) {
+    const d = new Date(dtLocal);
+    if (isNaN(d.getTime())) {
+      Components.applyFieldErrors(form, [{ field: 'dtstart', message: 'invalid date/time' }]);
+      return null;
+    }
+    out.dtstart = d.toISOString();
+  }
+  const dur = (fd.get('estimated_duration_seconds') || '').toString().trim();
+  if (dur) {
+    const n = parseInt(dur, 10);
+    if (isNaN(n) || n < 0) {
+      Components.applyFieldErrors(form, [{ field: 'estimated_duration_seconds', message: 'must be a non-negative integer' }]);
+      return null;
+    }
+    out.estimated_duration_seconds = n;
+  }
+  // template_id: empty string means "not set" — drop the key on create
+  // so the omitempty JSON handling on the server treats it naturally.
+  // On edit we send "" if the user cleared it so the server applies
+  // clear_template semantics via the partial patch.
+  if (!out.template_id) {
+    delete out.template_id;
+  }
+  if (mode === 'edit') {
+    const status = (fd.get('status') || '').toString();
+    if (status === 'active' || status === 'paused') {
+      out.enabled = status === 'active';
+    }
+  }
+  return out;
+}
+
+// showFormError routes an APIError into the right surface: 422 with
+// field_errors → inline via applyFieldErrors; everything else → the
+// general banner at the top of the form.
+function showFormError(form, err) {
+  if (!form) return;
+  if (err && err.fieldErrors && err.fieldErrors.length) {
+    Components.applyFieldErrors(form, err.fieldErrors);
+    return;
+  }
+  const general = form.querySelector('[data-field-error="__general__"]');
+  if (general) {
+    const title = (err && err.problem && err.problem.title) || (err && err.message) || 'Request failed';
+    const detail = err && err.problem && err.problem.detail ? ' — ' + err.problem.detail : '';
+    general.textContent = title + detail;
+    general.style.display = 'block';
+  }
+}

--- a/internal/webui/static/js/pages/schedules.js
+++ b/internal/webui/static/js/pages/schedules.js
@@ -256,6 +256,49 @@ const SchedulesPage = {
   bindDetailActions(app, s) {
     const editBtn = document.getElementById('schedule-edit-btn');
     if (editBtn) editBtn.addEventListener('click', () => this.openEditForm(app, s));
+
+    const pauseBtn = document.getElementById('schedule-pause-btn');
+    if (pauseBtn) pauseBtn.addEventListener('click', () => this.setPauseState(app, s, false));
+
+    const resumeBtn = document.getElementById('schedule-resume-btn');
+    if (resumeBtn) resumeBtn.addEventListener('click', () => this.setPauseState(app, s, true));
+
+    const delBtn = document.getElementById('schedule-delete-btn');
+    if (delBtn) delBtn.addEventListener('click', () => this.confirmDelete(app, s));
+  },
+
+  async setPauseState(app, s, toActive) {
+    const btnId = toActive ? 'schedule-resume-btn' : 'schedule-pause-btn';
+    const btn = document.getElementById(btnId);
+    const origLabel = btn ? btn.textContent : '';
+    if (btn) { btn.disabled = true; btn.textContent = '…'; }
+    try {
+      if (toActive) await API.resumeSchedule(s.id);
+      else await API.pauseSchedule(s.id);
+      SchedulesPage.renderDetail(app, s.id);
+    } catch (err) {
+      const box = document.getElementById('schedule-action-error');
+      if (box) box.innerHTML = Components.errorBanner(err);
+      if (btn) { btn.disabled = false; btn.textContent = origLabel; }
+    }
+  },
+
+  async confirmDelete(app, s) {
+    const ok = await Components.confirmDialog({
+      title: 'Delete schedule?',
+      message: `Delete schedule "${s.name || s.id}"? This cannot be undone.`,
+      confirmLabel: 'Delete',
+      danger: true,
+    });
+    if (!ok) return;
+    try {
+      await API.deleteSchedule(s.id);
+      location.hash = '#/schedules';
+      SchedulesPage.render(app, {});
+    } catch (err) {
+      const box = document.getElementById('schedule-action-error');
+      if (box) box.innerHTML = Components.errorBanner(err);
+    }
   },
 
   detailTemplate(s, upcoming) {
@@ -284,7 +327,12 @@ const SchedulesPage = {
             ${Components.scheduleStatusBadge(s.status)}
             <div style="margin-left:auto;display:flex;gap:8px" id="schedule-detail-actions">
               <button type="button" class="btn btn-ghost" id="schedule-edit-btn">Edit</button>
+              ${s.status === 'active'
+                ? '<button type="button" class="btn btn-ghost" id="schedule-pause-btn">Pause</button>'
+                : '<button type="button" class="btn btn-ghost" id="schedule-resume-btn">Resume</button>'}
+              <button type="button" class="btn btn-danger" id="schedule-delete-btn">Delete</button>
             </div>
+            <div id="schedule-action-error" style="margin-top:8px"></div>
           </div>
           <div class="detail-grid" style="margin-top:12px">
             <span class="detail-label">ID</span><span class="detail-value mono">${escapeHtml(s.id)}</span>

--- a/internal/webui/static/js/pages/schedules.js
+++ b/internal/webui/static/js/pages/schedules.js
@@ -77,14 +77,17 @@ const SchedulesPage = {
     }
 
     const rows = items.map(s => `
-      <tr class="clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">
-        <td class="mono">${Components.truncateID(s.id)}</td>
-        <td>${escapeHtml(s.name || '-')}</td>
-        <td class="mono">${Components.truncateID(s.target_id)}</td>
-        <td class="mono">${s.template_id ? Components.truncateID(s.template_id) : '<span class="text-muted">—</span>'}</td>
-        <td>${Components.scheduleStatusBadge(s.status)}</td>
-        <td>${Components.rruleCompact(s.rrule)}</td>
-        <td class="text-muted">${Components.nextRun(s.next_run_at)}</td>
+      <tr data-schedule-id="${encodeURIComponent(s.id)}">
+        <td class="bulk-cell" onclick="event.stopPropagation()">
+          <input type="checkbox" class="bulk-row-check" data-id="${escapeHtml(s.id)}">
+        </td>
+        <td class="mono clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">${Components.truncateID(s.id)}</td>
+        <td class="clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">${escapeHtml(s.name || '-')}</td>
+        <td class="mono clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">${Components.truncateID(s.target_id)}</td>
+        <td class="mono clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">${s.template_id ? Components.truncateID(s.template_id) : '<span class="text-muted">—</span>'}</td>
+        <td class="clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">${Components.scheduleStatusBadge(s.status)}</td>
+        <td class="clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">${Components.rruleCompact(s.rrule)}</td>
+        <td class="text-muted clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">${Components.nextRun(s.next_run_at)}</td>
       </tr>
     `).join('');
 
@@ -99,11 +102,21 @@ const SchedulesPage = {
         </div>
       </div>
       ${filterBar}
+      <div id="schedules-bulk-error" style="margin-bottom:8px"></div>
       ${Components.table(
-        ['ID', 'Name', 'Target', 'Template', 'Status', 'RRULE', 'Next run'],
+        ['<input type="checkbox" id="bulk-select-all" title="Select all on this page">',
+         'ID', 'Name', 'Target', 'Template', 'Status', 'RRULE', 'Next run'],
         [rows]
       )}
       ${pager}
+      <div id="schedules-bulk-bar-host">${Components.bulkActionsBar({
+        selectedCount: 0,
+        actions: [
+          { label: 'Pause selected' },
+          { label: 'Resume selected' },
+          { label: 'Delete selected', danger: true },
+        ],
+      })}</div>
     `;
   },
 
@@ -150,6 +163,101 @@ const SchedulesPage = {
     }
     const newBtn = document.getElementById('schedules-new');
     if (newBtn) newBtn.addEventListener('click', () => this.openCreateForm(app, f));
+
+    // Bulk selection wiring. Selection state lives on the page module
+    // as a Set<string> so toggling checkboxes doesn't force a list
+    // re-render; after a successful bulk op we refresh the whole page
+    // and selection resets naturally.
+    this._selected = new Set();
+    const checks = app.querySelectorAll('.bulk-row-check');
+    checks.forEach(cb => cb.addEventListener('change', () => this.onRowCheck(app, f)));
+
+    const all = document.getElementById('bulk-select-all');
+    if (all) all.addEventListener('change', () => {
+      checks.forEach(cb => { cb.checked = all.checked; });
+      this.onRowCheck(app, f);
+    });
+
+    this.rebindBulkBar(app, f);
+  },
+
+  onRowCheck(app, f) {
+    const checks = app.querySelectorAll('.bulk-row-check');
+    this._selected = new Set();
+    checks.forEach(cb => {
+      const row = cb.closest('tr');
+      if (cb.checked) {
+        this._selected.add(cb.dataset.id);
+        if (row) row.classList.add('row-selected');
+      } else if (row) {
+        row.classList.remove('row-selected');
+      }
+    });
+    const host = document.getElementById('schedules-bulk-bar-host');
+    if (host) {
+      host.innerHTML = Components.bulkActionsBar({
+        selectedCount: this._selected.size,
+        actions: [
+          { label: 'Pause selected' },
+          { label: 'Resume selected' },
+          { label: 'Delete selected', danger: true },
+        ],
+      });
+      this.rebindBulkBar(app, f);
+    }
+  },
+
+  rebindBulkBar(app, f) {
+    const host = document.getElementById('schedules-bulk-bar-host');
+    if (!host) return;
+    const btns = host.querySelectorAll('[data-bulk-action]');
+    btns.forEach(btn => {
+      const idx = parseInt(btn.dataset.bulkAction, 10);
+      btn.addEventListener('click', () => {
+        if (idx === 0) this.runBulk(app, f, 'pause');
+        else if (idx === 1) this.runBulk(app, f, 'resume');
+        else if (idx === 2) this.confirmBulkDelete(app, f);
+      });
+    });
+  },
+
+  async confirmBulkDelete(app, f) {
+    const ids = Array.from(this._selected);
+    if (!ids.length) return;
+    const ok = await Components.confirmDialog({
+      title: 'Delete schedules?',
+      message: `Delete ${ids.length} schedule(s)? This cannot be undone.`,
+      confirmLabel: 'Delete',
+      danger: true,
+    });
+    if (!ok) return;
+    await this.runBulk(app, f, 'delete');
+  },
+
+  async runBulk(app, f, operation) {
+    const ids = Array.from(this._selected);
+    if (!ids.length) return;
+    const errBox = document.getElementById('schedules-bulk-error');
+    if (errBox) errBox.innerHTML = '';
+    try {
+      const resp = await API.bulkSchedules({ operation, schedule_ids: ids });
+      const succeeded = resp && resp.succeeded ? resp.succeeded.length : 0;
+      const failed = resp && resp.failed ? resp.failed : [];
+      if (errBox) {
+        const parts = [`<div class="text-muted">Bulk ${escapeHtml(operation)}: <strong>${succeeded}</strong> succeeded, <strong>${failed.length}</strong> failed.</div>`];
+        if (failed.length) {
+          parts.push('<ul>' + failed.map(fe =>
+            `<li class="mono">${escapeHtml(fe.schedule_id)}: ${escapeHtml(fe.error)}</li>`
+          ).join('') + '</ul>');
+        }
+        errBox.innerHTML = parts.join('');
+      }
+      // Refresh the list so paused→active (etc.) visibly flips and
+      // deleted rows disappear. Keep filters.
+      SchedulesPage.render(app, f);
+    } catch (err) {
+      if (errBox) errBox.innerHTML = Components.errorBanner(err);
+    }
   },
 
   // --- SPEC-SCHED1.4b: create / edit form modal ---

--- a/internal/webui/static/js/pages/settings_defaults.js
+++ b/internal/webui/static/js/pages/settings_defaults.js
@@ -4,17 +4,118 @@
 // saved — detected here by the "0001-01-01" year prefix so the UI can
 // clearly label "server defaults" vs "saved by operator".
 const SettingsDefaultsPage = {
+  _mode: 'view',    // 'view' | 'edit'
+  _current: null,   // last fetched defaults (for merge during save)
+
   async render(app) {
     app.innerHTML = '<div class="loading">Loading defaults...</div>';
     try {
       const d = await API.getScheduleDefaults();
-      app.innerHTML = this.template(d);
+      this._current = d;
+      if (this._mode === 'edit') {
+        app.innerHTML = this.editTemplate(d);
+        this.bindEditActions(app);
+      } else {
+        app.innerHTML = this.template(d);
+        this.bindViewActions(app);
+      }
     } catch (err) {
       app.innerHTML = `
         <div class="page-header"><h2>Schedule defaults</h2></div>
         ${Components.errorBanner(err)}
       `;
     }
+  },
+
+  bindViewActions(app) {
+    const editBtn = document.getElementById('defaults-edit-btn');
+    if (editBtn) editBtn.addEventListener('click', () => {
+      this._mode = 'edit';
+      this.render(app);
+    });
+  },
+
+  bindEditActions(app) {
+    const cancelBtn = document.getElementById('defaults-cancel-btn');
+    if (cancelBtn) cancelBtn.addEventListener('click', () => {
+      this._mode = 'view';
+      this.render(app);
+    });
+    const form = document.getElementById('defaults-form');
+    if (form) form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      this.save(app, form);
+    });
+  },
+
+  async save(app, form) {
+    const fd = new FormData(form);
+    const body = {
+      // PUT is a full-replace on the singleton: keep fields the UI
+      // doesn't surface (tool_config, maintenance_window, template_id)
+      // straight from the last fetched state so editing one field
+      // doesn't silently reset the others.
+      default_template_id: this._current && this._current.default_template_id ? this._current.default_template_id : undefined,
+      default_rrule: (fd.get('default_rrule') || '').toString().trim(),
+      default_timezone: (fd.get('default_timezone') || '').toString().trim() || 'UTC',
+      default_tool_config: (this._current && this._current.default_tool_config) || {},
+      default_maintenance_window: (this._current && this._current.default_maintenance_window) || undefined,
+      max_concurrent_scans: parseInt((fd.get('max_concurrent_scans') || '4').toString(), 10) || 4,
+      run_on_start: (fd.get('run_on_start') || 'false').toString() === 'true',
+      jitter_seconds: parseInt((fd.get('jitter_seconds') || '0').toString(), 10) || 0,
+    };
+    if (!body.default_template_id) delete body.default_template_id;
+    if (!body.default_maintenance_window) delete body.default_maintenance_window;
+
+    const saveBtn = document.getElementById('defaults-save-btn');
+    if (saveBtn) { saveBtn.disabled = true; saveBtn.textContent = '…'; }
+    try {
+      await API.updateDefaults(body);
+      this._mode = 'view';
+      this.render(app);
+    } catch (err) {
+      if (err && err.fieldErrors && err.fieldErrors.length) {
+        Components.applyFieldErrors(form, err.fieldErrors);
+      } else {
+        const general = form.querySelector('[data-field-error="__general__"]');
+        if (general) {
+          const title = (err.problem && err.problem.title) || err.message || 'Save failed';
+          const detail = err.problem && err.problem.detail ? ' — ' + err.problem.detail : '';
+          general.textContent = title + detail;
+          general.style.display = 'block';
+        }
+      }
+      if (saveBtn) { saveBtn.disabled = false; saveBtn.textContent = 'Save'; }
+    }
+  },
+
+  editTemplate(d) {
+    return `
+      <div class="page-header">
+        <h2>Schedule defaults</h2>
+        <div style="margin-left:auto"><span class="text-muted">Editing</span></div>
+      </div>
+      <form id="defaults-form" class="settings-form" novalidate>
+        <div class="field-error" data-field-error="__general__" style="display:none;margin-bottom:12px;padding:8px 12px;background:var(--sev-critical-bg);border-radius:var(--radius)"></div>
+        ${Components.formInput({ label: 'Default RRULE', name: 'default_rrule', value: d.default_rrule, required: true })}
+        ${Components.formInput({ label: 'Default timezone', name: 'default_timezone', value: d.default_timezone || 'UTC', required: true })}
+        ${Components.formInput({ label: 'Max concurrent scans', name: 'max_concurrent_scans', type: 'number', value: d.max_concurrent_scans, required: true, help: 'Minimum 1.' })}
+        ${Components.formSelect({
+          label: 'Run on start', name: 'run_on_start',
+          options: [{ value: 'false', label: 'No' }, { value: 'true', label: 'Yes' }],
+          value: d.run_on_start ? 'true' : 'false',
+        })}
+        ${Components.formInput({ label: 'Jitter (seconds)', name: 'jitter_seconds', type: 'number', value: d.jitter_seconds, help: 'Minimum 0.' })}
+        <div style="display:flex;gap:8px;margin-top:16px">
+          <button type="submit" class="btn btn-primary" id="defaults-save-btn">Save</button>
+          <button type="button" class="btn btn-ghost" id="defaults-cancel-btn">Cancel</button>
+        </div>
+        <p class="text-muted" style="margin-top:12px;font-size:12px">
+          Tool config and maintenance window editing is deferred to 1.4c.
+          Saving preserves those fields from the current state.
+        </p>
+      </form>
+    `;
   },
 
   template(d) {
@@ -36,7 +137,12 @@ const SettingsDefaultsPage = {
       : '<span class="text-muted">none</span>';
 
     return `
-      <div class="page-header"><h2>Schedule defaults</h2></div>
+      <div class="page-header">
+        <h2>Schedule defaults</h2>
+        <div style="margin-left:auto">
+          <button type="button" class="btn btn-primary" id="defaults-edit-btn">Edit</button>
+        </div>
+      </div>
       ${banner}
       <div class="scan-detail-stack">
         <div class="detail-panel">

--- a/internal/webui/static/js/pages/templates.js
+++ b/internal/webui/static/js/pages/templates.js
@@ -19,6 +19,7 @@ const TemplatesPage = {
     try {
       const data = await API.listTemplates({ limit, offset });
       app.innerHTML = this.template(data, { limit, offset });
+      this.bindListActions(app);
     } catch (err) {
       app.innerHTML = `
         <div class="page-header"><h2>Templates</h2></div>
@@ -27,15 +28,25 @@ const TemplatesPage = {
     }
   },
 
+  bindListActions(app) {
+    const newBtn = document.getElementById('templates-new');
+    if (newBtn) newBtn.addEventListener('click', () => this.openCreateForm(app));
+  },
+
   template(data, f) {
     const items = data.items || [];
     const total = data.total || 0;
 
+    const headerActions = '<div style="margin-left:auto"><button type="button" class="btn btn-primary" id="templates-new">New template</button></div>';
+
     if (items.length === 0) {
       return `
-        <div class="page-header"><h2>Templates</h2></div>
+        <div class="page-header">
+          <h2>Templates</h2>
+          ${headerActions}
+        </div>
         ${Components.emptyState('No templates',
-          'No templates yet. Create one via CLI: <code class="mono">surfbot template create --name \'...\' --rrule \'...\'</code>')}
+          'No templates yet. Click <strong>New template</strong> above or use <code class="mono">surfbot template create</code>.')}
       `;
     }
 
@@ -60,6 +71,7 @@ const TemplatesPage = {
       <div class="page-header">
         <h2>Templates</h2>
         <p>${total} template${total === 1 ? '' : 's'}</p>
+        ${headerActions}
       </div>
       ${Components.table(
         ['ID', 'Name', 'Description', 'Tools', 'RRULE', 'Updated'],
@@ -104,12 +116,21 @@ const TemplatesPage = {
         usedBy = [];
       }
       app.innerHTML = this.detailTemplate(t, usedBy);
+      this.bindDetailActions(app, t, usedBy);
     } catch (err) {
       app.innerHTML = `
         ${Components.backLink('#/templates', 'Back to templates')}
         ${Components.errorBanner(err)}
       `;
     }
+  },
+
+  bindDetailActions(app, t, usedBy) {
+    const editBtn = document.getElementById('template-edit-btn');
+    if (editBtn) editBtn.addEventListener('click', () => this.openEditForm(app, t));
+
+    const delBtn = document.getElementById('template-delete-btn');
+    if (delBtn) delBtn.addEventListener('click', () => this.confirmDelete(app, t, usedBy));
   },
 
   detailTemplate(t, usedBy) {
@@ -131,7 +152,12 @@ const TemplatesPage = {
           <div class="detail-header">
             <h2>${escapeHtml(t.name)}</h2>
             ${t.is_system ? '<span class="badge badge-muted">system</span>' : ''}
+            <div style="margin-left:auto;display:flex;gap:8px">
+              ${t.is_system ? '' : '<button type="button" class="btn btn-ghost" id="template-edit-btn">Edit</button>'}
+              ${t.is_system ? '' : '<button type="button" class="btn btn-danger" id="template-delete-btn">Delete</button>'}
+            </div>
           </div>
+          <div id="template-action-error" style="margin-top:8px"></div>
           <div class="detail-grid" style="margin-top:12px">
             <span class="detail-label">ID</span><span class="detail-value mono">${escapeHtml(t.id)}</span>
             <span class="detail-label">Description</span><span class="detail-value">${escapeHtml(t.description || '-')}</span>
@@ -159,4 +185,171 @@ const TemplatesPage = {
       </div>
     `;
   },
+
+  // --- SPEC-SCHED1.4b: template create / edit / delete ---
+  //
+  // Tool config is a `<textarea>` holding pretty-printed JSON. The UI
+  // validates only the outer shape (top-level keys in the known tool
+  // set + parseable JSON); per-tool parameter validation happens
+  // server-side and comes back as field errors scoped to
+  // `tool_config.<name>`. Delete surfaces the 409 /problems/template-
+  // in-use payload as a follow-up cascade-delete confirm.
+
+  openCreateForm(app) {
+    this.openForm({
+      mode: 'create',
+      onSaved: () => TemplatesPage.render(app, {}),
+    });
+  },
+
+  openEditForm(app, t) {
+    this.openForm({
+      mode: 'edit',
+      template: t,
+      onSaved: () => TemplatesPage.renderDetail(app, t.id),
+    });
+  },
+
+  openForm({ mode, template, onSaved }) {
+    const t = template || {};
+    const toolConfigJson = JSON.stringify(t.tool_config || {}, null, 2);
+    const body = `
+      <form id="template-form" novalidate>
+        <div class="field-error" data-field-error="__general__" style="display:none;margin-bottom:12px;padding:8px 12px;background:var(--sev-critical-bg);border-radius:var(--radius)"></div>
+        ${Components.formInput({ label: 'Name', name: 'name', value: t.name, required: true })}
+        ${Components.formInput({ label: 'Description', name: 'description', value: t.description || '' })}
+        ${Components.rruleField({ label: 'RRULE', name: 'rrule', value: t.rrule })}
+        ${Components.formInput({ label: 'Timezone', name: 'timezone', value: t.timezone || 'UTC' })}
+        ${Components.formTextarea({
+          label: 'Tool config (JSON)', name: 'tool_config',
+          value: t.tool_config ? toolConfigJson : '{}',
+          rows: 10, monospace: true,
+          help: 'Top-level keys must be known tool names (nuclei, naabu, httpx, subfinder, dnsx). Per-tool params are validated on the server.',
+        })}
+      </form>
+    `;
+
+    const m = Components.modal({
+      title: mode === 'create' ? 'New template' : 'Edit template',
+      body,
+      size: 'lg',
+      primaryAction: {
+        label: mode === 'create' ? 'Create' : 'Save',
+        onClick: async ({ close }) => {
+          const form = document.getElementById('template-form');
+          const data = readTemplateForm(form);
+          if (!data) return;
+          try {
+            if (mode === 'create') await API.createTemplate(data);
+            else await API.updateTemplate(t.id, data);
+            if (onSaved) onSaved();
+            close('saved');
+          } catch (err) {
+            showTemplateFormError(form, err);
+          }
+        },
+      },
+      secondaryAction: { label: 'Cancel' },
+    });
+    Components.rruleAttachBlurCheck(m.root.querySelector('#template-form'), 'rrule');
+  },
+
+  async confirmDelete(app, t, usedBy) {
+    const box = document.getElementById('template-action-error');
+    const dependents = usedBy || [];
+
+    const initial = await Components.confirmDialog({
+      title: 'Delete template?',
+      message: dependents.length
+        ? `Template "${t.name}" is referenced by ${dependents.length} schedule(s). Delete the template first? Schedules that still reference it will be listed next.`
+        : `Delete template "${t.name}"? This cannot be undone.`,
+      confirmLabel: 'Delete',
+      danger: true,
+    });
+    if (!initial) return;
+
+    try {
+      await API.deleteTemplate(t.id);
+      location.hash = '#/templates';
+      TemplatesPage.render(app, {});
+      return;
+    } catch (err) {
+      if (err && err.code === 'TEMPLATE_IN_USE') {
+        const ids = (err.fieldErrors || []).map(fe => fe.message);
+        const cascade = await Components.confirmDialog({
+          title: 'Cascade delete?',
+          message: `Template is still referenced by ${ids.length} schedule(s). Delete template AND its schedules?`,
+          confirmLabel: 'Delete template + schedules',
+          danger: true,
+        });
+        if (!cascade) return;
+        try {
+          await API.deleteTemplate(t.id, { force: true });
+          location.hash = '#/templates';
+          TemplatesPage.render(app, {});
+          return;
+        } catch (err2) {
+          if (box) box.innerHTML = Components.errorBanner(err2);
+          return;
+        }
+      }
+      if (box) box.innerHTML = Components.errorBanner(err);
+    }
+  },
 };
+
+const KNOWN_TOOLS = new Set(['nuclei', 'naabu', 'httpx', 'subfinder', 'dnsx']);
+
+// readTemplateForm serializes the template form into the API shape.
+// Returns null after surfacing client-side JSON/tool errors.
+function readTemplateForm(form) {
+  if (!form) return null;
+  const fd = new FormData(form);
+  const out = {
+    name: (fd.get('name') || '').toString().trim(),
+    description: (fd.get('description') || '').toString(),
+    rrule: (fd.get('rrule') || '').toString().trim(),
+    timezone: (fd.get('timezone') || '').toString().trim() || 'UTC',
+  };
+  const tcRaw = (fd.get('tool_config') || '').toString().trim();
+  if (tcRaw) {
+    let tc;
+    try {
+      tc = JSON.parse(tcRaw);
+    } catch (err) {
+      Components.applyFieldErrors(form, [{ field: 'tool_config', message: 'Invalid JSON: ' + err.message }]);
+      return null;
+    }
+    if (tc === null || typeof tc !== 'object' || Array.isArray(tc)) {
+      Components.applyFieldErrors(form, [{ field: 'tool_config', message: 'Must be a JSON object' }]);
+      return null;
+    }
+    const unknown = Object.keys(tc).filter(k => !KNOWN_TOOLS.has(k));
+    if (unknown.length) {
+      Components.applyFieldErrors(form, unknown.map(k => ({
+        field: 'tool_config.' + k,
+        message: 'Unknown tool (allowed: ' + Array.from(KNOWN_TOOLS).join(', ') + ')',
+      })));
+      return null;
+    }
+    out.tool_config = tc;
+  } else {
+    out.tool_config = {};
+  }
+  return out;
+}
+
+function showTemplateFormError(form, err) {
+  if (!form) return;
+  if (err && err.fieldErrors && err.fieldErrors.length) {
+    Components.applyFieldErrors(form, err.fieldErrors);
+    return;
+  }
+  const general = form.querySelector('[data-field-error="__general__"]');
+  if (general) {
+    const title = (err && err.problem && err.problem.title) || (err && err.message) || 'Request failed';
+    const detail = err && err.problem && err.problem.detail ? ' — ' + err.problem.detail : '';
+    general.textContent = title + detail;
+    general.style.display = 'block';
+  }
+}

--- a/internal/webui/ui_integration_test.go
+++ b/internal/webui/ui_integration_test.go
@@ -219,6 +219,89 @@ func TestIntegration_UIScaffold_ShellAndEmbed(t *testing.T) {
 	assert.Error(t, err, "embed.FS still bundles the deleted settings_schedule.js")
 }
 
+// TestIntegration_UIWriteFlows asserts the 1.4b additions are in the
+// embedded SPA bundle and the shell wires the ad-hoc nav button. Every
+// assertion is a string-match on the embedded file contents or on the
+// served index.html — cheap and stable. Behavior verification lives in
+// the operator smoke TODO in the PR body; no JS test runner is added.
+func TestIntegration_UIWriteFlows(t *testing.T) {
+	_, base, stop := startIntegrationServer(t)
+	defer stop()
+
+	code, body := getBody(t, base+"/")
+	require.Equal(t, http.StatusOK, code)
+	html := string(body)
+
+	// (1) Ad-hoc page module is embedded and wired into the shell.
+	_, err := fs.Stat(staticFS, "static/js/pages/adhoc.js")
+	assert.NoError(t, err, "embed.FS missing static/js/pages/adhoc.js")
+	assert.Contains(t, html, `/js/pages/adhoc.js`, "shell missing adhoc.js <script> tag")
+
+	// (2) "Run scan now" nav button in the sidebar.
+	assert.Contains(t, html, `id="nav-adhoc-btn"`, "shell missing Run scan now nav button")
+	assert.Contains(t, html, `Run scan now`, "shell missing Run scan now label")
+
+	// (3) components.js carries every 1.4b helper name.
+	components := readEmbedded(t, "static/js/components.js")
+	for _, name := range []string{
+		"formInput", "formSelect", "formTextarea", "formDatetime",
+		"rruleField", "rruleAttachBlurCheck",
+		"modal", "confirmDialog", "applyFieldErrors", "bulkActionsBar",
+	} {
+		assert.Contains(t, components, name, "components.js missing %s", name)
+	}
+
+	// (4) api.js exposes every 1.4b write method.
+	apijs := readEmbedded(t, "static/js/api.js")
+	for _, name := range []string{
+		"createSchedule", "updateSchedule", "deleteSchedule",
+		"pauseSchedule", "resumeSchedule", "bulkSchedules",
+		"createTemplate", "updateTemplate", "deleteTemplate",
+		"createBlackout", "updateBlackout", "deleteBlackout",
+		"updateDefaults", "createAdHocScan",
+		// Typed-error mapping for the dispatcher modal.
+		"DISPATCHER_UNREACHABLE", "TARGET_BUSY", "IN_BLACKOUT",
+	} {
+		assert.Contains(t, apijs, name, "api.js missing %s", name)
+	}
+
+	// (5) pages/*.js each carry their write-flow entry points.
+	schedulesJS := readEmbedded(t, "static/js/pages/schedules.js")
+	for _, name := range []string{
+		"openCreateForm", "openEditForm",
+		"setPauseState", "confirmDelete",
+		"runBulk", "confirmBulkDelete",
+	} {
+		assert.Contains(t, schedulesJS, name, "schedules.js missing %s", name)
+	}
+	templatesJS := readEmbedded(t, "static/js/pages/templates.js")
+	for _, name := range []string{"openCreateForm", "openEditForm", "confirmDelete"} {
+		assert.Contains(t, templatesJS, name, "templates.js missing %s", name)
+	}
+	blackoutsJS := readEmbedded(t, "static/js/pages/blackouts.js")
+	for _, name := range []string{"openCreateForm", "openEditForm", "confirmDelete"} {
+		assert.Contains(t, blackoutsJS, name, "blackouts.js missing %s", name)
+	}
+	defaultsJS := readEmbedded(t, "static/js/pages/settings_defaults.js")
+	for _, name := range []string{"editTemplate", "bindEditActions", "save"} {
+		assert.Contains(t, defaultsJS, name, "settings_defaults.js missing %s", name)
+	}
+	adhocJS := readEmbedded(t, "static/js/pages/adhoc.js")
+	for _, name := range []string{"AdHocPage", "readAdHocForm", "swapToSuccessView"} {
+		assert.Contains(t, adhocJS, name, "adhoc.js missing %s", name)
+	}
+}
+
+func readEmbedded(t *testing.T, path string) string {
+	t.Helper()
+	f, err := staticFS.Open(path)
+	require.NoError(t, err, "open embedded %s", path)
+	defer func() { _ = f.Close() }()
+	b, err := io.ReadAll(f)
+	require.NoError(t, err)
+	return string(b)
+}
+
 // TestIntegration_UIScaffold_RemovedEndpoints proves R9 and R10 removal
 // at the HTTP surface. Without the handler, the SPA fallback catches
 // `GET /settings/schedule` and serves the shell (200); `POST


### PR DESCRIPTION
## What shipped

Every 1.3a write endpoint now has a UI surface, the schedules list supports bulk ops, and a top-nav "Run scan now" modal covers ad-hoc dispatch. 10 commits, vanilla-JS SPA, no new frameworks or build steps.

- **Form / modal / confirm / bulk helpers** — [components.js](internal/webui/static/js/components.js): `formInput`, `formSelect`, `formTextarea`, `formDatetime`, `rruleField` (with non-blocking client-side FREQ regex check), `modal`, `confirmDialog`, `applyFieldErrors`, `bulkActionsBar`. Plus matching CSS (`.modal-backdrop`, `.form-field`, `.field-error`, `.bulk-actions-bar`).
- **API client writes** — [api.js](internal/webui/static/js/api.js) extended with `createSchedule`/`updateSchedule`/`deleteSchedule`/`pauseSchedule`/`resumeSchedule`/`bulkSchedules`, template/blackout CRUD, `updateDefaults`, `createAdHocScan`. Errors parsed into `{status, problem, fieldErrors, code}` with `code` ∈ `{DISPATCHER_UNREACHABLE, TARGET_BUSY, IN_BLACKOUT, TEMPLATE_IN_USE, OVERLAP, VALIDATION, NOT_FOUND, CONFLICT}` derived from the Problem `type`.
- **Schedules** — "New schedule" button, Edit/Pause/Resume/Delete on detail, per-row checkboxes + sticky bulk bar, `POST /schedules/bulk` with per-item success/failure display.
- **Templates** — "New template" + Edit + Delete with cascade confirm on 409 `/problems/template-in-use`. JSON textarea for `tool_config` with client-side top-level key whitelist (`nuclei`/`naabu`/`httpx`/`subfinder`/`dnsx`); server does deep validation.
- **Blackouts** — "New blackout" + Edit + Delete. Scope select (global/target) + target_id input; duration rendered as hours/minutes/seconds, serialized to `duration_seconds`.
- **Defaults** — Edit toggle (inline mode per OQ2). Tool config and maintenance window preserved from the last fetch during PUT so editing one field doesn't reset the others.
- **Ad-hoc dispatcher modal** — [pages/adhoc.js](internal/webui/static/js/pages/adhoc.js) with free-text target input, optional reason, optional `tool_config_override` JSON textarea. 202 renders a success view with run/scan IDs; 503/409/422 map to tailored messages.
- **Integration test** extended with embed + shell + helper-name assertions across [ui_integration_test.go](internal/webui/ui_integration_test.go).

## Deviations

- **OQ1 (modal vs route)** — modal, applied consistently across schedules/templates/blackouts/ad-hoc.
- **OQ2 (defaults edit)** — inline toggle via `SettingsDefaultsPage._mode`.
- **OQ3 (blackout `target_ids` shape)** — recovered from [internal/api/v1/blackouts.go](internal/api/v1/blackouts.go). **The API uses `scope: "global"|"target"` + a single optional `target_id`, NOT a `target_ids` array as the 1.4b draft implied.** For multi-target blackouts the operator creates multiple rows. UI form renders a scope select + single target_id input.
- **OQ4 (ad-hoc target picker)** — free-text input. Targets-page picker is 1.4c (spec non-goal N3).
- **OQ5 (toast helper)** — no existing toast helper found in `components.js` or pages. Used inline success (modal close + list refresh) and error banners. Toast deferred.
- **OQ6 (RRULE client-side check level)** — basic regex (`FREQ=(SECONDLY|MINUTELY|HOURLY|DAILY|WEEKLY|MONTHLY|YEARLY)`) as a non-blocking warning on blur. Server 422 is still the source of truth.
- Unrelated cleanup: the existing `get/post/put/patch/del` wrappers in [api.js](internal/webui/static/js/api.js) were tightened to throw the richer `APIError` shape uniformly (handles 204 No Content, single error factory). Legacy callers continue to read `.message` without change.

## Gates

- [x] `go build ./...`
- [x] `go test ./... -race -count=1`
- [x] `go test -tags=integration ./... -race -count=1`
- [x] `golangci-lint run` — clean

## Operator smoke TODO (six steps)

1. **Create schedule** — open `#/schedules`, click "New schedule", fill all fields, submit, observe new row.
2. **Field errors** — create with `RRULE=BAD`; observe client-side warning on blur ("RRULE syntax looks off"), submit anyway, observe server 422 with inline error under the `rrule` field. Fix + resubmit.
3. **Edit + pause + resume + delete** — from schedule detail, edit `estimated_duration_seconds`; pause; resume; delete via confirm.
4. **Template cascade delete** — create template, attach 1 schedule, try deleting the template → observe 409 + follow-up cascade-delete modal; cancel; retry with cascade → both gone.
5. **Bulk ops** — create 3 schedules, tick 2 via checkboxes, click "Pause selected", observe both move to paused; "Delete selected" with confirm.
6. **Ad-hoc dispatch** — click "Run scan now" in the sidebar, dispatch against a valid target → observe `ad_hoc_run_id` + `scan_id`; dispatch with bad target → observe 422 inline; stop the daemon and retry → observe the "Daemon dispatcher is not reachable" message.