### PR TITLE
webui: hydrate schedule edit form to prevent modal state bleed (SUR-256)

### DIFF
--- a/docs/manual-tests/sched2.2-modal-bleed.md
+++ b/docs/manual-tests/sched2.2-modal-bleed.md
@@ -1,0 +1,75 @@
+# Manual smoke test — SPEC-SCHED2.2 (schedule edit-modal state bleed)
+
+**Spec:** `surfbot-strategy/specs/SPEC-SCHED2.2-modal-bleed.md`
+**Linear:** [SUR-256](https://linear.app/surfbot/issue/SUR-256)
+
+The bug: opening the edit modal for schedule A, closing it, then opening
+the edit modal for schedule B used to show A's field values. Saving B
+silently overwrote it with A's RRULE / target / template / etc.
+
+The fix is a JS-only change in `internal/webui/static/js/pages/schedules.js`
+(`hydrateScheduleForm` + `onClose` cleanup). There is no Go change and no
+new automated test — this doc is the smoke check.
+
+## Setup
+
+```sh
+make build
+./surfbot ui &
+# or: ./surfbot daemon  + open the UI port in a browser
+```
+
+Create two targets and two schedules with distinct values so the bleed
+is visually obvious:
+
+```sh
+./surfbot target add foo.test.local
+./surfbot target add bar.test.local
+```
+
+In the UI (Schedules → New schedule), create:
+
+- **A**: name `alpha`, target = `foo.test.local`, RRULE = `FREQ=DAILY`,
+  DTSTART = any future minute, timezone `UTC`.
+- **B**: name `beta`, target = `bar.test.local`, RRULE = `FREQ=WEEKLY`,
+  DTSTART = any future minute, timezone `UTC`.
+
+## Repro of the bug (pre-fix; for historical reference)
+
+1. Schedules → click row A → **Edit**.
+2. Verify form shows `name=alpha`, `rrule=FREQ=DAILY`.
+3. Close the modal — try all three dismiss paths: Esc, backdrop click,
+   Cancel button. The bug reproduced under all three.
+4. Schedules → click row B → **Edit**.
+5. **Bug:** form shows `name=alpha`, `rrule=FREQ=DAILY` (bleed from A).
+6. Click **Save**. The B row in the list now has A's RRULE and name.
+
+## Verification (post-fix)
+
+Repeat steps 1–5. At step 5, every field reflects B's server state:
+`name=beta`, `rrule=FREQ=WEEKLY`, target = `bar.test.local`.
+
+Run all three dismiss paths (Esc, backdrop, Cancel) between A and B and
+confirm none of them leak state.
+
+Bonus checks:
+
+- A → Edit → close → **New schedule**: every field is blank except
+  `Timezone`, which defaults to `UTC`.
+- New schedule → fill in fields → close → **New schedule** again:
+  blank again (no state from the previous create attempt).
+- Edit B → change `name` to `betaprime` → Save → reopen Edit on B:
+  shows `betaprime` (server is the source of truth, not the previous
+  modal session).
+
+## What's deferred
+
+- **Visual diff indicator + reset control** (R3 of the original Linear
+  ticket — defensive UX, not a bug fix). Tracked separately under UX
+  hardening.
+- **Audit of `templates.js` / `blackouts.js` modals** for the same
+  pattern. They use the same `value=` attribute mechanism and are
+  candidates for the same fix if the bug reproduces there. Not in
+  scope for this ticket.
+- **JS unit-test infrastructure** (jsdom / Vitest / Playwright). No
+  framework exists in the repo today; adding one is its own ticket.

--- a/internal/webui/static/js/pages/schedules.js
+++ b/internal/webui/static/js/pages/schedules.js
@@ -327,7 +327,27 @@ const SchedulesPage = {
         },
       },
       secondaryAction: { label: 'Cancel' },
+      onClose: () => {
+        // SPEC-SCHED2.2: clear field values on unmount as a belt-and-
+        // suspenders measure against browser autofill carrying state
+        // from one open into the next. R1's hydrateScheduleForm is the
+        // load-bearing fix; this just makes sure stale values don't
+        // outlive the modal in any reference held elsewhere.
+        const form = m.root.querySelector('#schedule-form');
+        if (!form) return;
+        Array.from(form.elements).forEach(el => {
+          const tag = el.tagName;
+          if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+            el.value = '';
+          }
+        });
+      },
     });
+    // SPEC-SCHED2.2: explicit state hydration. Don't rely on the value=
+    // attribute alone — Chrome/Safari autofill can override it when the
+    // form is re-mounted with the same field names, leaking values from
+    // a previously-edited schedule into the next open.
+    hydrateScheduleForm(m.root.querySelector('#schedule-form'), s, mode);
     // Non-blocking RRULE syntax warning wires after the DOM is in place.
     Components.rruleAttachBlurCheck(m.root.querySelector('#schedule-form'), 'rrule');
   },
@@ -480,6 +500,37 @@ const SchedulesPage = {
     `;
   },
 };
+
+// hydrateScheduleForm sets each field's `.value` IDL property explicitly
+// from the schedule object after the modal mounts. Setting the property
+// (not the attribute) ensures the browser's autofill / form-restore
+// behavior cannot override us with cached values from a previous open
+// of the same form. Required for SPEC-SCHED2.2 — without this, editing
+// schedule A then closing and editing schedule B would re-display A's
+// values and silently overwrite B on save.
+function hydrateScheduleForm(form, schedule, mode) {
+  if (!form) return;
+  const s = schedule || {};
+  const isCreate = mode === 'create';
+
+  const setVal = (name, value) => {
+    const el = form.elements[name];
+    if (!el) return;
+    el.value = value == null ? '' : String(value);
+  };
+
+  setVal('name', isCreate ? '' : s.name);
+  setVal('target_id', isCreate ? '' : s.target_id);
+  setVal('template_id', isCreate ? '' : s.template_id);
+  setVal('rrule', isCreate ? '' : s.rrule);
+  // datetime-local needs "YYYY-MM-DDTHH:MM"; the API gives back ISO-8601.
+  setVal('dtstart', isCreate ? '' : toDatetimeLocal(s.dtstart));
+  setVal('timezone', s.timezone || 'UTC');
+  setVal('estimated_duration_seconds', '');
+  if (form.elements.status) {
+    setVal('status', s.status || 'active');
+  }
+}
 
 // readScheduleForm serializes the schedule form into the API shape.
 // DTSTART is converted from "datetime-local" ("YYYY-MM-DDTHH:MM") to a


### PR DESCRIPTION
## Summary
- Edit modal for schedule A used to leak field values into a subsequent open of schedule B (autofill resurrected the previous form), and saving B silently overwrote it with A's values.
- Fix: explicit `hydrateScheduleForm` after mount sets each field's `.value` IDL property from the server-side schedule, overriding browser autofill. `onClose` blanks fields belt-and-suspenders.
- Adds `docs/manual-tests/sched2.2-modal-bleed.md` smoke check (no automated JS test infra in the repo).

Linear: [SUR-256](https://linear.app/surfbot/issue/SUR-256)
Spec: SPEC-SCHED2.2

## Test plan
- [ ] `make build && ./surfbot ui` then follow `docs/manual-tests/sched2.2-modal-bleed.md` (Esc / backdrop / Cancel dismiss paths).
- [ ] Edit A → close → Edit B: form reflects B's server state.
- [ ] Edit A → close → New: form blank except Timezone=UTC.