### PR TITLE
SCHED1.4c: ui timeline + target integration + final polish

### DIFF
--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -1434,6 +1434,46 @@ body.modal-open { overflow: hidden; }
   border-top: 1px solid var(--border);
 }
 
+/* Timeline (SCHED1.4c). */
+.timeline-day {
+  margin-bottom: 20px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.timeline-day-header {
+  padding: 10px 14px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  display: flex; justify-content: space-between; align-items: center;
+}
+.timeline-day-items { padding: 4px 0; }
+.timeline-row {
+  display: grid;
+  grid-template-columns: 80px 1fr 1fr 1fr;
+  gap: 12px;
+  padding: 8px 14px;
+  font-size: 13px;
+  border-bottom: 1px solid var(--border);
+}
+.timeline-row:last-child { border-bottom: 0; }
+.timeline-row.clickable { cursor: pointer; }
+.timeline-row.clickable:hover { background: var(--bg-hover); }
+.timeline-time { color: var(--accent); }
+.timeline-empty-slot {
+  padding: 10px 14px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-style: italic;
+}
+.timeline-empty-slot.clickable { cursor: pointer; }
+.timeline-empty-slot.clickable:hover { background: var(--bg-hover); color: var(--text-secondary); }
+
 /* Bulk actions bar (SCHED1.4b). */
 .bulk-actions-bar {
   position: sticky;

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -43,6 +43,10 @@
           <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.062 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/></svg>
           <span class="nav-label">Tools</span>
         </a></li>
+        <li><a href="#/timeline" class="nav-link" data-page="timeline">
+          <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"/></svg>
+          <span class="nav-label">Timeline</span>
+        </a></li>
         <li><a href="#/schedules" class="nav-link" data-page="schedules">
           <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd"/></svg>
           <span class="nav-label">Schedules</span>
@@ -79,6 +83,7 @@
   <script src="/js/pages/scans.js"></script>
   <script src="/js/pages/targets.js"></script>
   <script src="/js/pages/tools.js"></script>
+  <script src="/js/pages/timeline.js"></script>
   <script src="/js/pages/schedules.js"></script>
   <script src="/js/pages/templates.js"></script>
   <script src="/js/pages/blackouts.js"></script>

--- a/internal/webui/static/js/app.js
+++ b/internal/webui/static/js/app.js
@@ -15,6 +15,7 @@ const Router = {
     // longest-prefix match wins. No Go-side route changes — the SPA
     // fallback in server.go already serves index.html for any unknown
     // path, so these hash routes resolve entirely client-side.
+    { pattern: /^#\/timeline/, page: 'timeline', render: () => TimelinePage.render(app, parseQueryParams()) },
     { pattern: /^#\/schedules\/(.+)$/, page: 'schedules', render: (m) => SchedulesPage.render(app, { id: decodeURIComponent(m[1]) }) },
     { pattern: /^#\/schedules/, page: 'schedules', render: () => SchedulesPage.render(app, parseQueryParams()) },
     { pattern: /^#\/templates\/(.+)$/, page: 'templates', render: (m) => TemplatesPage.render(app, { id: decodeURIComponent(m[1]) }) },

--- a/internal/webui/static/js/components.js
+++ b/internal/webui/static/js/components.js
@@ -442,6 +442,112 @@ const Components = {
   // bulkActionsBar renders a sticky bottom bar with a selection count
   // and action buttons. The caller mounts it once and toggles visibility
   // via .hidden based on selection state.
+  // --- SPEC-SCHED1.4c: timeline helpers ---
+  //
+  // The timeline is a day-grouped vertical list, not a calendar grid —
+  // no date library, only native Date arithmetic. Grouping uses the
+  // browser's local timezone so "Today" on the header matches what the
+  // operator reads on their wall clock.
+
+  groupByDay(firings) {
+    const map = new Map();
+    (firings || []).forEach(f => {
+      const d = new Date(f.fires_at);
+      if (isNaN(d.getTime())) return;
+      const key = d.getFullYear() + '-' + pad2(d.getMonth() + 1) + '-' + pad2(d.getDate());
+      if (!map.has(key)) map.set(key, []);
+      map.get(key).push(f);
+    });
+    const keys = Array.from(map.keys()).sort();
+    return keys.map(key => ({
+      date: key,
+      dayLabel: relativeDayLabel(key),
+      items: map.get(key).sort((a, b) => new Date(a.fires_at) - new Date(b.fires_at)),
+    }));
+  },
+
+  timelineRow({ firing, onClick }) {
+    const time = new Date(firing.fires_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    const tmpl = firing.template_id
+      ? `<span class="mono" title="${escapeHtml(firing.template_id)}">${Components.truncateID(firing.template_id)}</span>`
+      : '<span class="text-muted">—</span>';
+    const row = document.createElement('div');
+    row.className = 'timeline-row';
+    row.innerHTML = `
+      <span class="timeline-time mono">${escapeHtml(time)}</span>
+      <span class="timeline-target mono" title="${escapeHtml(firing.target_id)}">${Components.truncateID(firing.target_id)}</span>
+      <span class="timeline-template">${tmpl}</span>
+      <span class="timeline-schedule mono" title="${escapeHtml(firing.schedule_id)}">${Components.truncateID(firing.schedule_id)}</span>
+    `;
+    if (typeof onClick === 'function') {
+      row.classList.add('clickable');
+      row.addEventListener('click', () => onClick(firing));
+    }
+    return row;
+  },
+
+  // timelineEmptySlot renders a clickable empty-state rectangle for a
+  // day with no firings. Defaults to local 09:00 per OQ2 — the most
+  // common "start of business day" anchor operators reach for.
+  timelineEmptySlot({ date, onClickCreate }) {
+    const slot = document.createElement('div');
+    slot.className = 'timeline-empty-slot';
+    slot.textContent = 'Click to create a schedule for this day (09:00 local)';
+    if (typeof onClickCreate === 'function') {
+      slot.classList.add('clickable');
+      slot.addEventListener('click', () => {
+        const [y, m, d] = date.split('-').map(n => parseInt(n, 10));
+        const local = new Date(y, m - 1, d, 9, 0, 0);
+        onClickCreate(local.toISOString(), date);
+      });
+    }
+    return slot;
+  },
+
+  // horizonSelector wraps a <select>. Default is 24h. onChange fires
+  // with the Go-duration string ("1h", "24h", "7d", etc.) the server's
+  // upcoming handler accepts.
+  horizonSelector({ current, onChange }) {
+    const opts = [
+      { v: '1h', l: '1 hour' },
+      { v: '6h', l: '6 hours' },
+      { v: '24h', l: '24 hours' },
+      { v: '72h', l: '3 days' },
+      { v: '168h', l: '7 days' },
+      { v: '720h', l: '30 days' },
+    ];
+    const sel = document.createElement('select');
+    sel.className = 'filter-select';
+    sel.innerHTML = opts.map(o =>
+      `<option value="${o.v}"${o.v === (current || '24h') ? ' selected' : ''}>${o.l}</option>`
+    ).join('');
+    if (typeof onChange === 'function') {
+      sel.addEventListener('change', () => onChange(sel.value));
+    }
+    return sel;
+  },
+
+  // targetFilterSelector renders a datalist-backed text input so the
+  // operator can type any target ID without coupling to a /targets
+  // fetch. Existing target IDs (optional) populate the autocomplete.
+  targetFilterSelector({ targets, current, onChange }) {
+    const wrap = document.createElement('span');
+    const listID = 'target-filter-dl';
+    const datalistHTML = (targets || []).map(t =>
+      `<option value="${escapeHtml(t.id || t)}">${escapeHtml(t.value || t.id || t)}</option>`
+    ).join('');
+    wrap.innerHTML = `
+      <input class="form-input" list="${listID}" placeholder="All targets"
+             value="${escapeHtml(current || '')}" style="width:240px">
+      <datalist id="${listID}">${datalistHTML}</datalist>
+    `;
+    const input = wrap.querySelector('input');
+    if (typeof onChange === 'function') {
+      input.addEventListener('change', () => onChange(input.value.trim()));
+    }
+    return wrap;
+  },
+
   bulkActionsBar({ selectedCount, actions }) {
     const hidden = selectedCount > 0 ? '' : ' hidden';
     const btns = (actions || []).map((a, i) => {
@@ -454,6 +560,22 @@ const Components = {
     </div>`;
   },
 };
+
+function pad2(n) { return String(n).padStart(2, '0'); }
+
+// relativeDayLabel renders a day-key ("YYYY-MM-DD") as "Today", "Tomorrow",
+// "Yesterday", or "Weekday, Mon D" relative to the browser's local date.
+function relativeDayLabel(key) {
+  const [y, m, d] = key.split('-').map(n => parseInt(n, 10));
+  const date = new Date(y, m - 1, d);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const deltaDays = Math.round((date - today) / 86400000);
+  if (deltaDays === 0) return 'Today';
+  if (deltaDays === 1) return 'Tomorrow';
+  if (deltaDays === -1) return 'Yesterday';
+  return date.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
+}
 
 // toDatetimeLocal converts an ISO-8601 / Date value to the native
 // datetime-local format ("YYYY-MM-DDTHH:MM") the input expects. Returns

--- a/internal/webui/static/js/pages/adhoc.js
+++ b/internal/webui/static/js/pages/adhoc.js
@@ -8,8 +8,24 @@
 // targets-page integration lands in 1.4c (spec non-goal N3).
 
 const AdHocPage = {
-  open() {
-    const body = this.formBody({});
+  // SPEC-SCHED1.4c R4: open() accepts an optional prefill object so
+  // target-page launchers can pre-fill target_id without duplicating
+  // the modal wiring. Backwards compatible — existing callers pass no
+  // argument. When `lockTargetID` is truthy (typical when launched
+  // from a target page) the field renders readonly with an "Edit
+  // target" link that relaxes the lock — guards against accidental
+  // retargeting per OQ3.
+  open(prefill) {
+    const p = prefill || {};
+    const body = this.formBody({
+      target_id: p.prefillTargetID || p.target_id || '',
+      template_id: p.prefillTemplateID || p.template_id || '',
+      reason: p.prefillReason || p.reason || '',
+      tool_config_override: p.prefillToolConfigOverride || p.tool_config_override || '',
+      lockTargetID: p.lockTargetID !== undefined
+        ? !!p.lockTargetID
+        : !!p.prefillTargetID,
+    });
     const m = Components.modal({
       title: 'Run scan now',
       body,
@@ -30,6 +46,20 @@ const AdHocPage = {
       },
       secondaryAction: { label: 'Close' },
     });
+
+    // Unlock link wiring: clicking "Edit target" drops the readonly
+    // attribute and focuses the field. Idempotent.
+    const unlock = m.root.querySelector('#adhoc-target-unlock');
+    if (unlock) unlock.addEventListener('click', (e) => {
+      e.preventDefault();
+      const input = m.root.querySelector('input[name="target_id"]');
+      if (input) {
+        input.removeAttribute('readonly');
+        input.focus();
+        unlock.style.display = 'none';
+      }
+    });
+
     return m;
   },
 
@@ -37,14 +67,27 @@ const AdHocPage = {
   // restore the original form markup after a successful dispatch.
   formBody(preset) {
     const p = preset || {};
+    const lock = !!p.lockTargetID;
+    const targetIdField = `
+      <div class="form-field" data-field="target_id">
+        <label class="form-label" for="f-target_id">Target ID <span class="form-required">*</span></label>
+        <input class="form-input" id="f-target_id" name="target_id" type="text"
+               required
+               ${lock ? 'readonly' : ''}
+               placeholder="UUID from /targets"
+               value="${escapeHtml(p.target_id || '')}">
+        <div class="form-help">
+          ${lock
+            ? 'Pre-filled from the current target page. <a href="#" id="adhoc-target-unlock">Edit target</a>.'
+            : 'Free-text target ID. Picker ships in a future release.'}
+        </div>
+        <div class="field-error" data-field-error="target_id" style="display:none"></div>
+      </div>
+    `;
     return `
       <form id="adhoc-form" novalidate>
         <div class="field-error" data-field-error="__general__" style="display:none;margin-bottom:12px;padding:8px 12px;background:var(--sev-critical-bg);border-radius:var(--radius)"></div>
-        ${Components.formInput({
-          label: 'Target ID', name: 'target_id', value: p.target_id || '', required: true,
-          placeholder: 'UUID from /targets',
-          help: 'Free-text target ID. Picker ships in 1.4c.',
-        })}
+        ${targetIdField}
         ${Components.formInput({ label: 'Template ID', name: 'template_id', value: p.template_id || '',
           help: 'Optional. If set, the template\'s tool_config is used (overlaid with the override below).' })}
         ${Components.formInput({ label: 'Reason', name: 'reason', value: p.reason || '',

--- a/internal/webui/static/js/pages/blackouts.js
+++ b/internal/webui/static/js/pages/blackouts.js
@@ -190,12 +190,26 @@ const BlackoutsPage = {
           </div>
         </div>
 
-        <div class="card">
+        <div class="card" data-section="blackout-activations-placeholder">
           <div class="card-label">Upcoming activations</div>
-          <div style="margin-top:8px">
-            <span class="text-muted">Preview unavailable in 1.4a. The
-              <a href="#/schedules">/schedules/upcoming</a> endpoint returns
-              blackouts within the horizon of the calendar view (1.4b).</span>
+          <div style="margin-top:8px;font-size:13px">
+            <p class="text-muted" style="margin:0">
+              Activation preview will be available in a future release.
+              Expanding an RRULE client-side would duplicate the
+              scheduler's intervalsched logic; a dedicated endpoint is
+              tracked as post-launch work.
+            </p>
+            <p style="margin-top:8px">
+              This blackout's RRULE:
+              <br><code class="mono">${escapeHtml(b.rrule || '(none)')}</code>
+              for <code class="mono">${escapeHtml(b.duration_seconds + 's')}</code>
+              in <code class="mono">${escapeHtml(b.timezone || 'UTC')}</code>.
+            </p>
+            <p class="text-muted" style="margin-top:8px">
+              Use <code class="mono">surfbot blackout show ${escapeHtml(b.id)}</code>
+              or query SQLite directly to inspect occurrences until the
+              endpoint lands.
+            </p>
           </div>
         </div>
       </div>

--- a/internal/webui/static/js/pages/dashboard.js
+++ b/internal/webui/static/js/pages/dashboard.js
@@ -12,6 +12,15 @@ const DashboardPage = {
       // own poll loop, independent of the dashboard refresh.
       const slot = document.getElementById('agent-card-slot');
       if (slot && typeof AgentCard !== 'undefined') AgentCard.mount(slot);
+
+      // SPEC-SCHED1.4c R5: restore the "Run scan now" button removed
+      // with the /api/daemon/trigger endpoint in 1.4a. Opens the 1.4b
+      // ad-hoc modal with no prefill — same behavior as the sidebar
+      // button, but in the more visible dashboard header location.
+      const runBtn = document.getElementById('dashboard-run-scan-btn');
+      if (runBtn) runBtn.addEventListener('click', () => {
+        if (typeof AdHocPage !== 'undefined' && AdHocPage.open) AdHocPage.open();
+      });
     } catch (err) {
       app.innerHTML = Components.emptyState('Error', 'Failed to load dashboard: ' + err.message);
     }
@@ -39,6 +48,9 @@ const DashboardPage = {
       <div class="page-header">
         <h2>Dashboard</h2>
         <p>Security posture overview</p>
+        <div style="margin-left:auto">
+          <button type="button" class="btn btn-accent" id="dashboard-run-scan-btn" data-action="run-scan-now">Run scan now</button>
+        </div>
       </div>
 
       <div id="agent-card-slot"></div>

--- a/internal/webui/static/js/pages/targets.js
+++ b/internal/webui/static/js/pages/targets.js
@@ -182,8 +182,19 @@ const TargetsPage = {
     `;
 
     // Wire action buttons.
+    // SPEC-SCHED1.4c R4: the detail-page "Scan now" button opens the
+    // 1.4b ad-hoc dispatcher modal with target_id pre-filled (readonly
+    // by default; unlockable via the modal's "Edit target" link). The
+    // list-page row's legacy scanTarget() path still uses the synchronous
+    // /api/v1/scans endpoint — targets list overhaul is separate work.
     const scanBtn = document.getElementById('target-scan-btn');
-    if (scanBtn) scanBtn.addEventListener('click', () => this.scanTarget(t.id, t.value));
+    if (scanBtn) scanBtn.addEventListener('click', () => {
+      if (typeof AdHocPage !== 'undefined' && AdHocPage.open) {
+        AdHocPage.open({ prefillTargetID: t.id, lockTargetID: true });
+      } else {
+        this.scanTarget(t.id, t.value);
+      }
+    });
     const fBtn = document.getElementById('target-findings-btn');
     if (fBtn) fBtn.addEventListener('click', () => this.viewFindings(t.id));
     const aBtn = document.getElementById('target-assets-btn');

--- a/internal/webui/static/js/pages/targets.js
+++ b/internal/webui/static/js/pages/targets.js
@@ -175,6 +175,7 @@ const TargetsPage = {
         </div>
 
         ${stateCard}
+        <div id="target-schedules-slot"></div>
         ${findingsCard}
         ${scansCard}
       </div>
@@ -189,6 +190,81 @@ const TargetsPage = {
     if (aBtn) aBtn.addEventListener('click', () => { location.hash = '#/assets?target_id=' + t.id; });
     const dBtn = document.getElementById('target-delete-btn');
     if (dBtn) dBtn.addEventListener('click', () => this.deleteTarget(t.id, t.value));
+
+    // SPEC-SCHED1.4c R3: schedules-for-this-target section.
+    this.renderTargetSchedulesSection(t);
+  },
+
+  async renderTargetSchedulesSection(t) {
+    const slot = document.getElementById('target-schedules-slot');
+    if (!slot) return;
+    slot.innerHTML = '<div class="card"><div class="card-label">Schedules</div><div class="text-muted" style="padding:8px 0">Loading…</div></div>';
+    try {
+      const resp = await API.listSchedules({ target_id: t.id, limit: 100 });
+      const items = (resp && resp.items) || [];
+      slot.innerHTML = this.targetSchedulesCard(t, items);
+      this.bindTargetSchedulesActions(t);
+    } catch (err) {
+      slot.innerHTML = `<div class="card"><div class="card-label">Schedules</div>${Components.errorBanner(err)}</div>`;
+    }
+  },
+
+  targetSchedulesCard(t, items) {
+    if (items.length === 0) {
+      return `<div class="card">
+        <div class="card-label">Schedules</div>
+        <div style="margin-top:8px">
+          <span class="text-muted">No schedules for this target yet.</span>
+          <div style="margin-top:8px;display:flex;gap:8px">
+            <button type="button" class="btn btn-sm btn-accent" id="target-schedules-adhoc">Run scan now</button>
+            <button type="button" class="btn btn-sm btn-ghost" id="target-schedules-create">Create schedule</button>
+          </div>
+        </div>
+      </div>`;
+    }
+    const rows = items.map(s => `
+      <tr class="clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">
+        <td class="mono">${Components.truncateID(s.id)}</td>
+        <td class="mono">${s.template_id ? Components.truncateID(s.template_id) : '<span class="text-muted">—</span>'}</td>
+        <td>${Components.scheduleStatusBadge(s.status)}</td>
+        <td>${Components.rruleCompact(s.rrule)}</td>
+        <td class="text-muted">${Components.nextRun(s.next_run_at)}</td>
+      </tr>
+    `).join('');
+    return `<div class="card">
+      <div class="card-label">Schedules <span class="text-muted" style="font-weight:400;text-transform:none">(${items.length})</span>
+        <button type="button" class="btn btn-sm btn-ghost" id="target-schedules-create" style="margin-left:12px">+ New</button>
+      </div>
+      <div class="table-container" style="border:none;margin:8px 0 0">
+        <table>
+          <thead><tr>
+            <th scope="col">ID</th>
+            <th scope="col">Template</th>
+            <th scope="col">Status</th>
+            <th scope="col">RRULE</th>
+            <th scope="col">Next run</th>
+          </tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
+    </div>`;
+  },
+
+  bindTargetSchedulesActions(t) {
+    const adhocBtn = document.getElementById('target-schedules-adhoc');
+    if (adhocBtn) adhocBtn.addEventListener('click', () => {
+      if (typeof AdHocPage !== 'undefined' && AdHocPage.open) AdHocPage.open({ prefillTargetID: t.id });
+    });
+    const createBtn = document.getElementById('target-schedules-create');
+    if (createBtn) createBtn.addEventListener('click', () => {
+      if (typeof SchedulesPage !== 'undefined' && SchedulesPage.openForm) {
+        SchedulesPage.openForm({
+          mode: 'create',
+          schedule: { target_id: t.id },
+          onSaved: () => TargetsPage.renderDetail(document.getElementById('app'), t.id),
+        });
+      }
+    });
   },
 
   renderTargetStateCard(scan) {

--- a/internal/webui/static/js/pages/templates.js
+++ b/internal/webui/static/js/pages/templates.js
@@ -20,12 +20,59 @@ const TemplatesPage = {
       const data = await API.listTemplates({ limit, offset });
       app.innerHTML = this.template(data, { limit, offset });
       this.bindListActions(app);
+      // SPEC-SCHED1.4c R6: hydrate USED BY counts for the visible
+      // page. Runs after paint so the first render isn't blocked by
+      // the N per-template fetches.
+      this.hydrateUsedByCounts(data && data.items);
     } catch (err) {
       app.innerHTML = `
         <div class="page-header"><h2>Templates</h2></div>
         ${Components.errorBanner(err)}
       `;
     }
+  },
+
+  // USED_BY_SOFT_THRESHOLD: above this count we skip the per-template
+  // fetch (OQ5) — the latency budget would balloon with the list size,
+  // and anyone browsing that many templates probably already knows
+  // which ones are hot. Placeholder '—' with a tooltip explains why.
+  USED_BY_SOFT_THRESHOLD: 50,
+
+  async hydrateUsedByCounts(items) {
+    if (!items || !items.length) return;
+    const cells = document.querySelectorAll('[data-used-by]');
+    if (!cells.length) return;
+
+    if (items.length > this.USED_BY_SOFT_THRESHOLD) {
+      cells.forEach(cell => {
+        cell.textContent = '—';
+        cell.title = 'Count unavailable for lists over ' + this.USED_BY_SOFT_THRESHOLD + ' templates.';
+      });
+      return;
+    }
+
+    // Fetch in parallel: bounded by slowest single request, not by sum.
+    const byId = new Map();
+    cells.forEach(cell => byId.set(cell.dataset.usedBy, cell));
+
+    await Promise.all(items.map(async t => {
+      const cell = byId.get(t.id);
+      if (!cell) return;
+      try {
+        const resp = await API.listSchedules({ template_id: t.id, limit: 1 });
+        const total = (resp && typeof resp.total === 'number') ? resp.total : null;
+        if (total == null) {
+          cell.textContent = '?';
+          cell.title = 'Count not available (API did not return a total).';
+        } else {
+          cell.textContent = String(total);
+          cell.title = total === 0 ? 'No schedules reference this template.' : total + ' schedule(s) reference this template.';
+        }
+      } catch (err) {
+        cell.textContent = '?';
+        cell.title = 'Error loading count: ' + (err.message || 'unknown');
+      }
+    }));
   },
 
   bindListActions(app) {
@@ -59,6 +106,7 @@ const TemplatesPage = {
           <td>${escapeHtml(t.name || '-')} ${sysBadge}</td>
           <td class="text-muted">${escapeHtml(Components.truncate(t.description || '', 80))}</td>
           <td>${toolCount}</td>
+          <td data-used-by="${escapeHtml(t.id)}" title="Loading…">…</td>
           <td>${Components.rruleCompact(t.rrule)}</td>
           <td class="text-muted">${Components.timeAgo(t.updated_at)}</td>
         </tr>
@@ -74,7 +122,7 @@ const TemplatesPage = {
         ${headerActions}
       </div>
       ${Components.table(
-        ['ID', 'Name', 'Description', 'Tools', 'RRULE', 'Updated'],
+        ['ID', 'Name', 'Description', 'Tools', 'USED BY', 'RRULE', 'Updated'],
         [rows]
       )}
       ${pager}

--- a/internal/webui/static/js/pages/timeline.js
+++ b/internal/webui/static/js/pages/timeline.js
@@ -1,0 +1,183 @@
+// SPEC-SCHED1.4c R2: Timeline page.
+//
+// Day-grouped vertical list of upcoming firings from
+// /api/v1/schedules/upcoming. No 2D calendar grid — vanilla-JS tractable,
+// no date library. Horizon + target filter adjust the fetch. Days in
+// the horizon with zero firings get a clickable empty slot that opens
+// the 1.4b schedule create modal with dtstart pre-filled (OQ2: local
+// 09:00 default).
+
+const TimelinePage = {
+  _horizon: '24h',
+  _targetID: '',
+
+  async render(app, params) {
+    // Query params override in-memory state on route hit so deep links
+    // survive a refresh.
+    const f = this.parseParams(params || {});
+    this._horizon = f.horizon;
+    this._targetID = f.target_id;
+
+    app.innerHTML = '<div class="loading">Loading timeline...</div>';
+    try {
+      const apiParams = { horizon: f.horizon, limit: 500 };
+      if (f.target_id) apiParams.target_id = f.target_id;
+      const data = await API.upcomingSchedules(apiParams);
+      app.innerHTML = this.template(data, f);
+      this.bindHeader(app);
+      this.bindBody(app, data, f);
+    } catch (err) {
+      app.innerHTML = `
+        <div class="page-header"><h2>Timeline</h2></div>
+        ${Components.errorBanner(err)}
+      `;
+    }
+  },
+
+  parseParams(params) {
+    return {
+      horizon: params.horizon || this._horizon || '24h',
+      target_id: params.target_id || this._targetID || '',
+    };
+  },
+
+  template(data, f) {
+    const items = (data && data.items) || [];
+    const blackouts = (data && data.blackouts_in_horizon) || [];
+    const totalFirings = items.length;
+
+    const body = items.length === 0
+      ? Components.emptyState(
+          'No upcoming firings',
+          `No schedules are going to fire in the next ${escapeHtml(f.horizon)}. Check <a href="#/schedules">/schedules</a> to make sure at least one schedule is active.`,
+        )
+      : '<div id="timeline-days"></div>';
+
+    const bkHtml = blackouts.length === 0
+      ? ''
+      : `<div class="card" style="margin-top:16px">
+           <div class="card-label">Blackouts in horizon <span class="text-muted" style="font-weight:400;text-transform:none">(${blackouts.length})</span></div>
+           <ul style="margin-top:8px;font-size:13px">
+             ${blackouts.map(b => `<li><span class="mono">${Components.truncateID(b.blackout_id)}</span> — ${escapeHtml(new Date(b.starts_at).toLocaleString())} → ${escapeHtml(new Date(b.ends_at).toLocaleString())}</li>`).join('')}
+           </ul>
+         </div>`;
+
+    return `
+      <div class="page-header">
+        <h2>Timeline</h2>
+        <p>${totalFirings} upcoming firing${totalFirings === 1 ? '' : 's'} in the next ${escapeHtml(f.horizon)}</p>
+      </div>
+      <div class="inline-form" style="margin-bottom:16px;gap:12px;align-items:center">
+        <label class="form-label" style="margin:0">Horizon</label>
+        <span id="timeline-horizon-host"></span>
+        <label class="form-label" style="margin:0">Target</label>
+        <span id="timeline-target-host"></span>
+      </div>
+      ${body}
+      ${bkHtml}
+    `;
+  },
+
+  bindHeader(app) {
+    const hHost = document.getElementById('timeline-horizon-host');
+    if (hHost) {
+      const sel = Components.horizonSelector({
+        current: this._horizon,
+        onChange: (v) => {
+          this._horizon = v;
+          location.hash = this.hashForFilters();
+        },
+      });
+      hHost.appendChild(sel);
+    }
+    const tHost = document.getElementById('timeline-target-host');
+    if (tHost) {
+      const sel = Components.targetFilterSelector({
+        targets: [],
+        current: this._targetID,
+        onChange: (v) => {
+          this._targetID = v;
+          location.hash = this.hashForFilters();
+        },
+      });
+      tHost.appendChild(sel);
+    }
+  },
+
+  hashForFilters() {
+    const parts = [];
+    if (this._horizon && this._horizon !== '24h') parts.push('horizon=' + encodeURIComponent(this._horizon));
+    if (this._targetID) parts.push('target_id=' + encodeURIComponent(this._targetID));
+    return '#/timeline' + (parts.length ? '?' + parts.join('&') : '');
+  },
+
+  bindBody(app, data, f) {
+    const host = document.getElementById('timeline-days');
+    if (!host) return;
+
+    const grouped = Components.groupByDay((data && data.items) || []);
+    const horizonDays = expandHorizonDays(f.horizon, grouped);
+
+    horizonDays.forEach(({ key, label }) => {
+      const section = document.createElement('div');
+      section.className = 'timeline-day';
+      const header = document.createElement('div');
+      header.className = 'timeline-day-header';
+      header.innerHTML = `<span>${escapeHtml(label)}</span><span class="text-muted" style="font-size:11px">${escapeHtml(key)}</span>`;
+      section.appendChild(header);
+
+      const body = document.createElement('div');
+      body.className = 'timeline-day-items';
+      const group = grouped.find(g => g.date === key);
+      if (group && group.items.length) {
+        group.items.forEach(fi => {
+          body.appendChild(Components.timelineRow({
+            firing: fi,
+            onClick: (ff) => { location.hash = '#/schedules/' + encodeURIComponent(ff.schedule_id); },
+          }));
+        });
+      } else {
+        body.appendChild(Components.timelineEmptySlot({
+          date: key,
+          onClickCreate: (dtstartISO) => {
+            if (typeof SchedulesPage !== 'undefined' && SchedulesPage.openForm) {
+              SchedulesPage.openForm({
+                mode: 'create',
+                schedule: { dtstart: dtstartISO, target_id: f.target_id || '' },
+                onSaved: () => TimelinePage.render(app, {}),
+              });
+            }
+          },
+        }));
+      }
+      section.appendChild(body);
+      host.appendChild(section);
+    });
+  },
+};
+
+// expandHorizonDays returns the keyed day list to render. We start at
+// "today" and add days out to the horizon so the viewer sees empty days
+// (slot-creation targets) even when no firings fall on them. Horizon
+// strings we recognise: Nh (hours) / Nd (days). Unknown format → just
+// render the days present in `grouped`.
+function expandHorizonDays(horizon, grouped) {
+  const m = /^(\d+)([hd])$/.exec(horizon || '24h');
+  if (!m) return grouped.map(g => ({ key: g.date, label: g.dayLabel }));
+  const n = parseInt(m[1], 10);
+  const hours = m[2] === 'd' ? n * 24 : n;
+  const days = Math.max(1, Math.ceil(hours / 24));
+  const out = [];
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  for (let i = 0; i < days; i++) {
+    const d = new Date(today);
+    d.setDate(d.getDate() + i);
+    const key = d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+    out.push({
+      key,
+      label: i === 0 ? 'Today' : (i === 1 ? 'Tomorrow' : d.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' })),
+    });
+  }
+  return out;
+}

--- a/internal/webui/ui_integration_test.go
+++ b/internal/webui/ui_integration_test.go
@@ -292,6 +292,80 @@ func TestIntegration_UIWriteFlows(t *testing.T) {
 	}
 }
 
+// TestIntegration_UITimeline asserts the 1.4c additions: timeline
+// page module, sidebar link + hash route, timeline helpers in
+// components.js, schedules-for-target section, target-detail ad-hoc
+// prefill support, dashboard Run scan now button, USED BY column
+// header, and the blackout activations placeholder. All assertions are
+// string-matches on embedded files or the served shell.
+func TestIntegration_UITimeline(t *testing.T) {
+	_, base, stop := startIntegrationServer(t)
+	defer stop()
+
+	code, body := getBody(t, base+"/")
+	require.Equal(t, http.StatusOK, code)
+	html := string(body)
+
+	// Timeline nav link + <script> tag in the shell.
+	assert.Contains(t, html, `href="#/timeline"`, "shell missing Timeline nav link")
+	assert.Contains(t, html, `/js/pages/timeline.js`, "shell missing timeline.js <script> tag")
+
+	// Timeline page module embedded.
+	_, err := fs.Stat(staticFS, "static/js/pages/timeline.js")
+	assert.NoError(t, err, "embed.FS missing static/js/pages/timeline.js")
+
+	// app.js registers the #/timeline hash route. The regex literal
+	// uses JS-escaped `\/` so we assert on the stable symbol
+	// TimelinePage.render instead of the character-escape dance.
+	appJS := readEmbedded(t, "static/js/app.js")
+	assert.Contains(t, appJS, "TimelinePage.render", "app.js missing TimelinePage.render binding")
+	assert.Contains(t, appJS, "page: 'timeline'", "app.js missing timeline route registration")
+
+	// Timeline helpers in components.js.
+	components := readEmbedded(t, "static/js/components.js")
+	for _, name := range []string{
+		"groupByDay", "timelineRow", "timelineEmptySlot",
+		"horizonSelector", "targetFilterSelector",
+	} {
+		assert.Contains(t, components, name, "components.js missing %s", name)
+	}
+
+	// Target-detail schedules section + ad-hoc prefill launcher.
+	targetsJS := readEmbedded(t, "static/js/pages/targets.js")
+	for _, name := range []string{
+		"renderTargetSchedulesSection", "targetSchedulesCard",
+		"bindTargetSchedulesActions",
+		// 1.4c R4: the detail-page Scan now wires to AdHocPage.open.
+		"AdHocPage.open",
+	} {
+		assert.Contains(t, targetsJS, name, "targets.js missing %s", name)
+	}
+
+	// AdHoc modal accepts prefill (R4 signature extension).
+	adhocJS := readEmbedded(t, "static/js/pages/adhoc.js")
+	for _, name := range []string{"prefillTargetID", "lockTargetID", "adhoc-target-unlock"} {
+		assert.Contains(t, adhocJS, name, "adhoc.js missing %s", name)
+	}
+
+	// Dashboard Run scan now button restored.
+	dashJS := readEmbedded(t, "static/js/pages/dashboard.js")
+	for _, name := range []string{`data-action="run-scan-now"`, "dashboard-run-scan-btn"} {
+		assert.Contains(t, dashJS, name, "dashboard.js missing %s", name)
+	}
+
+	// Templates list USED BY column + hydration helper.
+	templatesJS := readEmbedded(t, "static/js/pages/templates.js")
+	for _, name := range []string{"USED BY", "hydrateUsedByCounts", "USED_BY_SOFT_THRESHOLD", "data-used-by"} {
+		assert.Contains(t, templatesJS, name, "templates.js missing %s", name)
+	}
+
+	// Blackout activations placeholder.
+	blackoutsJS := readEmbedded(t, "static/js/pages/blackouts.js")
+	for _, name := range []string{`data-section="blackout-activations-placeholder"`, "Activation preview will be available"} {
+		assert.Contains(t, blackoutsJS, name, "blackouts.js missing %s", name)
+	}
+}
+
 func readEmbedded(t *testing.T, path string) string {
 	t.Helper()
 	f, err := staticFS.Open(path)


### PR DESCRIPTION
## What shipped

Final UI phase of SPEC-SCHED1. Every committed 1.4 goal is now addressed; only 1.5 (agent-spec v3.0 + docs + e2e) remains.

- **Timeline page** at `#/timeline` — day-grouped vertical list of upcoming firings from `/api/v1/schedules/upcoming`. Horizon selector (1h / 6h / 24h / 3d / 7d / 30d, default 24h), target filter with datalist autocomplete, empty-day slots that open the 1.4b schedule create modal with `dtstart` pre-filled.
- **Timeline helpers** in [components.js](internal/webui/static/js/components.js): `groupByDay`, `timelineRow`, `timelineEmptySlot`, `horizonSelector`, `targetFilterSelector`. Pure native `Date` arithmetic, no date library.
- **Target detail integration** — [pages/targets.js](internal/webui/static/js/pages/targets.js) gains a "Schedules" card (schedules filtered by `target_id`) with empty-state CTAs for ad-hoc dispatch and schedule creation. The detail page's "Scan now" button now opens the 1.4b ad-hoc modal with `target_id` pre-filled (readonly, with "Edit target" unlock link).
- **Ad-hoc modal prefill** — [pages/adhoc.js](internal/webui/static/js/pages/adhoc.js) `open()` now accepts an optional `{prefillTargetID, prefillTemplateID, prefillReason, prefillToolConfigOverride, lockTargetID}`. Backwards compatible — existing callers pass no args.
- **Dashboard "Run scan now" button restored** — [pages/dashboard.js](internal/webui/static/js/pages/dashboard.js) header gains a primary-colored `data-action="run-scan-now"` button opening the generic ad-hoc modal. Replaces the button deleted with trigger in 1.4a.
- **USED BY column on templates list** — populated via `Promise.all` of per-template `listSchedules({template_id, limit:1}).total` fetches. Soft threshold at 50 templates: above that, `—` with tooltip. Per-fetch failure → `?` with error tooltip, list render does not fail.
- **Blackout activations placeholder** — [pages/blackouts.js](internal/webui/static/js/pages/blackouts.js) detail page carries an explicit `data-section="blackout-activations-placeholder"` card with the RRULE, duration, and timezone spelled out plus a CLI hint. Future work tracked.
- **Integration test extended** with timeline/target/dashboard/USED BY/placeholder embed + shell assertions. Prior 1.4a + 1.4b assertions preserved.

## Deviations

- **OQ1 (route name)** — `#/timeline`. Shorter than `#/schedules/upcoming`, matches operator mental model.
- **OQ2 (empty-slot default time)** — local `09:00`. Friendlier than UTC; `Date(y, m-1, d, 9, 0, 0).toISOString()` serializes to whatever UTC offset the browser is in.
- **OQ3 (target-detail prefill mode)** — readonly by default with an "Edit target" link that drops the `readonly` attribute and refocuses. Guards against accidental retargeting.
- **OQ4 (modal signature extension)** — `AdHocPage.open(prefill?)`. Was `open()` in 1.4b; extended backwards-compatibly.
- **OQ5 (USED BY threshold)** — 50. Conservative default; easy to tune via `TemplatesPage.USED_BY_SOFT_THRESHOLD` if operators hit it.
- **OQ6 (dashboard button position)** — top-right of the dashboard header (inside `.page-header`), matching the `New schedule` / `New template` / `New blackout` placements already used across the SPA.
- **OQ7 (blackouts-on-target section, NH1)** — deferred. Would need double-fetch (scope=global + scope=target merged) and isn't trivial; post-launch if operators request it.
- **targets.js list-row "Scan now"** — unchanged. The legacy `API.startScan('full')` path still fires for quick-actions on the list page; only the detail page button routes to the ad-hoc modal. List overhaul is separate work.

## Known limitation — blackout activations preview

The spec permits either a client-side RRULE expander or a new `/api/v1/blackouts/:id/upcoming` endpoint. Both are deliberately out of scope for 1.4c:
- JS expander would duplicate `intervalsched` (untouchable) and drift.
- A new endpoint would break the "no new API endpoints in 1.4c" constraint.

The placeholder explicitly documents this. Future work should be a small post-launch spec that picks one of the two options.

## Gates

- [x] `go build ./...`
- [x] `go test ./... -race -count=1`
- [x] `go test -tags=integration ./... -race -count=1`
- [x] `golangci-lint run` — clean

## Operator smoke TODO (seven steps)

1. **Timeline render** — open `#/timeline`; verify Today + Tomorrow sections; change horizon to "7 days" and confirm range widens; filter by a known target.
2. **Timeline inline-create** — click the "Click to create a schedule for this day" empty slot; verify the 1.4b create modal opens with `dtstart` pre-filled to 09:00 local of that day; submit; verify new row in timeline.
3. **Target detail: Schedules section** — open a target detail page that has ≥1 schedule; verify Schedules card appears. Open one with zero schedules; verify the empty-state CTAs render (`Run scan now` + `Create schedule`).
4. **Target detail: ad-hoc prefill** — on a target detail page, click "Scan now" in the header; verify the ad-hoc modal opens with `target_id` readonly and pre-filled. Click "Edit target" to drop the readonly; submit; observe the returned `ad_hoc_run_id` / `scan_id`.
5. **Dashboard Run scan now** — on `#/` (dashboard), click "Run scan now" in the header; verify the generic ad-hoc modal opens with no prefill.
6. **Templates USED BY column** — on `#/templates`, verify USED BY counts populate after paint. Create 3 templates with 0 / 1 / 3 schedules each and verify exact counts.
7. **Blackout activations placeholder** — open a blackout detail page; verify the "Upcoming activations" card renders the placeholder text plus the blackout's RRULE and CLI hint.