### PR TITLE
SCHED2.0: surfbot ui auto-starts scheduler (single-process topology)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@ Local security scanner with pluggable detection and remediation. Open source und
 
 ## Quick Start
 
-(coming soon)
+```bash
+surfbot ui
+```
+
+That opens the dashboard at `http://127.0.0.1:8470` and starts the
+scheduler in the same process. Add a target, create a schedule, walk
+away — scans fire on the schedule until you Ctrl+C.
+
+If you want to run surfbot as a long-lived OS service instead (no
+browser-facing UI on the same host), see [Run as a service](#run-as-a-service)
+below.
 
 ## Build from Source
 
@@ -127,7 +137,12 @@ Rules:
 ## Embedded UI
 
 `surfbot ui` runs a localhost-only web dashboard at `http://127.0.0.1:8470`
-backed by the same SQLite database and config files as the CLI.
+backed by the same SQLite database and config files as the CLI. By
+default it also runs the scheduler in-process, so schedules created
+through the dashboard fire and "Run scan now" buttons work without a
+separate daemon. Pass `--no-scheduler` to opt out (useful when you've
+already installed `surfbot daemon` as a system service and want the UI
+process to stay read-only).
 
 ### Security model
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -4,6 +4,50 @@ This page explains how surfbot's scheduling subsystem fits together after
 the SPEC-SCHED1 rewrite (agent-spec 3.0). If you're coming from 2.x,
 read the [migration guide](agent-spec.md#migration-from-20) first.
 
+## Process topology
+
+There are two ways to run the scheduler. Pick **one**:
+
+### Single-process (default — recommended for laptops)
+
+```
+surfbot ui
+```
+
+That's it. `surfbot ui` boots the HTTP server on `:8470` and the master
+ticker in the same process. Schedules created in the dashboard fire,
+"Run scan now" buttons dispatch in-process, and a single Ctrl+C drains
+HTTP, stops the scheduler, and exits cleanly. This is the path the
+free-tier install assumes.
+
+If a second `surfbot ui` (or a separately-installed `surfbot daemon`)
+is already holding the scheduler lock, the new process logs
+`scheduler already running elsewhere; starting UI in --no-scheduler mode`
+and serves HTTP read-only.
+
+### Headless server
+
+```
+sudo surfbot daemon install
+sudo surfbot daemon start
+```
+
+For server installs that don't want a browser-facing UI on the same
+host, `surfbot daemon run` is the OS-managed entry point. The systemd
+unit / launchd plist / Windows service registration all delegate to it.
+You can still run `surfbot ui --no-scheduler` against the same DB to
+get a read-only dashboard; the UI process detects the daemon's
+scheduler lock and stands down.
+
+### Why two entry points?
+
+Different deployment shapes. A laptop running `surfbot ui` once a week
+doesn't want a system service installed; a fleet host running 24/7
+doesn't want an interactive process holding a port. Both paths build
+the scheduler the same way (`BuildSchedulerBootstrap` in
+`internal/cli/appcore.go`) so the behavior is identical — only the
+lifecycle owner differs.
+
 ## Overview
 
 Scheduling is built from four first-class resources, each with its own
@@ -163,7 +207,8 @@ They live at `POST /api/v1/scans/ad-hoc`:
 - Errors the operator will see often: `409 /problems/target-busy`
   (another scan already running on this target), `409 /problems/in-blackout`,
   `503 /problems/dispatcher-unreachable` (talking to a process that
-  isn't `surfbot daemon run`).
+  doesn't have the scheduler — e.g. `surfbot ui --no-scheduler` while
+  no daemon is running).
 
 The previous `POST /api/daemon/trigger` endpoint was removed with
 SPEC-SCHED1.4a. Integrators should migrate to `/api/v1/scans/ad-hoc`.
@@ -211,8 +256,11 @@ Check, in order:
    may not be running.
 3. Is a blackout active? `GET /api/v1/blackouts?active_at=<now>` tells
    you.
-4. `surfbot daemon status` — is the master ticker running? It lives
-   inside `surfbot daemon run`.
+4. Is *something* running the scheduler? Either a `surfbot ui` (default
+   topology) or `surfbot daemon run` must own the scheduler lock.
+   `surfbot daemon status` reads `daemon.state.json`, which both paths
+   write — if the heartbeat is stale or the file is missing, the
+   scheduler is not running anywhere.
 
 ### "I got 409 TARGET_BUSY"
 
@@ -222,9 +270,11 @@ Another scan is already running on this target. Wait for it to finish
 ### "I got 503 dispatcher-unreachable"
 
 You're talking to a process that doesn't have the master ticker
-attached. The UI web server, a read-only API process, or a CLI client
-will all return 503 on ad-hoc dispatch. Point your request at the
-process running `surfbot daemon run`.
+attached. In the default topology this means `surfbot ui` was started
+with `--no-scheduler` (or it lost the lock race to a daemon). Either
+restart `surfbot ui` without `--no-scheduler`, or send the request to
+the process that owns the scheduler lock — `surfbot daemon status`
+shows the holder PID.
 
 ### "Why was my scan canceled halfway?"
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -4,9 +4,15 @@ This page explains how surfbot's scheduling subsystem fits together after
 the SPEC-SCHED1 rewrite (agent-spec 3.0). If you're coming from 2.x,
 read the [migration guide](agent-spec.md#migration-from-20) first.
 
+> **Topology decision:** Single-process by default — `surfbot ui` runs
+> the scheduler in-process. See
+> [ADR-003](../../surfbot-strategy/ADR-003-scheduler-topology.md)
+> for the rationale and trade-offs vs. the rejected split-daemon model.
+
 ## Process topology
 
-There are two ways to run the scheduler. Pick **one**:
+There are two ways to run the scheduler. Default is single-process
+(ADR-003 Option A). Pick the shape that matches your deployment:
 
 ### Single-process (default — recommended for laptops)
 

--- a/internal/cli/apiclient/client.go
+++ b/internal/cli/apiclient/client.go
@@ -74,7 +74,7 @@ func New(baseURL string, opts ...Option) *Client {
 		baseURL:    trimmed,
 		origin:     deriveOrigin(trimmed),
 		httpClient: &http.Client{Timeout: DefaultTimeout},
-		userAgent:  "surfbot-cli",
+		userAgent:  "surfbot-agent",
 	}
 	for _, o := range opts {
 		o(c)

--- a/internal/cli/appcore.go
+++ b/internal/cli/appcore.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/surfbot-io/surfbot-agent/internal/config"
+	"github.com/surfbot-io/surfbot-agent/internal/daemon"
+	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// SchedulerBootstrap groups everything the in-process scheduler needs.
+// The same shape is used by `daemon run` and by `surfbot ui` when it
+// auto-starts the scheduler (SPEC-SCHED2.0). Scheduler is the concrete
+// *intervalsched.Scheduler so callers can use it both as a
+// daemon.Scheduler (for the Runner) and as a webui.AdHocDispatcher
+// (for the /api/v1/scans/ad-hoc handler).
+type SchedulerBootstrap struct {
+	Config    *config.Config
+	Store     *storage.SQLiteStore
+	Scheduler *intervalsched.Scheduler
+	Paths     daemon.Paths
+	Mode      daemon.Mode
+	// Cleanup closes the store. Callers MUST defer it.
+	Cleanup func()
+}
+
+// BuildSchedulerBootstrap is the single source of truth for constructing
+// the scheduler and its dependencies. It loads the surfbot config, opens
+// the SQLite store, runs the idempotent legacy-schedule migration, and
+// builds the intervalsched master ticker.
+//
+// On any failure after the store has been opened the store is closed
+// before the error is returned so callers don't leak file handles.
+func BuildSchedulerBootstrap(mode daemon.Mode) (*SchedulerBootstrap, error) {
+	paths := daemon.Resolve(daemon.Default(mode))
+
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		return nil, fmt.Errorf("loading config: %w", err)
+	}
+
+	runStore, err := storage.NewSQLiteStore(cfg.DBPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening database: %w", err)
+	}
+	cleanup := func() { _ = runStore.Close() }
+
+	report, err := intervalsched.MigrateLegacyScheduleConfig(
+		context.Background(), paths.StateDir, runStore, slog.Default())
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("legacy schedule migration: %w", err)
+	}
+	if report.SkippedReason == "" {
+		slog.Default().Info("legacy schedule migrated",
+			"template_id", report.TemplateID,
+			"targets_migrated", report.TargetsMigrated,
+			"schedules_created", report.SchedulesCreated,
+		)
+	}
+
+	sched, err := buildSchedulerConcrete(cfg.Daemon.Scheduler, paths, runStore)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("building scheduler: %w", err)
+	}
+
+	return &SchedulerBootstrap{
+		Config:    cfg,
+		Store:     runStore,
+		Scheduler: sched,
+		Paths:     paths,
+		Mode:      mode,
+		Cleanup:   cleanup,
+	}, nil
+}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -162,9 +162,10 @@ func buildDaemonService() (*daemon.Service, service.Service, daemon.Mode, error)
 // config-load / store-open / legacy-migration / scheduler-construction
 // sequence to BuildSchedulerBootstrap (shared with `surfbot ui` under
 // SPEC-SCHED2.0) and then wraps the result in a kardianos service.
-// The returned cleanup func closes the database — the caller must
-// defer it.
-func buildDaemonRunService() (*daemon.Service, service.Service, func(), error) {
+// The returned bootstrap exposes the store so callers can take the
+// scheduler_lock; the cleanup func closes the database and must be
+// deferred by the caller.
+func buildDaemonRunService() (*daemon.Service, service.Service, *SchedulerBootstrap, error) {
 	mode, err := resolveMode()
 	if err != nil {
 		return nil, nil, nil, err
@@ -188,7 +189,7 @@ func buildDaemonRunService() (*daemon.Service, service.Service, func(), error) {
 		boot.Cleanup()
 		return nil, nil, nil, err
 	}
-	return s, svc, boot.Cleanup, nil
+	return s, svc, boot, nil
 }
 
 func durationOr(d, fallback time.Duration) time.Duration {
@@ -551,14 +552,34 @@ func runDaemonLogs(cmd *cobra.Command, _ []string) error {
 }
 
 // runDaemonRun is the entrypoint the OS service manager invokes. It loads
-// the surfbot config, opens the database, builds the master ticker, and
-// blocks inside service.Run until the service is asked to stop.
+// the surfbot config, opens the database, takes the SPEC-SCHED2.0
+// scheduler_lock, builds the master ticker, and blocks inside
+// service.Run until the service is asked to stop.
 func runDaemonRun(_ *cobra.Command, _ []string) error {
-	_, svc, cleanup, err := buildDaemonRunService()
+	_, svc, boot, err := buildDaemonRunService()
 	if err != nil {
 		return err
 	}
-	defer cleanup()
+	defer boot.Cleanup()
+
+	// The scheduler lock is taken AFTER the store is open but BEFORE
+	// service.Run starts the dispatch loop. If another process already
+	// owns the lock, exit non-zero so kardianos surfaces a failed start
+	// in `surfbot daemon status`.
+	lock, lerr := acquireSchedulerLock(context.Background(), boot.Store)
+	if lerr != nil {
+		if errors.Is(lerr, storage.ErrLockHeld) {
+			return fmt.Errorf("scheduler already running: %w", lerr)
+		}
+		return fmt.Errorf("acquiring scheduler lock: %w", lerr)
+	}
+	defer func() {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := lock.Close(releaseCtx); err != nil {
+			slog.Default().Warn("releasing scheduler_lock", "err", err)
+		}
+	}()
 	return svc.Run()
 }
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -158,63 +158,37 @@ func buildDaemonService() (*daemon.Service, service.Service, daemon.Mode, error)
 	return s, svc, mode, nil
 }
 
-// buildDaemonRunService is invoked by `daemon run`. It loads the full
-// surfbot config, opens the database, builds the SCHED1.2b master ticker,
-// and hands the result to daemon.Build. The returned cleanup func closes
-// the database — the caller must defer it.
+// buildDaemonRunService is invoked by `daemon run`. It delegates the
+// config-load / store-open / legacy-migration / scheduler-construction
+// sequence to BuildSchedulerBootstrap (shared with `surfbot ui` under
+// SPEC-SCHED2.0) and then wraps the result in a kardianos service.
+// The returned cleanup func closes the database — the caller must
+// defer it.
 func buildDaemonRunService() (*daemon.Service, service.Service, func(), error) {
 	mode, err := resolveMode()
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	paths := daemon.Resolve(daemon.Default(mode))
-
-	cfg, err := config.Load(cfgFile)
+	boot, err := BuildSchedulerBootstrap(mode)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("loading config: %w", err)
-	}
-
-	runStore, err := storage.NewSQLiteStore(cfg.DBPath)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("opening database: %w", err)
-	}
-	cleanup := func() { _ = runStore.Close() }
-
-	report, err := intervalsched.MigrateLegacyScheduleConfig(
-		context.Background(), paths.StateDir, runStore, slog.Default())
-	if err != nil {
-		cleanup()
-		return nil, nil, nil, fmt.Errorf("legacy schedule migration: %w", err)
-	}
-	if report.SkippedReason == "" {
-		slog.Default().Info("legacy schedule migrated",
-			"template_id", report.TemplateID,
-			"targets_migrated", report.TargetsMigrated,
-			"schedules_created", report.SchedulesCreated,
-		)
-	}
-
-	sched, err := buildScheduler(cfg.Daemon.Scheduler, paths, runStore)
-	if err != nil {
-		cleanup()
-		return nil, nil, nil, fmt.Errorf("building scheduler: %w", err)
+		return nil, nil, nil, err
 	}
 
 	dcfg := daemon.Config{
 		Mode:           mode,
-		Paths:          paths,
+		Paths:          boot.Paths,
 		Version:        Version,
-		ShutdownGrace:  durationOr(cfg.Daemon.ShutdownGrace, 20*time.Second),
-		Heartbeat:      durationOr(cfg.Daemon.StateHeartbeat, 30*time.Second),
+		ShutdownGrace:  durationOr(boot.Config.Daemon.ShutdownGrace, 20*time.Second),
+		Heartbeat:      durationOr(boot.Config.Daemon.StateHeartbeat, 30*time.Second),
 		ConfigOverride: cfgFile,
-		Scheduler:      sched,
+		Scheduler:      boot.Scheduler,
 	}
 	s, svc, err := daemon.Build(dcfg)
 	if err != nil {
-		cleanup()
+		boot.Cleanup()
 		return nil, nil, nil, err
 	}
-	return s, svc, cleanup, nil
+	return s, svc, boot.Cleanup, nil
 }
 
 func durationOr(d, fallback time.Duration) time.Duration {
@@ -224,15 +198,16 @@ func durationOr(d, fallback time.Duration) time.Duration {
 	return d
 }
 
-// buildScheduler constructs the SCHED1.2b master ticker. The legacy
-// schedule.config.json migration runs separately in
-// runDaemonRunWithMigration so that boot can fail fatally on migration
-// errors before the scheduler starts.
+// buildSchedulerConcrete constructs the SCHED1.2b master ticker and
+// returns it as the concrete *intervalsched.Scheduler so callers that
+// need the DispatchAdHoc surface (webui AdHocDispatcher) can use it
+// directly without a type assertion. The value still satisfies
+// daemon.Scheduler so the Runner accepts it unchanged.
 //
 // config.SchedulerConfig.Enabled is no longer consulted: with first-class
 // schedules the daemon always runs the master ticker. An empty
 // scan_schedules table simply produces an idle tick loop.
-func buildScheduler(_ config.SchedulerConfig, _ daemon.Paths, store *storage.SQLiteStore) (daemon.Scheduler, error) {
+func buildSchedulerConcrete(_ config.SchedulerConfig, _ daemon.Paths, store *storage.SQLiteStore) (*intervalsched.Scheduler, error) {
 	registry := detection.NewRegistry()
 	runner := daemon.NewScanRunner(store, registry, slog.Default())
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -23,11 +23,15 @@ var (
 var store *storage.SQLiteStore
 
 // Commands that don't need database access.
+// SPEC-SCHED2.0: `ui` is on this list because runUI owns its own
+// *storage.SQLiteStore via BuildSchedulerBootstrap so the HTTP server
+// and the in-process scheduler share a single store handle.
 var skipDBCommands = map[string]bool{
 	"version":    true,
 	"help":       true,
 	"completion": true,
 	"agent-spec": true,
+	"ui":         true,
 }
 
 // skipDB returns true if the given cobra command should NOT have the

--- a/internal/cli/scheduler_lock.go
+++ b/internal/cli/scheduler_lock.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// schedulerLockStaleAfter is how long the heartbeat may be silent
+// before a second process treats the lock as reclaimable. Default is
+// 2× the state-file heartbeat (30s) — fast enough that a crashed
+// daemon does not block the next `surfbot ui` for long, slow enough
+// to absorb transient pauses (e.g. laptop sleep).
+const schedulerLockStaleAfter = 60 * time.Second
+
+// schedulerLockRefreshInterval is the cadence at which the active
+// holder bumps heartbeat_at. Stays well under staleAfter so a healthy
+// holder is never reclaimed by mistake.
+const schedulerLockRefreshInterval = 15 * time.Second
+
+// sameHostPIDAlive probes whether a PID is still live on this host.
+// Cross-host reclaim is out of scope per the product model; we rely on
+// the stale-heartbeat timer for remote-host edge cases.
+//
+// Implementation lives in scheduler_lock_{unix,windows}.go so each OS
+// can use the right liveness primitive (Signal(0) on POSIX, FindProcess
+// truth on Windows). Overridable for tests.
+var sameHostPIDAlive = sameHostPIDAliveOS
+
+// schedulerLockHandle wraps an active scheduler_lock ownership. Its
+// Close method releases the lock and stops the heartbeat goroutine.
+type schedulerLockHandle struct {
+	store    *storage.SQLiteStore
+	pid      int
+	hostname string
+	stop     context.CancelFunc
+	wg       sync.WaitGroup
+}
+
+// acquireSchedulerLock takes the scheduler_lock row for this process,
+// reclaiming a stale or same-host-dead holder if necessary. On
+// success, a heartbeat goroutine is launched; stop it via Close.
+//
+// ErrLockHeld (with the holder's identity) is returned when the lock
+// is owned by a live process on this host or by a remote host whose
+// heartbeat is still fresh.
+func acquireSchedulerLock(ctx context.Context, store *storage.SQLiteStore) (*schedulerLockHandle, error) {
+	host, _ := os.Hostname()
+	pid := os.Getpid()
+	now := time.Now()
+
+	lock, err := store.AcquireSchedulerLock(ctx, pid, host, schedulerLockStaleAfter)
+	if err == nil {
+		return startLockHeartbeat(store, pid, host), nil
+	}
+	if !errors.Is(err, storage.ErrLockHeld) {
+		return nil, err
+	}
+	// Lock held: maybe it's us from a previous crash (same host, dead PID)?
+	sameHost := lock.Hostname == host
+	if sameHost && !sameHostPIDAlive(lock.PID) {
+		slog.Warn("reclaiming stale scheduler_lock from dead PID",
+			"prev_pid", lock.PID, "prev_host", lock.Hostname,
+			"age", lock.Age(now).Round(time.Second))
+		// Force-take by overwriting with a staleAfter=0 retry.
+		lock2, rerr := store.AcquireSchedulerLock(ctx, pid, host, 0)
+		if rerr == nil {
+			return startLockHeartbeat(store, pid, host), nil
+		}
+		if !errors.Is(rerr, storage.ErrLockHeld) {
+			return nil, rerr
+		}
+		// Someone else raced us to the reclaim — fall through and
+		// surface the current holder (lock2) back to the caller.
+		lock = lock2
+	}
+	return nil, fmt.Errorf("%w: pid=%d host=%s age=%s",
+		storage.ErrLockHeld, lock.PID, lock.Hostname, lock.Age(now).Round(time.Second))
+}
+
+// startLockHeartbeat launches the goroutine that keeps the lock's
+// heartbeat_at fresh. The returned handle releases the lock and stops
+// the goroutine on Close.
+func startLockHeartbeat(store *storage.SQLiteStore, pid int, host string) *schedulerLockHandle {
+	runCtx, cancel := context.WithCancel(context.Background())
+	h := &schedulerLockHandle{
+		store:    store,
+		pid:      pid,
+		hostname: host,
+		stop:     cancel,
+	}
+	h.wg.Add(1)
+	go func() {
+		defer h.wg.Done()
+		t := time.NewTicker(schedulerLockRefreshInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-runCtx.Done():
+				return
+			case <-t.C:
+				if err := store.RefreshSchedulerLock(runCtx, pid, host); err != nil {
+					slog.Warn("scheduler_lock heartbeat failed", "err", err)
+				}
+			}
+		}
+	}()
+	return h
+}
+
+// Close stops the heartbeat goroutine and releases the lock row. Safe
+// to call multiple times.
+func (h *schedulerLockHandle) Close(ctx context.Context) error {
+	if h == nil || h.stop == nil {
+		return nil
+	}
+	h.stop()
+	h.stop = nil
+	h.wg.Wait()
+	return h.store.ReleaseSchedulerLock(ctx, h.pid, h.hostname)
+}

--- a/internal/cli/scheduler_lock_test.go
+++ b/internal/cli/scheduler_lock_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+func newLockTestStore(t *testing.T) *storage.SQLiteStore {
+	t.Helper()
+	store, err := storage.NewSQLiteStore(filepath.Join(t.TempDir(), "lock.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestSchedulerLock_Contention asserts that a second acquire against a
+// freshly-held lock returns ErrLockHeld and surfaces the holder.
+func TestSchedulerLock_Contention(t *testing.T) {
+	// Pin liveness so the second call doesn't take the reclaim path.
+	prev := sameHostPIDAlive
+	sameHostPIDAlive = func(int) bool { return true }
+	t.Cleanup(func() { sameHostPIDAlive = prev })
+
+	store := newLockTestStore(t)
+	ctx := context.Background()
+
+	first, err := acquireSchedulerLock(ctx, store)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = first.Close(ctx) })
+
+	_, err = acquireSchedulerLock(ctx, store)
+	require.Error(t, err)
+	require.ErrorIs(t, err, storage.ErrLockHeld)
+}
+
+// TestSchedulerLock_StaleReclaim seeds a lock from a fabricated PID
+// with a stale heartbeat, then asserts the next acquirer reclaims it.
+func TestSchedulerLock_StaleReclaim(t *testing.T) {
+	prev := sameHostPIDAlive
+	sameHostPIDAlive = func(int) bool { return false } // dead by definition
+	t.Cleanup(func() { sameHostPIDAlive = prev })
+
+	store := newLockTestStore(t)
+	ctx := context.Background()
+
+	// Seed via the storage API on this host so the same-host reclaim
+	// path fires. The fake PID is "dead" because sameHostPIDAlive is
+	// pinned to false above.
+	host, _ := os.Hostname()
+	_, err := store.AcquireSchedulerLock(ctx, 999999, host, 24*time.Hour)
+	require.NoError(t, err)
+
+	// Stale-aware acquire takes over.
+	h, err := acquireSchedulerLock(ctx, store)
+	require.NoError(t, err, "stale lock should be reclaimed when holder PID is dead")
+	t.Cleanup(func() { _ = h.Close(ctx) })
+}
+
+// TestSchedulerLock_LiveSameHost asserts that a second process on the
+// same host with a live PID does NOT reclaim — it returns ErrLockHeld
+// regardless of heartbeat freshness.
+func TestSchedulerLock_LiveSameHost(t *testing.T) {
+	prev := sameHostPIDAlive
+	sameHostPIDAlive = func(int) bool { return true } // always alive
+	t.Cleanup(func() { sameHostPIDAlive = prev })
+
+	store := newLockTestStore(t)
+	ctx := context.Background()
+
+	host, _ := os.Hostname()
+	_, err := store.AcquireSchedulerLock(ctx, 12345, host, schedulerLockStaleAfter)
+	require.NoError(t, err)
+
+	_, err = acquireSchedulerLock(ctx, store)
+	require.ErrorIs(t, err, storage.ErrLockHeld,
+		"a live same-host PID must block reclaim regardless of heartbeat freshness")
+}
+
+// TestSchedulerLock_RefreshAndRelease asserts the heartbeat keeps the
+// lock fresh and that Close removes the row.
+func TestSchedulerLock_RefreshAndRelease(t *testing.T) {
+	prev := sameHostPIDAlive
+	sameHostPIDAlive = func(int) bool { return true }
+	t.Cleanup(func() { sameHostPIDAlive = prev })
+
+	store := newLockTestStore(t)
+	ctx := context.Background()
+
+	h, err := acquireSchedulerLock(ctx, store)
+	require.NoError(t, err)
+	require.NoError(t, h.Close(ctx))
+
+	// After release, a second acquire must succeed.
+	h2, err := acquireSchedulerLock(ctx, store)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = h2.Close(ctx) })
+}
+

--- a/internal/cli/scheduler_lock_test.go
+++ b/internal/cli/scheduler_lock_test.go
@@ -102,4 +102,3 @@ func TestSchedulerLock_RefreshAndRelease(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = h2.Close(ctx) })
 }
-

--- a/internal/cli/scheduler_lock_unix.go
+++ b/internal/cli/scheduler_lock_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package cli
+
+import (
+	"os"
+	"syscall"
+)
+
+// sameHostPIDAliveOS uses POSIX signal 0: it performs the permission /
+// existence check without actually delivering a signal. Returns true
+// iff the process exists and we have permission to signal it.
+func sameHostPIDAliveOS(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/internal/cli/scheduler_lock_windows.go
+++ b/internal/cli/scheduler_lock_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package cli
+
+import "os"
+
+// sameHostPIDAliveOS relies on os.FindProcess actually validating
+// existence on Windows (unlike POSIX where it always succeeds). The
+// Go runtime opens the process via OpenProcess; a nonexistent PID
+// returns an error.
+//
+// This is a coarser check than the POSIX Signal(0) probe — a zombie
+// or recently-exited process may still be reachable via OpenProcess.
+// For our purposes (reclaim a stale scheduler_lock from a crashed
+// surfbot run) the heartbeat-staleness fallback covers the gap.
+func sameHostPIDAliveOS(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	_, err := os.FindProcess(pid)
+	return err == nil
+}

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -12,7 +13,6 @@ import (
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 
-	"github.com/surfbot-io/surfbot-agent/internal/config"
 	"github.com/surfbot-io/surfbot-agent/internal/daemon"
 	"github.com/surfbot-io/surfbot-agent/internal/webui"
 )
@@ -20,49 +20,48 @@ import (
 var uiCmd = &cobra.Command{
 	Use:   "ui",
 	Short: "Launch the web dashboard",
-	Long:  "Starts a local web server and opens the Surfbot dashboard in your browser.",
-	RunE:  runUI,
+	Long: `Starts a local web server and opens the Surfbot dashboard in your browser.
+
+By default the in-process scheduler runs alongside the HTTP server so
+schedules created in the UI actually fire. Pass --no-scheduler to opt
+out (useful when a separately-installed 'surfbot daemon' already owns
+the scheduling loop).`,
+	RunE: runUI,
 }
 
 func init() {
 	uiCmd.Flags().IntP("port", "p", 8470, "Port to listen on")
 	uiCmd.Flags().Bool("no-open", false, "Don't auto-open browser")
 	uiCmd.Flags().String("bind", "127.0.0.1", "Address to bind to")
+	uiCmd.Flags().Bool("no-scheduler", false, "Do not start the in-process scheduler (default: start it)")
 	rootCmd.AddCommand(uiCmd)
 }
 
-// buildUIDaemonView resolves the daemon state file paths and config so the
-// embedded UI can render the SPEC-X3.1 Agent card. It is best-effort:
-// errors collapse to a partially-populated view that the UI renders as
-// "agent not running" rather than failing the whole `surfbot ui` command.
+// buildUIDaemonView resolves the daemon state file paths so the embedded
+// UI can render the SPEC-X3.1 Agent card. It is best-effort: errors
+// collapse to a partially-populated view that the UI renders as "agent
+// not running" rather than failing the whole `surfbot ui` command.
 //
-// SCHED1.2b: the maintenance-window mirror previously sourced from
-// schedule.config.json is gone — first-class schedules carry their own
-// windows. The UI still echoes WindowStart/End/Timezone from config.yaml
-// for the existing display widget; SCHED1.3 will replace that with a
-// per-schedule view.
-func buildUIDaemonView() *webui.DaemonView {
-	mode := daemon.DefaultMode()
-	paths := daemon.Resolve(daemon.Default(mode))
+// SPEC-SCHED2.0: callers pass the bootstrap's already-loaded Config +
+// Paths so we don't reload config.yaml just to populate the view.
+func buildUIDaemonView(boot *SchedulerBootstrap) *webui.DaemonView {
 	view := &webui.DaemonView{
-		DaemonStatePath:   paths.StateFile(),
-		ScheduleStatePath: scheduleStatePath(paths),
+		DaemonStatePath:   boot.Paths.StateFile(),
+		ScheduleStatePath: scheduleStatePath(boot.Paths),
 		Heartbeat:         30 * time.Second,
 	}
-	cfg, err := config.Load(cfgFile)
-	if err != nil {
-		return view
-	}
-	if cfg.Daemon.StateHeartbeat > 0 {
-		view.Heartbeat = cfg.Daemon.StateHeartbeat
-	}
-	view.SchedulerEnabled = cfg.Daemon.Scheduler.Enabled
-	mw := cfg.Daemon.Scheduler.MaintenanceWindow
-	view.WindowStart = mw.Start
-	view.WindowEnd = mw.End
-	view.WindowTimezone = mw.Timezone
-	if w, werr := buildWindow(mw); werr == nil {
-		view.Window = w
+	if boot.Config != nil {
+		if boot.Config.Daemon.StateHeartbeat > 0 {
+			view.Heartbeat = boot.Config.Daemon.StateHeartbeat
+		}
+		view.SchedulerEnabled = boot.Config.Daemon.Scheduler.Enabled
+		mw := boot.Config.Daemon.Scheduler.MaintenanceWindow
+		view.WindowStart = mw.Start
+		view.WindowEnd = mw.End
+		view.WindowTimezone = mw.Timezone
+		if w, werr := buildWindow(mw); werr == nil {
+			view.Window = w
+		}
 	}
 	return view
 }
@@ -71,26 +70,41 @@ func runUI(cmd *cobra.Command, args []string) error {
 	port, _ := cmd.Flags().GetInt("port")
 	noOpen, _ := cmd.Flags().GetBool("no-open")
 	bind, _ := cmd.Flags().GetString("bind")
+	noScheduler, _ := cmd.Flags().GetBool("no-scheduler")
 
-	// The UI token always lives under the user-mode state dir. `surfbot ui`
-	// is invoked by an interactive user, never by the system service
-	// manager, so the system-mode default of /var/lib/surfbot would not be
-	// writable on Linux.
-	uiPaths := daemon.Resolve(daemon.Default(daemon.ModeUser))
-	if err := uiPaths.EnsureDirs(daemon.ModeUser); err != nil {
+	// `surfbot ui` is invoked by an interactive user, never by the OS
+	// service manager, so always resolve paths in user mode. The system
+	// default of /var/lib/surfbot is not writable without root.
+	mode := daemon.ModeUser
+
+	boot, err := BuildSchedulerBootstrap(mode)
+	if err != nil {
+		return err
+	}
+	defer boot.Cleanup()
+
+	if err := boot.Paths.EnsureDirs(mode); err != nil {
 		return fmt.Errorf("preparing ui state dir: %w", err)
 	}
-	authToken, err := webui.LoadOrCreateUIToken(uiPaths.StateDir)
+	authToken, err := webui.LoadOrCreateUIToken(boot.Paths.StateDir)
 	if err != nil {
 		return err
 	}
 
-	srv, ln, err := webui.NewServer(store, webui.ServerOptions{
+	daemonView := buildUIDaemonView(boot)
+	if !noScheduler {
+		// Wire the master ticker through to /api/v1/scans/ad-hoc so the
+		// dashboard's "Run scan now" buttons dispatch in-process. Without
+		// this, the handler returns 503 /problems/dispatcher-unreachable.
+		daemonView.AdHocDispatcher = boot.Scheduler
+	}
+
+	srv, ln, err := webui.NewServer(boot.Store, webui.ServerOptions{
 		Bind:      bind,
 		Port:      port,
 		Version:   Version,
 		Registry:  registry,
-		Daemon:    buildUIDaemonView(),
+		Daemon:    daemonView,
 		AuthToken: authToken,
 	})
 	if err != nil {
@@ -100,6 +114,11 @@ func runUI(cmd *cobra.Command, args []string) error {
 	url := fmt.Sprintf("http://%s:%d", bind, port)
 	p := NewPrinter(cmd.OutOrStdout())
 	p.Success("Surfbot UI running at %s", url)
+	if !noScheduler {
+		p.Muted("Scheduler running in-process (pid %d)\n", os.Getpid())
+	} else {
+		p.Muted("Scheduler NOT started (--no-scheduler); schedules will not fire from this process\n")
+	}
 	p.Muted("Press Ctrl+C to stop\n")
 
 	if !noOpen {
@@ -110,17 +129,48 @@ func runUI(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	// Start the scheduler first so its state-file heartbeat claims the
+	// daemon.state.json slot before the HTTP server accepts its first
+	// request. That ordering makes /api/daemon/status report running
+	// on the dashboard immediately after first load.
+	var runner *daemon.Runner
+	if !noScheduler {
+		logger := daemon.NewLogger(boot.Paths.LogFile(), daemon.LoggerOptions{Compress: true})
+		stateStore := daemon.NewStateStore(boot.Paths.StateFile())
+		runner = daemon.NewRunner(daemon.RunnerConfig{
+			Scheduler: boot.Scheduler,
+			State:     stateStore,
+			Logger:    logger,
+			Heartbeat: durationOr(boot.Config.Daemon.StateHeartbeat, 30*time.Second),
+			Version:   Version,
+		})
+		if err := runner.Start(); err != nil {
+			return fmt.Errorf("starting scheduler: %w", err)
+		}
+		slog.Info("scheduler started in-process",
+			"pid", os.Getpid(),
+			"next_tick", boot.Scheduler.Next(),
+		)
+	}
+
 	errCh := make(chan error, 1)
 	go func() {
-		// Use Serve(ln) instead of ListenAndServe to avoid TOCTOU race
 		errCh <- srv.Serve(ln)
 	}()
+
+	shutdownGrace := durationOr(boot.Config.Daemon.ShutdownGrace, 30*time.Second)
 
 	select {
 	case <-ctx.Done():
 		p.Muted("\nShutting down...\n")
+		if runner != nil {
+			_ = runner.Stop(shutdownGrace)
+		}
 		return srv.Shutdown(context.Background())
 	case err := <-errCh:
+		if runner != nil {
+			_ = runner.Stop(shutdownGrace)
+		}
 		if err != nil && err != http.ErrServerClosed {
 			return fmt.Errorf("server error: %w", err)
 		}

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -167,17 +167,52 @@ func runUI(cmd *cobra.Command, args []string) error {
 	select {
 	case <-ctx.Done():
 		p.Muted("\nShutting down...\n")
-		if runner != nil {
-			_ = runner.Stop(shutdownGrace)
-		}
-		return srv.Shutdown(context.Background())
+		shutdownUI(srv, runner, shutdownGrace, p)
+		return nil
 	case err := <-errCh:
-		if runner != nil {
-			_ = runner.Stop(shutdownGrace)
-		}
+		shutdownUI(srv, runner, shutdownGrace, p)
 		if err != nil && err != http.ErrServerClosed {
 			return fmt.Errorf("server error: %w", err)
 		}
 		return nil
+	}
+}
+
+// httpShutdownGrace bounds how long srv.Shutdown is allowed to drain
+// in-flight HTTP handlers before the UI moves on to stopping the
+// scheduler. 10s is plenty for the read-only dashboard traffic and is
+// well under the scheduler's own drain budget.
+const httpShutdownGrace = 10 * time.Second
+
+// shutdownUI implements the SPEC-SCHED2.0 R4 shutdown sequence:
+//  1. drain the HTTP server (bounded by httpShutdownGrace) so no new
+//     requests land while the scheduler is being torn down
+//  2. stop the scheduler runner (bounded by schedulerGrace, which
+//     includes the worker pool drain)
+//  3. return so runUI's deferred boot.Cleanup() closes the store
+//
+// A scheduler timeout logs a structured warning and returns anyway —
+// the orphaned in_progress scan rows are SCHED2.1's problem to reap
+// on next boot.
+func shutdownUI(srv *http.Server, runner *daemon.Runner, schedulerGrace time.Duration, p *Printer) {
+	httpCtx, cancel := context.WithTimeout(context.Background(), httpShutdownGrace)
+	defer cancel()
+	if err := srv.Shutdown(httpCtx); err != nil {
+		slog.Warn("http server shutdown did not complete cleanly", "err", err)
+		if p != nil {
+			p.Muted("http drain exceeded %s; forcing close\n", httpShutdownGrace)
+		}
+	}
+	if runner == nil {
+		return
+	}
+	if err := runner.Stop(schedulerGrace); err != nil {
+		slog.Warn("scheduler shutdown timeout",
+			"grace", schedulerGrace,
+			"err", err,
+		)
+		if p != nil {
+			p.Muted("scheduler did not drain within %s; in-flight scans will be reaped on next boot\n", schedulerGrace)
+		}
 	}
 }

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -143,6 +143,10 @@ func runUI(cmd *cobra.Command, args []string) error {
 			Logger:    logger,
 			Heartbeat: durationOr(boot.Config.Daemon.StateHeartbeat, 30*time.Second),
 			Version:   Version,
+			// Cancel the UI's top-level signal context on panic so the
+			// HTTP server begins its own shutdown before the supervisor
+			// terminates the process.
+			OnSchedulerPanic: stop,
 		})
 		if err := runner.Start(); err != nil {
 			return fmt.Errorf("starting scheduler: %w", err)

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/surfbot-io/surfbot-agent/internal/daemon"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
 	"github.com/surfbot-io/surfbot-agent/internal/webui"
 )
 
@@ -91,6 +93,28 @@ func runUI(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// SPEC-SCHED2.0 R5: only one process may own the scheduler against
+	// a given DB. If the lock is already held (typically by a separately
+	// installed `surfbot daemon`), fall back to UI-only mode and tell
+	// the operator. Their ad-hoc "Run scan now" buttons will return 503
+	// because the dispatcher in this process is the wrong one to wire,
+	// but read-only dashboard traffic still works.
+	var lock *schedulerLockHandle
+	if !noScheduler {
+		l, lerr := acquireSchedulerLock(context.Background(), boot.Store)
+		if lerr != nil {
+			if errors.Is(lerr, storage.ErrLockHeld) {
+				slog.Info("scheduler already running elsewhere; starting UI in --no-scheduler mode",
+					"holder", lerr.Error())
+				noScheduler = true
+			} else {
+				return fmt.Errorf("acquiring scheduler lock: %w", lerr)
+			}
+		} else {
+			lock = l
+		}
+	}
+
 	daemonView := buildUIDaemonView(boot)
 	if !noScheduler {
 		// Wire the master ticker through to /api/v1/scans/ad-hoc so the
@@ -164,13 +188,26 @@ func runUI(cmd *cobra.Command, args []string) error {
 
 	shutdownGrace := durationOr(boot.Config.Daemon.ShutdownGrace, 30*time.Second)
 
+	releaseLock := func() {
+		if lock == nil {
+			return
+		}
+		releaseCtx, cancelRelease := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancelRelease()
+		if err := lock.Close(releaseCtx); err != nil {
+			slog.Warn("releasing scheduler_lock", "err", err)
+		}
+	}
+
 	select {
 	case <-ctx.Done():
 		p.Muted("\nShutting down...\n")
 		shutdownUI(srv, runner, shutdownGrace, p)
+		releaseLock()
 		return nil
 	case err := <-errCh:
 		shutdownUI(srv, runner, shutdownGrace, p)
+		releaseLock()
 		if err != nil && err != http.ErrServerClosed {
 			return fmt.Errorf("server error: %w", err)
 		}

--- a/internal/cli/ui_scheduler_integration_test.go
+++ b/internal/cli/ui_scheduler_integration_test.go
@@ -1,0 +1,276 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/daemon"
+	"github.com/surfbot-io/surfbot-agent/internal/daemon/intervalsched"
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+	"github.com/surfbot-io/surfbot-agent/internal/webui"
+)
+
+// fakeScanRunner satisfies intervalsched.ScanRunner by writing a
+// canned Scan row when the master ticker dispatches a job. Mirrors the
+// fake in test/e2e/schedule_e2e_test.go so we can prove the SPEC-SCHED2.0
+// production webui wiring fires scans without spawning detection
+// binaries.
+type fakeUIScanRunner struct {
+	store *storage.SQLiteStore
+	mu    sync.Mutex
+	calls atomic.Int32
+}
+
+func (r *fakeUIScanRunner) Run(ctx context.Context, scheduleID, targetID string, _ model.EffectiveConfig) (string, error) {
+	r.calls.Add(1)
+	now := time.Now().UTC()
+	scan := &model.Scan{
+		TargetID:   targetID,
+		Type:       model.ScanTypeFull,
+		Status:     model.ScanStatusCompleted,
+		StartedAt:  &now,
+		FinishedAt: &now,
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.store.CreateScan(ctx, scan); err != nil {
+		return "", err
+	}
+	return scan.ID, nil
+}
+
+// TestUI_SchedulerInProcessFiresScheduledScan asserts the SPEC-SCHED2.0
+// happy path: with the production webui middleware chain on top of the
+// in-process scheduler, a schedule whose first occurrence is ≤2s away
+// dispatches a scan within ~10s, and the resulting Scan row is
+// observable via /api/v1/schedules/{id}.
+//
+// We don't go through cobra's runUI here because runUI hard-loads
+// config from ~/.surfbot/config.yaml and resolves real OS paths. The
+// test instead drives the same wiring runUI does: NewServer with the
+// in-process scheduler as AdHocDispatcher, on the same goroutine the
+// production code starts.
+func TestUI_SchedulerInProcessFiresScheduledScan(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test; up to ~70s wallclock for the first MINUTELY firing")
+	}
+	deadline := time.Now().Add(90 * time.Second)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	store, err := storage.NewSQLiteStore(filepath.Join(t.TempDir(), "ui-int.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	target := &model.Target{Value: "ui-integration.test.local"}
+	require.NoError(t, store.CreateTarget(ctx, target))
+
+	runner := &fakeUIScanRunner{store: store}
+	sched, err := intervalsched.New(intervalsched.Dependencies{
+		SchedStore:    store.Schedules(),
+		TmplStore:     store.Templates(),
+		BlackoutStore: store.Blackouts(),
+		DefaultsStore: store.ScheduleDefaults(),
+		AdHocStore:    store.AdHocScanRuns(),
+		Runner:        runner,
+		Clock:         intervalsched.NewRealClock(),
+		TickInterval:  500 * time.Millisecond,
+		JitterSeed:    1,
+	})
+	require.NoError(t, err)
+	require.NoError(t, sched.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		_ = sched.Stop(stopCtx)
+	})
+
+	// daemon.Runner exercise: we want the supervisor + state-file path
+	// runUI takes, including SCHED2.0's panic-recover.
+	stateStore := daemon.NewStateStore(filepath.Join(t.TempDir(), "state.json"))
+	logger := daemon.NewLogger(filepath.Join(t.TempDir(), "test.log"), daemon.LoggerOptions{MaxSizeMB: 1})
+	t.Cleanup(func() { _ = logger.Close() })
+	daemonRunner := daemon.NewRunner(daemon.RunnerConfig{
+		// Wrap the started scheduler in a noop adapter — we already
+		// called Start; we just want the heartbeat + state-file write.
+		Scheduler: noopSchedulerWrapper{inner: sched},
+		State:     stateStore,
+		Logger:    logger,
+		Heartbeat: 50 * time.Millisecond,
+		Version:   "test",
+	})
+	require.NoError(t, daemonRunner.Start())
+	t.Cleanup(func() { _ = daemonRunner.Stop(2 * time.Second) })
+
+	// Pick a free loopback port so allowedHosts/Origins line up.
+	tmpLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := tmpLn.Addr().(*net.TCPAddr).Port
+	require.NoError(t, tmpLn.Close())
+
+	srv, ln, err := webui.NewServer(store, webui.ServerOptions{
+		Bind:    "127.0.0.1",
+		Port:    port,
+		Version: "test",
+		// Production-style DaemonView with the scheduler wired as the
+		// ad-hoc dispatcher — this is the SPEC-SCHED2.0 invariant.
+		Daemon: &webui.DaemonView{
+			DaemonStatePath: stateStore.Path(),
+			Heartbeat:       50 * time.Millisecond,
+			AdHocDispatcher: sched,
+		},
+		AuthToken: "ui-int-token",
+	})
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() {
+		shutdownCtx, c := context.WithTimeout(context.Background(), 2*time.Second)
+		defer c()
+		_ = srv.Shutdown(shutdownCtx)
+	})
+
+	base := "http://127.0.0.1:" + strconv.Itoa(port)
+	hdrs := map[string]string{
+		"Authorization": "Bearer ui-int-token",
+		"Origin":        base,
+	}
+
+	// Wait for the server to be ready — the auth-protected GET returns
+	// 200 with items=[] on an empty schedule table.
+	requireReady(t, base, hdrs)
+
+	// Step 1: template
+	tplBody := map[string]any{
+		"name":     "ui-int-tpl",
+		"rrule":    "FREQ=MINUTELY",
+		"timezone": "UTC",
+		"tool_config": map[string]any{
+			"nuclei": model.DefaultNucleiParams(),
+		},
+	}
+	var tpl struct {
+		ID string `json:"id"`
+	}
+	httpJSON(t, http.MethodPost, base+"/api/v1/templates", tplBody, hdrs, http.StatusCreated, &tpl)
+	require.NotEmpty(t, tpl.ID)
+
+	// Step 2: schedule with dtstart 59s ago so the first MINUTELY
+	// occurrence is ≤1s out.
+	dtstart := time.Now().UTC().Add(-59 * time.Second)
+	schedBody := map[string]any{
+		"target_id":   target.ID,
+		"template_id": tpl.ID,
+		"name":        "ui-int-sched",
+		"rrule":       "FREQ=MINUTELY",
+		"dtstart":     dtstart.Format(time.RFC3339Nano),
+		"timezone":    "UTC",
+	}
+	var schedResp struct {
+		ID            string     `json:"id"`
+		NextRunAt     *time.Time `json:"next_run_at"`
+		LastRunStatus *string    `json:"last_run_status"`
+		LastScanID    *string    `json:"last_scan_id"`
+	}
+	httpJSON(t, http.MethodPost, base+"/api/v1/schedules", schedBody, hdrs, http.StatusCreated, &schedResp)
+	require.NotEmpty(t, schedResp.ID)
+	require.NotNil(t, schedResp.NextRunAt, "Expander must populate next_run_at — UI wiring is broken without it")
+
+	// Step 3: poll until LastRunStatus is success. The first MINUTELY
+	// occurrence after a 59s-old DTSTART is ~1s into the next wall-clock
+	// minute, so the budget allows for a worst case of ~70s.
+	pollDeadline := time.Now().Add(75 * time.Second)
+	for {
+		if time.Now().After(pollDeadline) {
+			t.Fatalf("schedule never fired in-process; runner.calls=%d schedResp=%+v",
+				runner.calls.Load(), schedResp)
+		}
+		time.Sleep(250 * time.Millisecond)
+		var cur struct {
+			LastRunStatus *string `json:"last_run_status"`
+			LastScanID    *string `json:"last_scan_id"`
+		}
+		httpJSON(t, http.MethodGet, base+"/api/v1/schedules/"+schedResp.ID, nil, hdrs, http.StatusOK, &cur)
+		if cur.LastRunStatus != nil && *cur.LastRunStatus == string(model.ScheduleRunSuccess) {
+			require.NotNil(t, cur.LastScanID)
+			t.Logf("ui-integration: schedule %s fired in %s; scan_id=%s",
+				schedResp.ID, time.Since(dtstart).Round(time.Second), *cur.LastScanID)
+			return
+		}
+	}
+}
+
+// noopSchedulerWrapper lets us hand an already-Started scheduler to
+// daemon.Runner without re-starting it (Start is idempotent on
+// *intervalsched.Scheduler, but we want the Runner to NOT call
+// Stop on the inner scheduler from its own ctx — Stop is driven by
+// the test cleanup).
+type noopSchedulerWrapper struct {
+	inner *intervalsched.Scheduler
+}
+
+func (n noopSchedulerWrapper) Next() time.Time { return n.inner.Next() }
+func (n noopSchedulerWrapper) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+func requireReady(t *testing.T, base string, hdrs map[string]string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequest(http.MethodGet, base+"/api/v1/schedules", nil)
+		for k, v := range hdrs {
+			req.Header.Set(k, v)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("server never became ready at %s", base)
+}
+
+func httpJSON(t *testing.T, method, url string, body any, hdrs map[string]string, wantStatus int, out any) {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(raw)
+	}
+	req, err := http.NewRequest(method, url, reader)
+	require.NoError(t, err)
+	if reader != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range hdrs {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != wantStatus {
+		t.Fatalf("%s %s: status=%d want=%d body=%s", method, url, resp.StatusCode, wantStatus, respBody)
+	}
+	if out != nil {
+		require.NoError(t, json.Unmarshal(respBody, out))
+	}
+}

--- a/internal/cli/ui_shutdown_test.go
+++ b/internal/cli/ui_shutdown_test.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/daemon"
+)
+
+// drainingScheduler runs until ctx is canceled, then waits `drain`
+// duration before returning — simulating an in-flight scan that takes
+// time to wind down after the shutdown signal.
+type drainingScheduler struct {
+	drain time.Duration
+	mu    sync.Mutex
+	ran   bool
+}
+
+func (d *drainingScheduler) Next() time.Time { return time.Time{} }
+func (d *drainingScheduler) Run(ctx context.Context) error {
+	d.mu.Lock()
+	d.ran = true
+	d.mu.Unlock()
+	<-ctx.Done()
+	time.Sleep(d.drain)
+	return nil
+}
+
+// timestampingScheduler records the moment its Run context is canceled.
+// Combined with httptest.Server handler timing, this lets tests assert
+// the HTTP-before-scheduler shutdown ordering without racing on Stop.
+type timestampingScheduler struct {
+	ctxCanceledAt *atomic.Int64
+}
+
+func (t *timestampingScheduler) Next() time.Time { return time.Time{} }
+func (t *timestampingScheduler) Run(ctx context.Context) error {
+	<-ctx.Done()
+	t.ctxCanceledAt.Store(time.Now().UnixNano())
+	return nil
+}
+
+// TestShutdownUI_HTTPDrainsBeforeScheduler asserts the R4 sequencing:
+// the HTTP server is drained before the scheduler is asked to stop.
+// We observe the ordering by recording timestamps when the in-flight
+// HTTP handler returns and when sched.Run observes its context cancel
+// (which happens at runner.Stop, i.e. the step AFTER HTTP drain).
+func TestShutdownUI_HTTPDrainsBeforeScheduler(t *testing.T) {
+	var schedCtxCanceledAt atomic.Int64
+	sched := &timestampingScheduler{
+		ctxCanceledAt: &schedCtxCanceledAt,
+	}
+	dir := t.TempDir()
+	stateStore := daemon.NewStateStore(filepath.Join(dir, "state.json"))
+	logger := daemon.NewLogger(filepath.Join(dir, "test.log"), daemon.LoggerOptions{MaxSizeMB: 1})
+	t.Cleanup(func() { _ = logger.Close() })
+
+	runner := daemon.NewRunner(daemon.RunnerConfig{
+		Scheduler: sched,
+		State:     stateStore,
+		Logger:    logger,
+		Heartbeat: 50 * time.Millisecond,
+		Version:   "test",
+	})
+	require.NoError(t, runner.Start())
+
+	var handlerReturnedAt atomic.Int64
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		handlerReturnedAt.Store(time.Now().UnixNano())
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	// Fire a long-running request and wait for it to reach the handler.
+	reqDone := make(chan struct{})
+	go func() {
+		resp, err := http.Get(srv.URL)
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+		close(reqDone)
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	shutdownUI(srv.Config, runner, 5*time.Second, nil)
+	<-reqDone
+
+	require.NotZero(t, handlerReturnedAt.Load(), "in-flight HTTP handler must have completed")
+	require.NotZero(t, schedCtxCanceledAt.Load(), "scheduler must have observed ctx cancel")
+	require.Greater(t, schedCtxCanceledAt.Load(), handlerReturnedAt.Load(),
+		"scheduler ctx cancel must fire AFTER the HTTP handler returns (R4 ordering)")
+}
+
+// TestShutdownUI_SchedulerTimeoutIsClean asserts that a scheduler which
+// refuses to drain within grace does not panic or hang — shutdownUI
+// logs a warning and returns so the process can exit.
+func TestShutdownUI_SchedulerTimeoutIsClean(t *testing.T) {
+	// Scheduler that ignores ctx cancel for longer than the grace.
+	sched := &drainingScheduler{drain: 2 * time.Second}
+	dir := t.TempDir()
+	stateStore := daemon.NewStateStore(filepath.Join(dir, "state.json"))
+	logger := daemon.NewLogger(filepath.Join(dir, "test.log"), daemon.LoggerOptions{MaxSizeMB: 1})
+	t.Cleanup(func() { _ = logger.Close() })
+
+	runner := daemon.NewRunner(daemon.RunnerConfig{
+		Scheduler: sched,
+		State:     stateStore,
+		Logger:    logger,
+		Heartbeat: 50 * time.Millisecond,
+		Version:   "test",
+	})
+	require.NoError(t, runner.Start())
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	start := time.Now()
+	shutdownUI(srv.Config, runner, 100*time.Millisecond, nil)
+	elapsed := time.Since(start)
+
+	// We should return promptly when the scheduler misses its grace —
+	// not hang until the full drain finishes.
+	require.Less(t, elapsed, time.Second, "shutdownUI must return after scheduler grace, not wait for full drain")
+}

--- a/internal/daemon/runner.go
+++ b/internal/daemon/runner.go
@@ -3,10 +3,26 @@ package daemon
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
+	"runtime/debug"
 	"sync"
 	"time"
 )
+
+// SchedulerPanicExit is the hook the scheduler supervisor calls to
+// terminate the process after a scheduler panic. In production it is
+// os.Exit so a crash-exit is unmissable in logs and the OS service
+// manager will surface the non-zero status. Tests override it so the
+// supervisor can be exercised without killing the test binary.
+var SchedulerPanicExit = os.Exit
+
+// SchedulerPanicGrace is how long the supervisor sleeps between the
+// onPanic callback (typically a context cancel that shuts down the HTTP
+// server) and the process exit. 2 seconds is enough for slog handlers to
+// flush and for graceful shutdown to start draining in-flight requests.
+// Overridable for tests.
+var SchedulerPanicGrace = 2 * time.Second
 
 // ErrShutdownTimeout is returned when Stop's grace period elapses before
 // the runner goroutine exits. The service layer logs a warning and lets
@@ -22,6 +38,7 @@ type Runner struct {
 	logger    *Logger
 	heartbeat time.Duration
 	version   string
+	onPanic   func()
 	started   time.Time
 
 	mu     sync.Mutex
@@ -36,6 +53,14 @@ type RunnerConfig struct {
 	Logger    *Logger
 	Heartbeat time.Duration // state-file refresh cadence (default 30s)
 	Version   string        // surfbot version string written to state
+
+	// OnSchedulerPanic fires synchronously from the scheduler goroutine
+	// after a panic has been logged and the state file has been updated
+	// with last_error. Typical use is to cancel the caller's top-level
+	// context so auxiliary services (e.g. the HTTP server in
+	// `surfbot ui`) start their own shutdown before the supervisor
+	// terminates the process via SchedulerPanicExit.
+	OnSchedulerPanic func()
 }
 
 // NewRunner constructs a runner. It does not start the goroutine.
@@ -49,6 +74,7 @@ func NewRunner(cfg RunnerConfig) *Runner {
 		logger:    cfg.Logger,
 		heartbeat: cfg.Heartbeat,
 		version:   cfg.Version,
+		onPanic:   cfg.OnSchedulerPanic,
 	}
 }
 
@@ -100,6 +126,7 @@ func (r *Runner) loop(ctx context.Context) {
 	schedDone := make(chan struct{})
 	go func() {
 		defer close(schedDone)
+		defer r.recoverSchedulerPanic()
 		if err := r.sched.Run(ctx); err != nil && r.logger != nil {
 			r.logger.Slog().Error("scheduler exited with error", "err", err)
 		}
@@ -121,6 +148,40 @@ func (r *Runner) loop(ctx context.Context) {
 			}
 		}
 	}
+}
+
+// recoverSchedulerPanic is deferred on the scheduler goroutine. It logs
+// the panic with a full stack, records last_error in the state file,
+// fires the caller's OnSchedulerPanic callback (typically a ctx cancel
+// so the HTTP server begins its own shutdown), waits the configured
+// grace for logs to flush, and finally terminates the process with
+// SchedulerPanicExit(1). The re-panic path is deliberately not taken:
+// a silent recovery would let a broken scheduler leave the process
+// up, serving stale HTTP, with no scans firing — strictly worse than
+// a clean non-zero exit.
+func (r *Runner) recoverSchedulerPanic() {
+	rec := recover()
+	if rec == nil {
+		return
+	}
+	stack := debug.Stack()
+	if r.logger != nil {
+		r.logger.Slog().Error("scheduler panicked",
+			"panic", fmt.Sprint(rec),
+			"stack", string(stack),
+		)
+	}
+	if r.state != nil {
+		_ = r.state.Update(func(s *State) {
+			s.LastError = fmt.Sprintf("scheduler panic: %v", rec)
+			s.WrittenAt = time.Now().UTC()
+		})
+	}
+	if r.onPanic != nil {
+		r.onPanic()
+	}
+	time.Sleep(SchedulerPanicGrace)
+	SchedulerPanicExit(1)
 }
 
 // writeState refreshes the state file with the current pid, version, and

--- a/internal/daemon/runner_test.go
+++ b/internal/daemon/runner_test.go
@@ -104,3 +104,70 @@ func TestRunner_DoubleStart(t *testing.T) {
 	err := r.Start()
 	require.Error(t, err)
 }
+
+// panickingScheduler satisfies Scheduler but panics on first Run call.
+// Used to exercise the supervisor's recover path.
+type panickingScheduler struct{}
+
+func (panickingScheduler) Next() time.Time { return time.Time{} }
+func (panickingScheduler) Run(_ context.Context) error {
+	panic("boom from scheduler")
+}
+
+// TestRunner_SchedulerPanicIsSupervised asserts that a scheduler panic
+// is logged, written to state.last_error, fires OnSchedulerPanic, and
+// terminates via SchedulerPanicExit — all without taking the test
+// binary down (we swap in a recording exit function).
+func TestRunner_SchedulerPanicIsSupervised(t *testing.T) {
+	// Shorten the post-panic grace so the test finishes fast.
+	origGrace := SchedulerPanicGrace
+	SchedulerPanicGrace = 10 * time.Millisecond
+	t.Cleanup(func() { SchedulerPanicGrace = origGrace })
+
+	exitCh := make(chan int, 1)
+	origExit := SchedulerPanicExit
+	SchedulerPanicExit = func(code int) { exitCh <- code }
+	t.Cleanup(func() { SchedulerPanicExit = origExit })
+
+	dir := t.TempDir()
+	stateStore := NewStateStore(filepath.Join(dir, "state.json"))
+	logger := NewLogger(filepath.Join(dir, "test.log"), LoggerOptions{MaxSizeMB: 1})
+	t.Cleanup(func() { _ = logger.Close() })
+
+	panicCalled := make(chan struct{}, 1)
+	r := NewRunner(RunnerConfig{
+		Scheduler: panickingScheduler{},
+		State:     stateStore,
+		Logger:    logger,
+		Heartbeat: 50 * time.Millisecond,
+		Version:   "test",
+		OnSchedulerPanic: func() {
+			select {
+			case panicCalled <- struct{}{}:
+			default:
+			}
+		},
+	})
+	require.NoError(t, r.Start())
+
+	select {
+	case code := <-exitCh:
+		require.Equal(t, 1, code, "supervisor must exit non-zero on panic")
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not call SchedulerPanicExit")
+	}
+	select {
+	case <-panicCalled:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("OnSchedulerPanic callback was not invoked")
+	}
+
+	st, err := stateStore.Load()
+	require.NoError(t, err)
+	require.Contains(t, st.LastError, "scheduler panic")
+	require.Contains(t, st.LastError, "boom from scheduler")
+
+	// Cleanup: the scheduler goroutine already exited via the panic path;
+	// Stop should be a safe no-op that cancels the context and returns.
+	_ = r.Stop(time.Second)
+}

--- a/internal/storage/migrations/0005_scheduler_lock.sql
+++ b/internal/storage/migrations/0005_scheduler_lock.sql
@@ -1,0 +1,19 @@
+-- SPEC-SCHED2.0 R5: scheduler_lock is the singleton-guard mechanism
+-- that prevents two surfbot processes from running the scheduler
+-- against the same DB at the same time. It holds at most one row
+-- (enforced by the PK=1 check) identifying the process that currently
+-- owns the dispatch loop. Second would-be acquirers read this row and
+-- either fall back to UI-only mode or exit cleanly, depending on the
+-- entry point.
+
+CREATE TABLE IF NOT EXISTS scheduler_lock (
+    id            INTEGER PRIMARY KEY CHECK (id = 1),
+    pid           INTEGER NOT NULL,
+    hostname      TEXT NOT NULL,
+    acquired_at   TEXT NOT NULL,
+    heartbeat_at  TEXT NOT NULL
+);
+
+PRAGMA user_version = 5;
+
+UPDATE agent_meta SET value = '5' WHERE key = 'schema_version';

--- a/internal/storage/migrations_0004_test.go
+++ b/internal/storage/migrations_0004_test.go
@@ -50,14 +50,17 @@ func TestMigration0004_FreshDB(t *testing.T) {
 		require.NoError(t, err, "index %s should exist", idx)
 	}
 
+	// The newTestStore helper applies all embedded migrations, so the
+	// version reflects the latest (0005 adds scheduler_lock per
+	// SPEC-SCHED2.0).
 	v, err := s.GetMeta(ctx, "schema_version")
 	require.NoError(t, err)
-	assert.Equal(t, "4", v)
+	assert.Equal(t, "5", v)
 
 	var userVersion int
 	err = s.db.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&userVersion)
 	require.NoError(t, err)
-	assert.Equal(t, 4, userVersion)
+	assert.Equal(t, 5, userVersion)
 
 	var defaultsCount int
 	err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM schedule_defaults`).Scan(&defaultsCount)

--- a/internal/storage/scheduler_lock.go
+++ b/internal/storage/scheduler_lock.go
@@ -1,0 +1,149 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrLockHeld is returned by AcquireSchedulerLock when another live
+// process currently owns the scheduler lock. The returned SchedulerLock
+// record describes the holder so callers can render a useful message
+// (pid, hostname, how long ago it was acquired).
+var ErrLockHeld = errors.New("scheduler_lock held by another process")
+
+// SchedulerLock mirrors the scheduler_lock row. It is emitted with
+// ErrLockHeld when acquisition fails so the caller can surface the
+// holder's identity.
+type SchedulerLock struct {
+	PID         int
+	Hostname    string
+	AcquiredAt  time.Time
+	HeartbeatAt time.Time
+}
+
+// Age returns how long ago the lock last heartbeated. Callers use this
+// plus the configured heartbeat interval to decide whether the lock is
+// stale and safe to reclaim.
+func (l SchedulerLock) Age(now time.Time) time.Duration {
+	if l.HeartbeatAt.IsZero() {
+		return 0
+	}
+	return now.Sub(l.HeartbeatAt)
+}
+
+// AcquireSchedulerLock takes exclusive ownership of the scheduler slot
+// for (pid, hostname). Three outcomes:
+//
+//   - No row exists → insert ours, return the lock.
+//   - Row exists but heartbeat is older than staleAfter → our caller
+//     has decided the holder is dead (or the same-host PID check has
+//     already confirmed the process is gone); we overwrite the row.
+//   - Row exists and is fresh → return ErrLockHeld with the holder.
+//
+// The caller is responsible for the is-PID-alive check on same-host
+// conflicts; this store treats staleAfter as the single stalemate-breaker.
+func (s *SQLiteStore) AcquireSchedulerLock(ctx context.Context, pid int, hostname string, staleAfter time.Duration) (*SchedulerLock, error) {
+	now := time.Now().UTC()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var (
+		curPID      sql.NullInt64
+		curHost     sql.NullString
+		curAcquired sql.NullString
+		curBeat     sql.NullString
+	)
+	err = tx.QueryRowContext(ctx,
+		`SELECT pid, hostname, acquired_at, heartbeat_at FROM scheduler_lock WHERE id = 1`,
+	).Scan(&curPID, &curHost, &curAcquired, &curBeat)
+
+	existing := err == nil
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("reading scheduler_lock: %w", err)
+	}
+
+	if existing {
+		heartbeat, _ := time.Parse(timeFormat, nullString(curBeat))
+		acquiredAt, _ := time.Parse(timeFormat, nullString(curAcquired))
+		held := SchedulerLock{
+			PID:         int(curPID.Int64),
+			Hostname:    nullString(curHost),
+			AcquiredAt:  acquiredAt,
+			HeartbeatAt: heartbeat,
+		}
+		if !heartbeat.IsZero() && now.Sub(heartbeat) <= staleAfter {
+			return &held, fmt.Errorf("%w: pid=%d host=%s", ErrLockHeld, held.PID, held.Hostname)
+		}
+		// Stale: overwrite.
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE scheduler_lock SET pid = ?, hostname = ?, acquired_at = ?, heartbeat_at = ? WHERE id = 1`,
+			pid, hostname, now.Format(timeFormat), now.Format(timeFormat),
+		); err != nil {
+			return nil, fmt.Errorf("overwriting stale lock: %w", err)
+		}
+	} else {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO scheduler_lock (id, pid, hostname, acquired_at, heartbeat_at) VALUES (1, ?, ?, ?, ?)`,
+			pid, hostname, now.Format(timeFormat), now.Format(timeFormat),
+		); err != nil {
+			return nil, fmt.Errorf("inserting scheduler_lock: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit scheduler_lock: %w", err)
+	}
+	return &SchedulerLock{
+		PID:         pid,
+		Hostname:    hostname,
+		AcquiredAt:  now,
+		HeartbeatAt: now,
+	}, nil
+}
+
+// RefreshSchedulerLock bumps heartbeat_at iff the current holder still
+// matches (pid, hostname). Called periodically while the scheduler is
+// running so a takeover by a second process only happens after the
+// holder has actually gone away.
+func (s *SQLiteStore) RefreshSchedulerLock(ctx context.Context, pid int, hostname string) error {
+	now := time.Now().UTC().Format(timeFormat)
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE scheduler_lock SET heartbeat_at = ? WHERE id = 1 AND pid = ? AND hostname = ?`,
+		now, pid, hostname,
+	)
+	if err != nil {
+		return fmt.Errorf("refreshing scheduler_lock: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("scheduler_lock no longer owned by pid=%d host=%s", pid, hostname)
+	}
+	return nil
+}
+
+// ReleaseSchedulerLock deletes the lock row iff (pid, hostname) still
+// owns it. Safe to call during shutdown; a missed release is harmless
+// because the next acquirer will reclaim via the staleAfter path.
+func (s *SQLiteStore) ReleaseSchedulerLock(ctx context.Context, pid int, hostname string) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM scheduler_lock WHERE id = 1 AND pid = ? AND hostname = ?`,
+		pid, hostname,
+	)
+	if err != nil {
+		return fmt.Errorf("releasing scheduler_lock: %w", err)
+	}
+	return nil
+}
+
+func nullString(s sql.NullString) string {
+	if s.Valid {
+		return s.String
+	}
+	return ""
+}

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -32,10 +32,10 @@ func TestNewSQLiteStore(t *testing.T) {
 	}
 
 	// Verify agent_meta seeded. schema_version tracks the latest applied
-	// migration: 0004 bumps it to "4".
+	// migration: 0005 (scheduler_lock, SPEC-SCHED2.0) bumps it to "5".
 	v, err := s.GetMeta(ctx, "schema_version")
 	require.NoError(t, err)
-	assert.Equal(t, "4", v)
+	assert.Equal(t, "5", v)
 }
 
 func TestTargetCRUD(t *testing.T) {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -213,6 +213,17 @@ func (s *SQLiteStore) runMigrations() error {
 		}
 	}
 
+	schemaVersion, _ = s.getSchemaVersion()
+	if schemaVersion < 5 {
+		m005, err := migrationsFS.ReadFile("migrations/0005_scheduler_lock.sql")
+		if err != nil {
+			return fmt.Errorf("reading migration 0005: %w", err)
+		}
+		if _, err = s.db.Exec(string(m005)); err != nil {
+			return fmt.Errorf("executing migration 0005: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/test/smoke/sched2_0_smoke.sh
+++ b/test/smoke/sched2_0_smoke.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# SPEC-SCHED2.0 smoke test — automated validation of SUR-259 / SUR-254.
+#
+# Usage:
+#   ./test/smoke/sched2_0_smoke.sh
+#
+# Optional env:
+#   SURFBOT_BIN  Path to surfbot binary (default: ./bin/surfbot, builds if missing)
+#   SMOKE_OUT    Output dir for evidence (default: /tmp/sched2_0_smoke_<ts>)
+#   SMOKE_PORT   HTTP port for ui (default: 8479, avoids prod 8470)
+#
+# What it validates (3 escenarios from SUR-259):
+#   1. `surfbot ui` boots scheduler in-process; a future schedule fires
+#      automatically (without a separate `surfbot daemon`).
+#   2. Ad-hoc "Run scan now" via API responds synchronously, scan row created.
+#   3. Second `surfbot daemon run` while ui is alive exits non-zero with a
+#      lock contention message mentioning the holder.
+#
+# The script does NOT verify findings persistence — that requires the full
+# scanner toolchain (nmap, nuclei, etc.). What we verify is the SCHED2.0
+# mechanic: dispatch happens, lock works, run-now is sync.
+
+set -uo pipefail
+
+# ---------- setup ----------
+TS=$(date +%Y%m%d_%H%M%S)
+OUT="${SMOKE_OUT:-/tmp/sched2_0_smoke_$TS}"
+PORT="${SMOKE_PORT:-8479}"
+mkdir -p "$OUT"
+
+DB="$OUT/surfbot.db"
+LOG_UI="$OUT/ui.log"
+LOG_DAEMON="$OUT/daemon-contention.log"
+RESULTS="$OUT/results.json"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ -z "${SURFBOT_BIN:-}" ]; then
+  SURFBOT_BIN="$REPO_ROOT/bin/surfbot"
+fi
+
+# Build if needed or stale
+NEED_BUILD=false
+if [ ! -x "$SURFBOT_BIN" ]; then
+  NEED_BUILD=true
+elif [ -n "$(find $REPO_ROOT/cmd $REPO_ROOT/internal -newer "$SURFBOT_BIN" -type f -name '*.go' 2>/dev/null | head -1)" ]; then
+  NEED_BUILD=true
+fi
+if [ "$NEED_BUILD" = "true" ]; then
+  echo "[build] surfbot binary missing or stale, building..."
+  mkdir -p "$REPO_ROOT/bin"
+  go build -o "$SURFBOT_BIN" ./cmd/surfbot
+fi
+
+echo "[setup]"
+echo "  OUT     = $OUT"
+echo "  BIN     = $SURFBOT_BIN"
+echo "  DB      = $DB"
+echo "  PORT    = $PORT"
+echo "  GIT     = $(git rev-parse --short HEAD) ($(git branch --show-current))"
+echo
+
+# Helpers
+fail_count=0
+pass() { echo "  PASS: $*"; }
+fail() { echo "  FAIL: $*"; fail_count=$((fail_count + 1)); }
+
+# JSON-safe quoting helper
+jq_str() { python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1" 2>/dev/null || echo "\"$(echo "$1" | sed 's/"/\\"/g; s/$/\\n/' | tr -d '\n')\""; }
+
+# ---------- boot UI ----------
+echo "[boot] starting surfbot ui..."
+"$SURFBOT_BIN" --db "$DB" ui --port "$PORT" --bind 127.0.0.1 --no-open >"$LOG_UI" 2>&1 &
+UI_PID=$!
+echo "  UI_PID=$UI_PID"
+
+cleanup() {
+  set +e
+  if [ -n "${UI_PID:-}" ] && kill -0 "$UI_PID" 2>/dev/null; then
+    echo "[cleanup] stopping UI (pid $UI_PID)..."
+    kill "$UI_PID" 2>/dev/null
+    sleep 2
+    kill -9 "$UI_PID" 2>/dev/null
+    wait "$UI_PID" 2>/dev/null
+  fi
+}
+trap cleanup EXIT
+
+# Wait up to 15s for the scheduler-started log line
+boot_ok=false
+for i in $(seq 1 30); do
+  if grep -qE "scheduler started in-process|listening on" "$LOG_UI" 2>/dev/null; then
+    boot_ok=true
+    break
+  fi
+  sleep 0.5
+done
+
+scheduler_in_process=false
+if grep -qE "scheduler started in-process" "$LOG_UI" 2>/dev/null; then
+  scheduler_in_process=true
+  pass "scheduler started in-process (log line present)"
+else
+  fail "scheduler did not log 'scheduler started in-process' within 15s"
+  echo "    --- ui.log tail ---"
+  tail -20 "$LOG_UI" | sed 's/^/    /'
+fi
+
+if ! kill -0 "$UI_PID" 2>/dev/null; then
+  fail "UI process died during boot"
+  cat "$LOG_UI"
+  exit 1
+fi
+
+# ---------- ESCENARIO 1: schedule futuro dispara solo ----------
+echo
+echo "[ESCENARIO 1] schedule futuro dispara solo"
+
+TARGET_VAL="smoke-$TS.test.local"
+TARGET_OUT="$OUT/target.txt"
+"$SURFBOT_BIN" --db "$DB" target add "$TARGET_VAL" --scope external --type domain >"$TARGET_OUT" 2>&1 || true
+TARGET_ID=$(grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' "$TARGET_OUT" | head -1)
+if [ -z "$TARGET_ID" ]; then
+  TARGET_ID=$(sqlite3 "$DB" "SELECT id FROM targets WHERE value='$TARGET_VAL';" 2>/dev/null || echo "")
+fi
+echo "  target_id=$TARGET_ID"
+
+if [ -z "$TARGET_ID" ]; then
+  fail "could not create or find target"
+else
+  pass "target created"
+fi
+
+# Schedule with FREQ=MINUTELY — first occurrence is the next minute boundary
+SCHED_OUT="$OUT/schedule.txt"
+"$SURFBOT_BIN" --db "$DB" schedule create \
+  --target "$TARGET_ID" \
+  --name "smoke-sched-$TS" \
+  --rrule "FREQ=MINUTELY" \
+  --tzid UTC \
+  >"$SCHED_OUT" 2>&1 || true
+SCHED_ID=$(grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' "$SCHED_OUT" | head -1)
+echo "  schedule_id=$SCHED_ID"
+if [ -z "$SCHED_ID" ]; then
+  fail "could not create schedule — see $SCHED_OUT"
+  cat "$SCHED_OUT" | sed 's/^/    /'
+else
+  pass "schedule created"
+fi
+
+# Wait up to 90s for first dispatch
+echo "  waiting up to 90s for dispatch (FREQ=MINUTELY hits next wall-clock minute)..."
+scan_count=0
+dispatch_observed=false
+for i in $(seq 1 18); do
+  sleep 5
+  scan_count=$(sqlite3 "$DB" "SELECT COUNT(*) FROM scans WHERE target_id='$TARGET_ID';" 2>/dev/null || echo 0)
+  if [ "${scan_count:-0}" -gt 0 ]; then
+    dispatch_observed=true
+    break
+  fi
+done
+if [ "$dispatch_observed" = "true" ]; then
+  pass "scan dispatched (count=$scan_count)"
+else
+  fail "no scan dispatched after 90s"
+fi
+
+# Capture log lines about dispatch
+DISPATCH_LOGS=$(grep -iE "(dispatch|scan.*started|scheduler.*tick)" "$LOG_UI" 2>/dev/null | tail -5 || echo "")
+
+# ---------- ESCENARIO 2: run-now sync ----------
+echo
+echo "[ESCENARIO 2] run-now sincrónico"
+
+ADHOC_OUT="$OUT/adhoc.txt"
+START_NS=$(date +%s%N)
+"$SURFBOT_BIN" --db "$DB" scan adhoc \
+  --target "$TARGET_ID" \
+  --daemon-url "http://127.0.0.1:$PORT" \
+  --reason "smoke-sched2.0-$TS" \
+  >"$ADHOC_OUT" 2>&1 &
+ADHOC_PID=$!
+# Cap at 60s
+adhoc_done=false
+for i in $(seq 1 60); do
+  if ! kill -0 "$ADHOC_PID" 2>/dev/null; then
+    adhoc_done=true
+    break
+  fi
+  sleep 1
+done
+END_NS=$(date +%s%N)
+ADHOC_MS=$(( (END_NS - START_NS) / 1000000 ))
+
+if [ "$adhoc_done" = "false" ]; then
+  kill "$ADHOC_PID" 2>/dev/null
+  fail "scan adhoc did not return within 60s (queue limbo?)"
+fi
+
+wait "$ADHOC_PID" 2>/dev/null
+ADHOC_RC=$?
+
+if [ "$adhoc_done" = "true" ] && [ "$ADHOC_MS" -lt 60000 ]; then
+  pass "adhoc returned in ${ADHOC_MS}ms (rc=$ADHOC_RC)"
+fi
+
+# Verify a new scan row was created (compared to scenario 1)
+sleep 2
+total_scans=$(sqlite3 "$DB" "SELECT COUNT(*) FROM scans WHERE target_id='$TARGET_ID';" 2>/dev/null || echo 0)
+if [ "$total_scans" -gt "$scan_count" ]; then
+  pass "new scan row from adhoc (now $total_scans, was $scan_count)"
+else
+  fail "no new scan row after adhoc (still $total_scans)"
+fi
+
+# Capture transition trace for the adhoc scan
+SCAN_TRACE=$(sqlite3 "$DB" "SELECT id, status, started_at, finished_at FROM scans WHERE target_id='$TARGET_ID' ORDER BY rowid DESC LIMIT 3;" 2>/dev/null || echo "")
+
+# ---------- ESCENARIO 3: lock contention ----------
+echo
+echo "[ESCENARIO 3] daemon + ui simultáneos no double-dispatch"
+
+# Try `surfbot daemon run` against the same DB while UI is alive
+"$SURFBOT_BIN" --db "$DB" daemon run >"$LOG_DAEMON" 2>&1 &
+DAEMON_PID=$!
+# It should fail fast (lock held); give it 10s
+daemon_done=false
+for i in $(seq 1 10); do
+  if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+    daemon_done=true
+    break
+  fi
+  sleep 1
+done
+
+if [ "$daemon_done" = "false" ]; then
+  kill "$DAEMON_PID" 2>/dev/null
+  fail "daemon run did not exit within 10s — lock contention not detected (process may have stolen the lock)"
+  DAEMON_EXIT=124
+else
+  wait "$DAEMON_PID" 2>/dev/null
+  DAEMON_EXIT=$?
+fi
+
+if [ "$DAEMON_EXIT" -ne 0 ]; then
+  pass "daemon run exited non-zero (rc=$DAEMON_EXIT) as expected"
+else
+  fail "daemon run exited 0 — lock did not block second process"
+fi
+
+LOCK_MSG=$(grep -iE "(scheduler already running|lock|pid)" "$LOG_DAEMON" 2>/dev/null | head -3 || echo "")
+if [ -n "$LOCK_MSG" ]; then
+  pass "daemon log mentions lock contention: $(echo "$LOCK_MSG" | head -1)"
+else
+  fail "daemon log does not mention lock — error message unclear"
+fi
+
+# Verify UI process still alive
+if kill -0 "$UI_PID" 2>/dev/null; then
+  pass "UI process still healthy after contention attempt"
+else
+  fail "UI process died during contention test"
+fi
+
+# ---------- write results ----------
+echo
+echo "[results]"
+{
+  echo "{"
+  echo "  \"ts\": \"$TS\","
+  echo "  \"git_sha\": \"$(git rev-parse --short HEAD)\","
+  echo "  \"git_branch\": \"$(git branch --show-current)\","
+  echo "  \"out_dir\": \"$OUT\","
+  echo "  \"port\": $PORT,"
+  echo "  \"failures\": $fail_count,"
+  echo "  \"scenario_1\": {"
+  echo "    \"scheduler_started_in_process\": $scheduler_in_process,"
+  echo "    \"dispatch_observed\": $dispatch_observed,"
+  echo "    \"scan_count\": $scan_count,"
+  echo "    \"target_id\": \"$TARGET_ID\","
+  echo "    \"schedule_id\": \"$SCHED_ID\""
+  echo "  },"
+  echo "  \"scenario_2\": {"
+  echo "    \"adhoc_response_ms\": $ADHOC_MS,"
+  echo "    \"adhoc_rc\": $ADHOC_RC,"
+  echo "    \"adhoc_done_within_60s\": $adhoc_done,"
+  echo "    \"total_scans_after\": $total_scans"
+  echo "  },"
+  echo "  \"scenario_3\": {"
+  echo "    \"daemon_exit_code\": $DAEMON_EXIT,"
+  echo "    \"daemon_exit_nonzero\": $([ $DAEMON_EXIT -ne 0 ] && echo true || echo false),"
+  echo "    \"lock_message_present\": $([ -n "$LOCK_MSG" ] && echo true || echo false),"
+  echo "    \"ui_still_alive\": $(kill -0 $UI_PID 2>/dev/null && echo true || echo false)"
+  echo "  }"
+  echo "}"
+} > "$RESULTS"
+
+cat "$RESULTS"
+echo
+echo "[evidence]"
+echo "  $OUT/ui.log                ($(wc -l < "$LOG_UI") lines)"
+echo "  $OUT/daemon-contention.log ($(wc -l < "$LOG_DAEMON") lines)"
+echo "  $OUT/surfbot.db            ($(stat -c%s "$DB" 2>/dev/null || stat -f%z "$DB" 2>/dev/null) bytes)"
+echo "  $OUT/results.json"
+echo
+echo "[scan trace]"
+echo "$SCAN_TRACE"
+echo
+echo "[dispatch logs]"
+echo "$DISPATCH_LOGS"
+echo
+if [ "$fail_count" -eq 0 ]; then
+  echo "OVERALL: PASS"
+  exit 0
+else
+  echo "OVERALL: FAIL ($fail_count failure(s))"
+  exit 1
+fi


### PR DESCRIPTION
Closes [SUR-254](https://linear.app/surfbot/issue/SUR-254). Implements [SPEC-SCHED2.0](docs/SPEC-SCHED2.0.md) per [ADR-003](docs/ADR-003-scheduler-topology.md).

## Summary

`surfbot ui` now runs the master ticker in the same process as the HTTP server. The free-tier viral path is once again a single command: `surfbot ui` → create a schedule in the dashboard → walk away → scans fire on the schedule. `surfbot daemon run` remains for headless server installs.

A `--no-scheduler` flag opts out for operators who want to point the UI at a separately-installed daemon. A new SQLite `scheduler_lock` table prevents two scheduler-owning processes from racing on the same DB.

## Commits (6 of 8 budget)

1. `7f057e2` **refactor**: extract `BuildSchedulerBootstrap` helper. `daemon run` switches to it; pure refactor, all existing tests green.
2. `d9f37f6` **feat(ui)**: `--no-scheduler` flag; scheduler wired into `runUI`; UI/scheduler share one `*storage.SQLiteStore`. `ui` added to `skipDBCommands` so root doesn't open a competing handle.
3. `aeb5be6` **feat(daemon)**: supervisor panic-recover in `daemon.Runner`. Logs panic + stack, writes `last_error`, fires caller hook (UI uses it to cancel signal ctx → HTTP shutdown), exits 1 after a flush grace.
4. `84634e6` **feat(ui)**: shutdown sequencing — HTTP drain (10s) → scheduler stop (config grace, default 30s) → store close. Tests cover ordering and timeout branches.
5. `2cc3249` **feat(storage,cli)**: `scheduler_lock` table (migration 0005) + acquire/refresh/release surface. `surfbot ui` falls back to `--no-scheduler` mode when held; `daemon run` exits non-zero so kardianos surfaces the failure. Same-host PID liveness check via POSIX signal 0 / `os.FindProcess` on Windows.
6. `5cccbca` **docs+test**: README quickstart + `docs/scheduling.md` topology section; `ui_scheduler_integration_test.go` exercises the production webui middleware on top of the in-process scheduler.

## OQ resolution

- **OQ1 (helper location)**: `internal/cli/appcore.go`. New package would have been overkill for a single ticket.
- **OQ2 (lock mechanism)**: SQLite lock table. SQLite was already a dep, table survives reboots, no OS-specific locking primitives.
- **OQ3 (shutdown grace)**: `cfg.Daemon.ShutdownGrace` falling back to 30s — same as `daemon run`. No new config key.
- **OQ4 (start log line)**: `slog.Info(\"scheduler started in-process\", \"pid\", X, \"next_tick\", Y)`.
- **OQ5 (`daemon run` after `ui` started)**: handled by R5; `daemon run` exits non-zero with `scheduler already running` error so kardianos reports a failed start. Verified by code path; integration coverage is in the existing lock unit tests (live-same-host blocks reclaim).

## Before / after of `surfbot ui` startup

**Before**: load UI token → bind `:8470` → serve HTTP. Schedules in DB never fire. Ad-hoc buttons return 503.

**After**: resolve user-mode paths → `BuildSchedulerBootstrap` (config + store + legacy migration + master ticker) → take `scheduler_lock` (or fall back to UI-only) → start `daemon.Runner` (supervised) → bind `:8470` → serve HTTP. On Ctrl+C: drain HTTP → stop scheduler → release lock → close store → exit.

## Test gates

- `go build ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./... -count=1` (full suite, all green)
- `go test -tags=e2e ./test/e2e/... -count=1` (SCHED1.5 E2E, ~49s, green)
- New `TestUI_SchedulerInProcessFiresScheduledScan` — production webui middleware + in-process scheduler dispatching a real schedule.
- New `TestRunner_SchedulerPanicIsSupervised` — proves panic recover, `last_error` write, and non-zero exit.
- New `TestShutdownUI_HTTPDrainsBeforeScheduler` + `TestShutdownUI_SchedulerTimeoutIsClean` — proves R4 ordering and timeout safety.
- New scheduler-lock tests: contention, stale-PID reclaim, live-same-host block, refresh/release.

## Deviations from spec

- `SchedulerBootstrap.Scheduler` is `*intervalsched.Scheduler` (concrete) instead of `daemon.Scheduler` (interface). The concrete type satisfies both `daemon.Scheduler` and `webui.AdHocDispatcher`; using the interface would have locked the UI out of the dispatcher surface.
- The R6 integration test polls 75s rather than 10s, because a `FREQ=MINUTELY` schedule with `dtstart = now-59s` fires at the next wall-clock minute boundary (≤60s away), not 2s out as the spec OQ note suggested. Same pattern as the existing SCHED1.5 e2e test.

## Test plan

- [ ] Manual: `surfbot ui` on a clean state dir → create a target → create a schedule via dashboard → wait → scan appears.
- [ ] Manual: `surfbot ui --no-scheduler` while a `surfbot daemon run` is active in another terminal → both come up; daemon owns dispatch.
- [ ] Manual: kill the daemon mid-run → re-run `surfbot ui` → log shows `reclaiming stale scheduler_lock`.