### PR TITLE
chore: gitignore local redesign-wireframes scratch html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ CLAUDE.md
 *.db
 *.db-wal
 *.db-shm
+
+# Local design scratch
+internal/webui/static/redesign-wireframes.html


### PR DESCRIPTION
## Summary
- Adds `internal/webui/static/redesign-wireframes.html` to `.gitignore`. It's a local design scratch file that lives inside `internal/webui/static/` (so it's served by the embedded UI dev path) but should not be committed.

## Test plan
- [ ] After merge, `git status` no longer reports the wireframes html as untracked.