### PR TITLE
SCHED1-HOTFIX: restore CLI writes and UI schedule firing

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -232,6 +232,18 @@ Check `scan_runs.reason` — if it's `blackout_pause`, a blackout window
 activated mid-scan (the pause-in-flight behavior). The next scheduled
 tick after the blackout ends re-dispatches normally.
 
+### "403 `missing origin` from the CLI"
+
+The `surfbot ui` web server enforces a same-origin check on every
+mutating request (`POST`/`PUT`/`DELETE`/`PATCH`) — cross-site callers
+without an `Origin` header pointing back at the loopback UI are
+rejected with `403 missing origin`. Builds from **SCHED1-HOTFIX-P0 and
+later** derive the `Origin` header automatically inside the CLI's API
+client, so the stock `surfbot schedule|template|blackout|defaults|scan
+adhoc` commands just work. If you see this 403, upgrade your `surfbot`
+binary; older builds predate the fix and will keep getting rejected
+even against localhost.
+
 ### "Edit to a template didn't take effect"
 
 Template edits cascade asynchronously: the server triggers

--- a/internal/cli/apiclient/client.go
+++ b/internal/cli/apiclient/client.go
@@ -21,8 +21,15 @@ const DefaultTimeout = 30 * time.Second
 // Client is the surfbot CLI's API client. One instance is shared
 // across all subcommands per invocation; tests create their own with
 // httptest.NewServer.
+//
+// The client sets an Origin header (derived from baseURL as
+// "scheme://host[:port]") on every request so that it satisfies the
+// same-origin check enforced by the webui middleware for mutating
+// methods. Callers pointing at a bare apiv1 mux (no webui middleware)
+// are unaffected — the header is additive.
 type Client struct {
 	baseURL    string
+	origin     string
 	httpClient *http.Client
 	userAgent  string
 	authToken  string
@@ -55,10 +62,17 @@ func WithAuthToken(token string) Option {
 
 // New returns a Client targeting baseURL (e.g. "http://127.0.0.1:8470").
 // Trailing slashes are trimmed so callers don't have to worry about
-// double-slashes in request paths.
+// double-slashes in request paths. An Origin header is derived from
+// baseURL and sent on every request to satisfy the webui same-origin
+// check; if baseURL is empty or unparseable, the origin is left empty
+// and requests fall through to the underlying HTTP round-trip (callers
+// pointing at an unauthenticated daemon or a bare apiv1 mux see no
+// behavior change).
 func New(baseURL string, opts ...Option) *Client {
+	trimmed := strings.TrimRight(baseURL, "/")
 	c := &Client{
-		baseURL:    strings.TrimRight(baseURL, "/"),
+		baseURL:    trimmed,
+		origin:     deriveOrigin(trimmed),
 		httpClient: &http.Client{Timeout: DefaultTimeout},
 		userAgent:  "surfbot-cli",
 	}
@@ -66,6 +80,21 @@ func New(baseURL string, opts ...Option) *Client {
 		o(c)
 	}
 	return c
+}
+
+// deriveOrigin reassembles the scheme+host of baseURL into the
+// Origin-header shape ("scheme://host[:port]"). Returns "" for inputs
+// that url.Parse rejects or that lack a scheme/host — callers treat an
+// empty origin as "do not set the header".
+func deriveOrigin(baseURL string) string {
+	if baseURL == "" {
+		return ""
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+	return u.Scheme + "://" + u.Host
 }
 
 // BaseURL returns the effective base URL — exposed so the CLI can
@@ -94,6 +123,9 @@ func (c *Client) do(ctx context.Context, method, path string, body any, out any)
 	}
 	req.Header.Set("Accept", "application/json, application/problem+json")
 	req.Header.Set("User-Agent", c.userAgent)
+	if c.origin != "" {
+		req.Header.Set("Origin", c.origin)
+	}
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}

--- a/internal/cli/apiclient/client_origin_test.go
+++ b/internal/cli/apiclient/client_origin_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+package apiclient_test
+
+// SPEC-SCHED1-HOTFIX R3: prove the apiclient works end-to-end against
+// the full webui middleware stack, not just the bare apiv1 mux.
+//
+// Before this hotfix, every POST/PUT/DELETE/PATCH from the CLI got 403
+// "missing origin" because the webui's validateOrigin middleware
+// enforces a same-origin check and the client never set the Origin
+// header. Unit tests in this package hit httptest.NewServer(handler)
+// and so bypassed that middleware entirely. This test is the missing
+// harness-layer check: it drives GET + POST + DELETE through
+// webui.NewServer (which wires securityHeaders → validateHost →
+// validateOrigin → mux) and asserts that every write verb returns 2xx.
+//
+// Run with: go test -tags=integration ./internal/cli/apiclient/... -race -count=1
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/cli/apiclient"
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+	"github.com/surfbot-io/surfbot-agent/internal/webui"
+)
+
+// startWebuiServer boots a real webui.NewServer on a loopback port with
+// a file-backed SQLite store. Mirrors the pattern used in
+// internal/webui/ui_integration_test.go — file-backed :memory: isn't
+// viable across the pool's multiple connections.
+func startWebuiServer(t *testing.T) (*apiclient.Client, *storage.SQLiteStore, func()) {
+	t.Helper()
+	store, err := storage.NewSQLiteStore(filepath.Join(t.TempDir(), "hotfix.db"))
+	require.NoError(t, err)
+
+	tmpLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := tmpLn.Addr().(*net.TCPAddr).Port
+	require.NoError(t, tmpLn.Close())
+
+	srv, ln, err := webui.NewServer(store, webui.ServerOptions{
+		Bind: "127.0.0.1", Port: port, Version: "hotfix-test",
+	})
+	require.NoError(t, err)
+
+	go func() { _ = srv.Serve(ln) }()
+	// Tiny settle so the listener is serving before the first request.
+	time.Sleep(20 * time.Millisecond)
+
+	base := "http://127.0.0.1:" + strconv.Itoa(port)
+	client := apiclient.New(base)
+
+	cleanup := func() {
+		_ = srv.Shutdown(context.Background())
+		_ = store.Close()
+	}
+	return client, store, cleanup
+}
+
+// TestClientOrigin_FullStack_GetPostDelete drives one GET, one POST,
+// and one DELETE through the full webui middleware chain. Pre-R1 this
+// failed with 403 "missing origin" on POST and DELETE; post-R1 every
+// call returns 2xx because the client now derives Origin from baseURL
+// and sets it on every request.
+func TestClientOrigin_FullStack_GetPostDelete(t *testing.T) {
+	client, store, stop := startWebuiServer(t)
+	defer stop()
+
+	ctx := context.Background()
+
+	// Seed a target so schedule create has a valid FK referent.
+	tgt := &model.Target{Value: "example.com"}
+	require.NoError(t, store.CreateTarget(ctx, tgt))
+
+	// GET: list schedules. Safe methods pre-R1 already worked because
+	// validateOrigin only gates mutating verbs — but we exercise it so
+	// the full round-trip is proven (auth + host + origin + mux).
+	listed, err := client.ListSchedules(ctx, apiclient.ListSchedulesParams{})
+	require.NoError(t, err, "GET /api/v1/schedules")
+	assert.Empty(t, listed.Items, "seed DB must start empty")
+
+	// POST: create a schedule. Pre-R1 this 403'd with "missing origin".
+	enabled := true
+	created, err := client.CreateSchedule(ctx, apiclient.CreateScheduleRequest{
+		TargetID: tgt.ID,
+		Name:     "hotfix-schedule",
+		RRule:    "FREQ=DAILY",
+		Timezone: "UTC",
+		Enabled:  &enabled,
+	})
+	require.NoError(t, err, "POST /api/v1/schedules must succeed through webui stack")
+	require.NotEmpty(t, created.ID, "created schedule has empty ID")
+
+	// DELETE: hard delete the row. Pre-R1 this 403'd likewise.
+	err = client.DeleteSchedule(ctx, created.ID)
+	require.NoError(t, err, "DELETE /api/v1/schedules/{id} must succeed through webui stack")
+
+	// Sanity: the row is gone.
+	after, err := client.ListSchedules(ctx, apiclient.ListSchedulesParams{})
+	require.NoError(t, err)
+	assert.Empty(t, after.Items)
+}

--- a/internal/cli/apiclient/client_test.go
+++ b/internal/cli/apiclient/client_test.go
@@ -253,6 +253,29 @@ func TestClientSchedulePauseResume(t *testing.T) {
 	}
 }
 
+func TestClientOriginHeader(t *testing.T) {
+	var gotOrigin string
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"POST /api/v1/schedules": func(w http.ResponseWriter, r *http.Request) {
+			gotOrigin = r.Header.Get("Origin")
+			writeJSON(w, http.StatusCreated, Schedule{ID: "s1"})
+		},
+	})
+	c := New(srv.URL)
+	if _, err := c.CreateSchedule(context.Background(), CreateScheduleRequest{TargetID: "t"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// httptest.NewServer URL is "http://127.0.0.1:PORT"; the derived
+	// Origin must be the scheme+host form of that URL exactly, so the
+	// webui's validateOrigin allow-list matches it without slashing.
+	if gotOrigin == "" {
+		t.Fatalf("Origin header not set")
+	}
+	if gotOrigin != srv.URL {
+		t.Fatalf("Origin = %q, want %q", gotOrigin, srv.URL)
+	}
+}
+
 func TestClientAuthorizationHeader(t *testing.T) {
 	var gotAuth string
 	srv := newTestServer(t, map[string]http.HandlerFunc{

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -2,6 +2,7 @@ package webui
 
 import (
 	"bytes"
+	"context"
 	"embed"
 	"fmt"
 	"html"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	apiv1 "github.com/surfbot-io/surfbot-agent/internal/api/v1"
+	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
 	"github.com/surfbot-io/surfbot-agent/internal/detection"
 	"github.com/surfbot-io/surfbot-agent/internal/storage"
 )
@@ -189,6 +191,20 @@ func NewServer(store *storage.SQLiteStore, opts ServerOptions) (*http.Server, ne
 // dispatcher slot is populated only when the caller plugged a live
 // AdHocDispatcher into the DaemonView — otherwise POST /scans/ad-hoc
 // returns 503 with the dispatcher-unreachable problem type.
+//
+// SPEC-SCHED1-HOTFIX R2: the RRule expander is constructed here so
+// schedule create/update and the template/defaults cascade handlers
+// can populate scan_schedules.next_run_at synchronously. Without this,
+// every schedule written via the REST API would land with
+// next_run_at = NULL and be invisible to the master ticker.
+//
+// The expander + blackout evaluator are built once at registration
+// from a current snapshot of schedule_defaults and blackouts. In the
+// single-process webui topology, operator edits to
+// /settings/defaults after startup will not flow into the in-process
+// expander until the process restarts — that's an accepted trade-off
+// for this hotfix; the daemon-owned scheduler refreshes on its own
+// loop and is the authoritative recomputer in the long run.
 func registerV1Routes(mux *http.ServeMux, store *storage.SQLiteStore, view *DaemonView) {
 	deps := apiv1.APIDeps{
 		Store:         store,
@@ -198,6 +214,7 @@ func registerV1Routes(mux *http.ServeMux, store *storage.SQLiteStore, view *Daem
 		DefaultsStore: store.ScheduleDefaults(),
 		AdHocStore:    store.AdHocScanRuns(),
 	}
+	deps.Expander, deps.Blackouts = buildV1Expander(store)
 	if view != nil && view.AdHocDispatcher != nil {
 		// webui.AdHocDispatcher and apiv1.Dispatcher have identical
 		// method sets; direct assignment wires the scheduler through
@@ -205,6 +222,29 @@ func registerV1Routes(mux *http.ServeMux, store *storage.SQLiteStore, view *Daem
 		deps.Dispatcher = view.AdHocDispatcher
 	}
 	apiv1.RegisterRoutes(mux, deps)
+}
+
+// buildV1Expander constructs an RRuleExpander + BlackoutEvaluator
+// snapshot for the REST API handlers. Returns (nil, nil) when the
+// defaults singleton can't be read — the handlers then fall back to
+// the pre-hotfix behavior (leaves next_run_at unset, daemon will
+// recompute on its next tick). This is strictly best-effort wiring
+// and must never fail the server boot.
+func buildV1Expander(store *storage.SQLiteStore) (*intervalsched.RRuleExpander, *intervalsched.BlackoutEvaluator) {
+	ctx := context.Background()
+	defaults, err := store.ScheduleDefaults().Get(ctx)
+	if err != nil || defaults == nil {
+		log.Printf("[webui] rrule expander not wired: %v", err)
+		return nil, nil
+	}
+	blackouts := intervalsched.NewBlackoutEvaluator(store.Blackouts())
+	if err := blackouts.Refresh(ctx); err != nil {
+		// Non-fatal: the evaluator treats an unpopulated cache as
+		// "no blackouts", which matches the fallback we want anyway.
+		log.Printf("[webui] blackout evaluator initial refresh failed: %v", err)
+	}
+	expander := intervalsched.NewRRuleExpander(*defaults, blackouts, nil, time.Now().UnixNano())
+	return expander, blackouts
 }
 
 // isAssetPath reports whether a request path lives under one of the

--- a/internal/webui/ui_integration_test.go
+++ b/internal/webui/ui_integration_test.go
@@ -434,6 +434,95 @@ func TestIntegration_NextRunAt_PopulatedOnCreate(t *testing.T) {
 	require.NotNil(t, got.NextRunAt, "stored schedule row must have next_run_at populated")
 }
 
+// TestIntegration_NextRunAt_PopulatedOnCascades covers the three other
+// paths that depend on APIDeps.Expander:
+//   - PUT /api/v1/templates/{id} triggers RecomputeNextRunForTemplate
+//   - PUT /api/v1/schedule-defaults cascades across every template
+//   - POST /api/v1/schedules/bulk (clone op) recomputes dependents of
+//     the affected template
+//
+// Each assertion reads the stored row directly so we verify the
+// write-through, not just the handler return value.
+func TestIntegration_NextRunAt_PopulatedOnCascades(t *testing.T) {
+	store, base, stop := startIntegrationServer(t)
+	defer stop()
+
+	ctx := t.Context()
+	tgt := &model.Target{Value: "example.com"}
+	require.NoError(t, store.CreateTarget(ctx, tgt))
+
+	// Seed a template and a schedule that references it but has
+	// next_run_at = NULL (as every pre-hotfix row would).
+	tmpl := &model.Template{Name: "nightly", RRule: "FREQ=DAILY", Timezone: "UTC"}
+	require.NoError(t, store.Templates().Create(ctx, tmpl))
+	sched := &model.Schedule{
+		TargetID:   tgt.ID,
+		Name:       "cascade-target",
+		RRule:      "FREQ=DAILY",
+		DTStart:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Timezone:   "UTC",
+		TemplateID: &tmpl.ID,
+		Enabled:    true,
+	}
+	require.NoError(t, store.Schedules().Create(ctx, sched))
+	require.Nil(t, sched.NextRunAt, "seed schedule must start without next_run_at")
+
+	client := apiclient.New(base)
+
+	// (1) Template update cascade.
+	newRRule := "FREQ=WEEKLY"
+	_, err := client.UpdateTemplate(ctx, tmpl.ID, apiclient.UpdateTemplateRequest{
+		RRule: &newRRule,
+	})
+	require.NoError(t, err, "PUT /api/v1/templates/{id} must succeed")
+
+	afterTmpl, err := store.Schedules().Get(ctx, sched.ID)
+	require.NoError(t, err)
+	require.NotNil(t, afterTmpl.NextRunAt,
+		"template-update cascade must populate dependent schedule's next_run_at")
+
+	// (2) Defaults PUT cascade. Clear next_run_at first so we prove the
+	// PUT repopulates it rather than inheriting the prior value.
+	require.NoError(t, store.Schedules().SetNextRunAt(ctx, sched.ID, nil))
+	cleared, err := store.Schedules().Get(ctx, sched.ID)
+	require.NoError(t, err)
+	require.Nil(t, cleared.NextRunAt, "setup: expected nil next_run_at before PUT")
+
+	_, err = client.UpdateDefaults(ctx, apiclient.UpdateScheduleDefaultsRequest{
+		DefaultRRule:       "FREQ=DAILY;BYHOUR=3",
+		DefaultTimezone:    "UTC",
+		MaxConcurrentScans: 4,
+		JitterSeconds:      0,
+	})
+	require.NoError(t, err, "PUT /api/v1/schedule-defaults must succeed")
+	afterDefaults, err := store.Schedules().Get(ctx, sched.ID)
+	require.NoError(t, err)
+	require.NotNil(t, afterDefaults.NextRunAt,
+		"defaults-update cascade must re-populate dependent schedule's next_run_at")
+
+	// (3) Bulk create path — clone preserves src.TemplateID so the
+	// affected template's dependents (including our `sched`) are
+	// recomputed after the tx commits. Clear next_run_at on the source
+	// first so we prove the bulk endpoint re-populates it via cascade.
+	require.NoError(t, store.Schedules().SetNextRunAt(ctx, sched.ID, nil))
+	bulk, err := client.BulkSchedules(ctx, apiclient.BulkScheduleRequest{
+		Operation:   "clone",
+		ScheduleIDs: []string{sched.ID},
+		CreateTemplate: &apiclient.CreateScheduleRequest{
+			Name:     "clone-of-cascade-target",
+			RRule:    "FREQ=DAILY",
+			Timezone: "UTC",
+		},
+	})
+	require.NoError(t, err, "POST /api/v1/schedules/bulk clone must succeed")
+	require.Len(t, bulk.Succeeded, 1, "clone reports one success")
+
+	afterBulk, err := store.Schedules().Get(ctx, sched.ID)
+	require.NoError(t, err)
+	require.NotNil(t, afterBulk.NextRunAt,
+		"bulk-create cascade must re-populate dependent schedule's next_run_at")
+}
+
 func readEmbedded(t *testing.T, path string) string {
 	t.Helper()
 	f, err := staticFS.Open(path)

--- a/internal/webui/ui_integration_test.go
+++ b/internal/webui/ui_integration_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/surfbot-io/surfbot-agent/internal/cli/apiclient"
 	"github.com/surfbot-io/surfbot-agent/internal/model"
 	"github.com/surfbot-io/surfbot-agent/internal/storage"
 )
@@ -392,6 +393,45 @@ func TestIntegration_SchemasEndpoint_ViaWebui(t *testing.T) {
 
 	code, _ = getBody(t, base+"/api/v1/schemas/tools/nonexistent")
 	assert.Equal(t, http.StatusNotFound, code)
+}
+
+// TestIntegration_NextRunAt_PopulatedOnCreate is SPEC-SCHED1-HOTFIX R4,
+// create-path flavor. Before this hotfix, registerV1Routes never set
+// APIDeps.Expander, so POST /api/v1/schedules landed with
+// next_run_at = NULL. This test drives a create through the full webui
+// HTTP stack (webui.NewServer, not apiv1.mux) via the apiclient, which
+// proves that the expander is wired AND that the CLI's Origin header
+// derivation threads cleanly through validateOrigin. A stored-row read
+// confirms the column is populated synchronously, not just on the
+// response body.
+func TestIntegration_NextRunAt_PopulatedOnCreate(t *testing.T) {
+	store, base, stop := startIntegrationServer(t)
+	defer stop()
+
+	ctx := t.Context()
+	tgt := &model.Target{Value: "example.com"}
+	require.NoError(t, store.CreateTarget(ctx, tgt))
+
+	client := apiclient.New(base)
+	enabled := true
+	created, err := client.CreateSchedule(ctx, apiclient.CreateScheduleRequest{
+		TargetID: tgt.ID,
+		Name:     "hotfix-create",
+		RRule:    "FREQ=DAILY",
+		Timezone: "UTC",
+		Enabled:  &enabled,
+	})
+	require.NoError(t, err, "POST /api/v1/schedules must succeed through webui stack")
+	require.NotNil(t, created.NextRunAt, "response body must carry next_run_at")
+	assert.True(t, created.NextRunAt.After(time.Now().Add(-1*time.Minute)),
+		"next_run_at must be a concrete near-future timestamp, got %v", created.NextRunAt)
+
+	// The stored row must reflect the same populated timestamp — proves
+	// the expander wrote through SetNextRunAt synchronously, not just
+	// that the response body computed a value locally.
+	got, err := store.Schedules().Get(ctx, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.NextRunAt, "stored schedule row must have next_run_at populated")
 }
 
 func readEmbedded(t *testing.T, path string) string {


### PR DESCRIPTION
> **This is a post-ship hotfix for SPEC-SCHED1.** SCHED1 remains closed. This PR repairs two wiring defects surfaced by the product audit of `e508e6b`; it does not reopen or extend SCHED1. No agent-spec version bump.
>
> **Base:** branched on top of PR #26 (SCHED1.5) because SCHED1.5 is not yet on `main`. Rebase onto `main` once #26 merges.

## Audit findings repaired

**P0.1 — CLI writes were 403'd universally.** Every `POST`/`PUT`/`DELETE`/`PATCH` from `surfbot schedule|template|blackout|defaults|scan adhoc` failed with `403 "missing origin"` against a running `surfbot ui`. Root cause: `internal/webui/security.go` (`validateOrigin`) gates mutating verbs behind a same-origin check; `internal/cli/apiclient/client.go` never set `Origin` or `Referer`. Unit tests passed because they hit `apiv1.mux` directly, bypassing the webui middleware stack.

**P0.2 — Schedules created via UI/REST never fired.** `POST /api/v1/schedules` landed rows with `next_run_at = NULL`; the master ticker then ignored them. Root cause: `internal/webui/server.go` (`registerV1Routes`) populated `APIDeps` but left `Expander` unset; `internal/api/v1/schedules.go` `refreshNextRun` checks `deps.Expander == nil` and silently bails. Timeline-on-UI rendered firings only because `upcoming.go` does its own server-side RRULE expansion — a false positive that masked the bug.

## Before → After

P0.1 via loopback curl against the live `surfbot ui`:

```
$ curl -s -o /dev/null -w "%{http_code}\n" -X POST http://127.0.0.1:18470/api/v1/schedules/.../pause
403                                                  # no Origin → rejected
$ curl -s -o /dev/null -w "%{http_code}\n" -X POST -H "Origin: http://127.0.0.1:18470" \
      http://127.0.0.1:18470/api/v1/schedules/.../pause
200                                                  # webui now accepts an Origin-carrying client
```

P0.2 via CLI → stored row:

```
$ bin/surfbot --daemon-url http://127.0.0.1:18470 --json schedule create \
    --target <id> --name smoke --rrule "FREQ=MINUTELY"
# response body carries a concrete next_run_at:
"next_run_at": "2026-04-20T03:27:52Z",
```

Pre-hotfix the same call landed a row with `next_run_at = NULL`.

## Requirements executed

| Req | What | Commit |
| --- | --- | --- |
| R1  | `apiclient` derives Origin from baseURL and sets it on every request. | `cli: set origin header on apiclient requests derived from baseurl` |
| R3  | Full-stack integration test drives GET + POST + DELETE through `webui.NewServer` — fails pre-R1 with 403, passes post-R1. | `cli: add full-stack integration test for apiclient writes via webui handler` |
| R2  | `registerV1Routes` constructs `RRuleExpander` + `BlackoutEvaluator` from the defaults+blackouts snapshot and assigns them to `APIDeps`. | `webui: wire rrule expander into v1 api deps` |
| R4  | Extended `ui_integration_test.go` with four full-stack assertions that `next_run_at` is non-null after schedule create, template update, defaults PUT, and bulk clone. | `webui: assert next_run_at populated after schedule create ...` + cascade sibling commit |
| R5  | Doc comment on `apiclient.Client` states the Origin policy; `docs/scheduling.md` carries a Troubleshooting entry for the 403 case. | `docs: document origin policy and 403 troubleshooting ...` |

## Open Questions — resolutions (verified by code inspection)

1. **`RRuleExpander` goroutine-safe?** Yes. `ComputeNextRunAt` holds an internal `sync.Mutex` around the jitter RNG; `defaults`, `clock`, and `blackouts` are read-only after construction. `BlackoutEvaluator` is `sync.Mutex`-protected. Decision: single instance at route registration, no adapter needed.
2. **Context for defaults load?** `ScheduleDefaults().Get` is a single-row SELECT — `context.Background()` is fine at registration time.
3. **Live defaults edits reflected immediately?** No — eager-once-at-registration. Defaults edits through `/settings/defaults` after the webui process has started will not flow into the in-process expander until the process restarts. The daemon-owned scheduler refreshes on its own loop and remains the authoritative recomputer; acknowledged as a known limitation per the spec's permitted fallback (c). Documented in the helper's Go doc.
4. **Bare-host Origin (`http://localhost/` with no port)?** `validateOrigin` compares exact strings against `allowedOrigins(port)` which always includes a port. CLI derivation uses `scheme://Host`; URL parse preserves host+port exactly from baseURL. Callers pointing at a base URL without explicit port will 403 — acceptable since loopback defaults (CLI, apiclient) always carry a port.
5. **`--listen 0.0.0.0:8470` vs CLI at `127.0.0.1:8470`?** `validateHost`/`validateOrigin` are port-driven, not bind-address-driven. Origin `http://127.0.0.1:8470` matches against the allow list regardless of listener bind address. Verified OK.
6. **Backfill stale `next_run_at = NULL` rows?** No migration. Documented path: `surfbot schedule update <id>` (no-op touch) repopulates. Pre-launch fleet is small.
7. **`apiclient.New` error on bad baseURL?** Kept lenient. `deriveOrigin` returns "" for unparseable inputs so origin is simply not set — callers pointing at a bare apiv1 mux (tests, daemon-only) see no behavior change. Changing the signature to `(*Client, error)` would have cascaded through every CLI command for a hotfix; not worth it.

## Manual operator smoke (passed)

Run on `127.0.0.1:18470` against a fresh DB:

1. `./bin/surfbot ui &` — server came up clean.
2. `./bin/surfbot schedule create --target <id> --name smoke --rrule "FREQ=MINUTELY"` — exit 0, response body carried a concrete `next_run_at` ~60s in the future.
3. UI `#/schedules` row — rendered with the populated Next run timestamp (verified by visiting the React shell at http://127.0.0.1:18470/).
4. `./bin/surfbot schedule pause <id>` — exit 0, status flipped to `paused`.

## Frozen files untouched

Confirmed: no changes to `internal/scheduler/*`, `internal/daemon/intervalsched/*.go` (source files — only imported), `internal/storage/schema.sql`, `internal/api/v1/router.go`'s `APIDeps` struct definition (only the caller populates `Expander`), `internal/api/v1/schedules.go`'s `refreshNextRun`, `internal/webui/security.go`, `docs/agent-spec.md`, or `test/e2e/schedule_e2e_test.go`.

## Tests

- `go test ./... -race -count=1` — all green.
- `go test -tags=integration ./... -race -count=1` — all green; new `TestClientOrigin_FullStack_GetPostDelete`, `TestIntegration_NextRunAt_PopulatedOnCreate`, `TestIntegration_NextRunAt_PopulatedOnCascades` pass.
- `go test -tags=e2e ./test/e2e/... -count=1 -timeout 180s` — passed in ~49s wallclock.

## Commit count

6 — matches the plan. No commit-count escape hatch triggered.