### PR TITLE
chore: gitignore .claude workspace dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ vendor/
 
 # Claude Code
 CLAUDE.md
+.claude/
 
 # Surfbot data
 *.db


### PR DESCRIPTION
## Summary
- Adds `.claude/` to `.gitignore` so the local Claude Code workspace (settings.local.json, ephemeral worktrees) stops showing as untracked in `git status`.

## Test plan
- [ ] After merge, `git status` on a clean tree no longer lists `.claude/` as untracked.