### PR TITLE
webui: ui v2 foundation tokens and shared components (#34)

### DIFF
--- a/internal/webui/foundation_assets_test.go
+++ b/internal/webui/foundation_assets_test.go
@@ -1,0 +1,88 @@
+package webui
+
+// UI v2 foundation snapshot (issue #34). The redesign sprint relies on
+// a small vocabulary of CSS tokens and JS component helpers that later
+// PRs build on. A simple string-presence check on the embedded static
+// assets catches the common break modes — accidental removal during a
+// refactor, a typo on a token name, a forgotten //go:embed match —
+// without standing up a JS test runner just for this. When the
+// foundation is renamed in a future sprint, update both the symbol
+// list and the call sites at the same time.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFoundationCSSTokens(t *testing.T) {
+	data, err := staticFS.ReadFile("static/css/style.css")
+	require.NoError(t, err)
+	css := string(data)
+
+	tokens := []string{
+		// Surface scale.
+		"--ink-900:", "--ink-800:", "--ink-700:", "--ink-600:",
+		// Brand alias.
+		"--brand:",
+		// Severity (pre-existing, asserted as a regression guard).
+		"--sev-critical:", "--sev-high:", "--sev-medium:", "--sev-low:", "--sev-info:",
+		// Finding triage status (net new in PR1).
+		"--status-open:", "--status-ack:", "--status-resolved:",
+		"--status-fp:", "--status-ignored:",
+	}
+	for _, tok := range tokens {
+		assert.True(t, strings.Contains(css, tok),
+			"foundation token %q missing from style.css", tok)
+	}
+
+	classes := []string{
+		".pill", ".pill-dot",
+		".sev-pill-critical", ".sev-pill-high", ".sev-pill-medium",
+		".sev-pill-low", ".sev-pill-info",
+		".status-pill-open", ".status-pill-ack", ".status-pill-resolved",
+		".status-pill-fp", ".status-pill-ignored",
+		".filter-chip", ".filter-chip-remove",
+		".kbd",
+		".icon-12", ".icon-14", ".icon-16",
+		".slide-over", ".slide-over-backdrop", ".slide-over-header",
+		".slide-over-body", ".slide-over-footer", ".slide-over-close",
+		".bulk-bar", ".bulk-bar-count", ".bulk-bar-actions",
+	}
+	for _, cls := range classes {
+		assert.True(t, strings.Contains(css, cls),
+			"foundation class %q missing from style.css", cls)
+	}
+}
+
+func TestFoundationComponentHelpers(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/components.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	// Each helper is checked by the property-name form used in the
+	// Components object literal so the test fails if it's renamed or
+	// promoted out of the object without intent.
+	helpers := []string{
+		"severityPill(", "statusPill(", "filterChip(",
+		"kbd(", "icon(", "slideOver(", "bulkBar(",
+	}
+	for _, h := range helpers {
+		assert.True(t, strings.Contains(js, h),
+			"foundation helper %q missing from components.js", h)
+	}
+
+	// The icon registry must list at least the seed glyphs so PR2 can
+	// rely on them without re-discovering whether they exist.
+	icons := []string{
+		"x:", "search:", "plus:",
+		"'chevron-down':", "'chevron-right':",
+		"check:", "clock:", "alert:", "copy:",
+	}
+	for _, ic := range icons {
+		assert.True(t, strings.Contains(js, ic),
+			"foundation icon %q missing from components.js ICONS registry", ic)
+	}
+}

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -1509,3 +1509,226 @@ tr.row-selected { background: rgba(0,229,153,0.06); }
   max-height: 320px;
 }
 
+/* === UI v2 foundation (PR1 #34) =====================================
+ * Design tokens and shared component styles for the redesign. Existing
+ * tokens (--bg-*, --accent, --sev-*) stay untouched — these are
+ * additive aliases plus net-new tokens for finding triage status. The
+ * later sprint PRs migrate page-level CSS over; until then both
+ * vocabularies coexist.
+ * =================================================================== */
+
+:root {
+  /* Surface scale — lower number = darker. Mapped 1:1 to existing
+   * --bg-* so the redesign can reach for semantic names without a
+   * second source of truth for the actual hex. */
+  --ink-900: #0d1117;
+  --ink-800: #161b22;
+  --ink-700: #21262d;
+  --ink-600: #30363d;
+
+  /* Brand alias for --accent. Keeps the wireframe vocabulary. */
+  --brand: var(--accent);
+  --brand-strong: var(--accent-hover);
+
+  /* Finding triage status. Open is attention-red, ack is amber,
+   * resolved is brand green, fp/ignored fade to muted greys. */
+  --status-open:     #f85149;
+  --status-ack:      #d29922;
+  --status-resolved: #00E599;
+  --status-fp:       #8b949e;
+  --status-ignored:  #6e7681;
+
+  --status-open-bg:     rgba(248,81,73,0.15);
+  --status-ack-bg:      rgba(210,153,34,0.15);
+  --status-resolved-bg: rgba(0,229,153,0.15);
+  --status-fp-bg:       rgba(139,148,158,0.15);
+  --status-ignored-bg:  rgba(110,118,129,0.15);
+
+  --status-open-border:     rgba(248,81,73,0.4);
+  --status-ack-border:      rgba(210,153,34,0.4);
+  --status-resolved-border: rgba(0,229,153,0.4);
+  --status-fp-border:       rgba(139,148,158,0.3);
+  --status-ignored-border:  rgba(110,118,129,0.3);
+}
+
+/* --- Pills (severity + status) -------------------------------------
+ * Rounded-full label with optional leading dot. The variant class
+ * supplies color/bg/border via the tokens above. */
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-size: 11px;
+  line-height: 1.4;
+  font-weight: 500;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.pill-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: currentColor;
+}
+
+.sev-pill-critical { color: var(--sev-critical); background: var(--sev-critical-bg); border-color: rgba(248,81,73,0.4); }
+.sev-pill-high     { color: var(--sev-high);     background: var(--sev-high-bg);     border-color: rgba(219,109,40,0.4); }
+.sev-pill-medium   { color: var(--sev-medium);   background: var(--sev-medium-bg);   border-color: rgba(210,153,34,0.4); }
+.sev-pill-low      { color: var(--sev-low);      background: var(--sev-low-bg);      border-color: rgba(88,166,255,0.4); }
+.sev-pill-info     { color: var(--sev-info);     background: var(--sev-info-bg);     border-color: rgba(139,148,158,0.4); }
+
+.status-pill-open     { color: var(--status-open);     background: var(--status-open-bg);     border-color: var(--status-open-border); }
+.status-pill-ack      { color: var(--status-ack);      background: var(--status-ack-bg);      border-color: var(--status-ack-border); }
+.status-pill-resolved { color: var(--status-resolved); background: var(--status-resolved-bg); border-color: var(--status-resolved-border); }
+.status-pill-fp       { color: var(--status-fp);       background: var(--status-fp-bg);       border-color: var(--status-fp-border); }
+.status-pill-ignored  { color: var(--status-ignored);  background: var(--status-ignored-bg);  border-color: var(--status-ignored-border); }
+
+/* --- Filter chip ---------------------------------------------------
+ * Persistent removable filter affordance. The ✕ button is wired by
+ * Components.filterChip(); CSS only handles the look. */
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 4px 2px 10px;
+  border-radius: 9999px;
+  background: var(--ink-700);
+  border: 1px solid var(--ink-600);
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.filter-chip-label { font-weight: 500; }
+.filter-chip-remove {
+  width: 16px;
+  height: 16px;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 50%;
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0;
+}
+.filter-chip-remove:hover { background: var(--ink-600); color: var(--text-primary); }
+
+/* --- Kbd hint ------------------------------------------------------- */
+.kbd {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--ink-700);
+  color: var(--text-primary);
+  border: 1px solid var(--ink-600);
+  box-shadow: 0 1px 0 rgba(0,0,0,0.3);
+  line-height: 1;
+}
+
+/* --- Icon sizes ----------------------------------------------------- */
+.icon { display: inline-block; flex-shrink: 0; vertical-align: middle; }
+.icon-12 { width: 12px; height: 12px; }
+.icon-14 { width: 14px; height: 14px; }
+.icon-16 { width: 16px; height: 16px; }
+
+/* --- Slide-over panel ---------------------------------------------
+ * Right-anchored sheet for finding/asset detail. Mounts under
+ * <body>; the .open class triggers the slide-in transition. */
+.slide-over-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  background: rgba(0,0,0,0.4);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.18s ease-out;
+}
+.slide-over-backdrop.open { opacity: 1; pointer-events: auto; }
+
+.slide-over {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(640px, 100vw);
+  background: var(--ink-800);
+  border-left: 1px solid var(--ink-600);
+  box-shadow: -8px 0 24px rgba(0,0,0,0.4);
+  display: flex;
+  flex-direction: column;
+  transform: translateX(100%);
+  transition: transform 0.18s ease-out;
+  z-index: 31;
+}
+.slide-over.open { transform: translateX(0); }
+
+.slide-over-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--ink-600);
+  flex-shrink: 0;
+}
+.slide-over-title {
+  flex: 1;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+.slide-over-close {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 22px;
+  line-height: 1;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+}
+.slide-over-close:hover { background: var(--ink-700); color: var(--text-primary); }
+.slide-over-body { flex: 1; padding: 20px; overflow-y: auto; }
+.slide-over-footer {
+  padding: 12px 20px;
+  border-top: 1px solid var(--ink-600);
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* --- Bulk bar (UI v2 floating shape) -------------------------------
+ * Distinct from the legacy .bulk-actions-bar (rectangular sticky
+ * bottom). This one is a pill-shaped floater meant for the findings
+ * list. Both shapes coexist while pages migrate. */
+.bulk-bar {
+  position: sticky;
+  bottom: 16px;
+  margin: 16px auto 0;
+  width: max-content;
+  max-width: calc(100% - 32px);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px 8px 16px;
+  background: var(--ink-700);
+  border: 1px solid var(--ink-600);
+  border-radius: 9999px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+  z-index: 20;
+}
+.bulk-bar.hidden { display: none; }
+.bulk-bar-count { font-size: 13px; color: var(--text-secondary); }
+.bulk-bar-count strong { color: var(--brand); margin-right: 4px; }
+.bulk-bar-actions { display: flex; gap: 6px; align-items: center; }
+

--- a/internal/webui/static/js/components.js
+++ b/internal/webui/static/js/components.js
@@ -559,7 +559,201 @@ const Components = {
       <span class="bulk-actions-buttons">${btns}</span>
     </div>`;
   },
+
+  // --- UI v2 foundation (PR1 #34) ---------------------------------
+  //
+  // The redesign introduces "pill" shapes for severity and finding
+  // status, a removable filter chip, kbd hints, a registry for inline
+  // SVG icons, an imperative slide-over panel, and a floating bulk-bar
+  // (distinct from the legacy bulkActionsBar). These helpers are
+  // additive; the older severityBadge/statusBadge/bulkActionsBar stay
+  // for the pages that haven't been migrated yet.
+
+  // severityPill renders a CRITICAL/HIGH/... pill with a leading dot
+  // colored from --sev-{level}. Unknown levels fall back to info.
+  severityPill(level) {
+    const lvl = SEVERITY_LEVELS[level] ? level : 'info';
+    const label = (level || 'info').toString().toUpperCase();
+    return `<span class="pill sev-pill-${lvl}"><span class="pill-dot"></span>${escapeHtml(label)}</span>`;
+  },
+
+  // statusPill renders a finding triage status (open/ack/resolved/fp/
+  // ignored) with the human label. Unknown statuses render as raw.
+  statusPill(status) {
+    const labels = {
+      open: 'Open',
+      ack: 'Acknowledged',
+      resolved: 'Resolved',
+      fp: 'False positive',
+      ignored: 'Ignored',
+    };
+    const cls = labels[status] ? `status-pill-${status}` : 'status-pill-fp';
+    const label = labels[status] || (status || '').toString();
+    return `<span class="pill ${cls}">${escapeHtml(label)}</span>`;
+  },
+
+  // filterChip returns an HTMLElement (not a string) so the caller can
+  // wire onRemove without setting up event delegation. Passing
+  // onRemove=null/undefined renders without the ✕ button — useful for
+  // read-only displays.
+  filterChip(label, onRemove) {
+    const el = document.createElement('span');
+    el.className = 'filter-chip';
+    const removeHtml = onRemove
+      ? `<button type="button" class="filter-chip-remove" aria-label="Remove ${escapeHtml(label)}">&times;</button>`
+      : '';
+    el.innerHTML = `<span class="filter-chip-label">${escapeHtml(label)}</span>${removeHtml}`;
+    if (onRemove) {
+      el.querySelector('.filter-chip-remove').addEventListener('click', (e) => {
+        e.stopPropagation();
+        onRemove(e);
+      });
+    }
+    return el;
+  },
+
+  // kbd wraps a shortcut hint in a styled <kbd>. Used by Cmd+K,
+  // help overlays, and inline shortcuts.
+  kbd(label) {
+    return `<kbd class="kbd">${escapeHtml(label)}</kbd>`;
+  },
+
+  // icon looks up a name in ICONS and returns an inline <svg> string
+  // sized to 12/14/16px. Unknown names return ''. Keep ICONS as the
+  // single registry — adding a glyph here makes it available app-wide.
+  icon(name, size) {
+    const sz = size === 12 || size === 14 || size === 16 ? size : 16;
+    const path = ICONS[name];
+    if (!path) return '';
+    return `<svg class="icon icon-${sz}" width="${sz}" height="${sz}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${path}</svg>`;
+  },
+
+  // slideOver mounts a right-anchored panel as a sibling of <body>.
+  // body may be an HTML string or an HTMLElement; the latter is taken
+  // over (appendChild) so callers can wire up event listeners before
+  // mounting. actions is an array of { label, onClick, primary, danger }
+  // rendered as buttons in the footer.
+  //
+  // Returns { close, root, body } so the caller can refresh the body
+  // (e.g. after a status change) without closing the panel.
+  //
+  // Esc and backdrop click both invoke onClose with reason='dismiss'.
+  slideOver({ title, body, actions, onClose }) {
+    const backdrop = document.createElement('div');
+    backdrop.className = 'slide-over-backdrop';
+    const panel = document.createElement('aside');
+    panel.className = 'slide-over';
+    panel.setAttribute('role', 'dialog');
+    panel.setAttribute('aria-modal', 'true');
+    panel.setAttribute('aria-label', title || 'Detail');
+
+    const actionsHtml = (actions || []).map((a, i) => {
+      const cls = a.danger ? 'btn btn-danger' : (a.primary ? 'btn btn-primary' : 'btn btn-ghost');
+      return `<button type="button" class="${cls}" data-slide-action="${i}">${escapeHtml(a.label)}</button>`;
+    }).join('');
+
+    panel.innerHTML = `
+      <div class="slide-over-header">
+        <h3 class="slide-over-title">${escapeHtml(title || '')}</h3>
+        <button type="button" class="slide-over-close" aria-label="Close">&times;</button>
+      </div>
+      <div class="slide-over-body" data-slide-body></div>
+      ${actions && actions.length ? `<div class="slide-over-footer">${actionsHtml}</div>` : ''}
+    `;
+    const bodyEl = panel.querySelector('[data-slide-body]');
+    if (body instanceof HTMLElement) {
+      bodyEl.appendChild(body);
+    } else if (typeof body === 'string') {
+      bodyEl.innerHTML = body;
+    }
+
+    document.body.appendChild(backdrop);
+    document.body.appendChild(panel);
+    // Force a reflow so the .open class triggers the transition
+    // instead of being collapsed into the initial paint.
+    void panel.offsetWidth;
+    backdrop.classList.add('open');
+    panel.classList.add('open');
+    document.body.classList.add('modal-open');
+
+    let closed = false;
+    function close(reason) {
+      if (closed) return;
+      closed = true;
+      backdrop.classList.remove('open');
+      panel.classList.remove('open');
+      document.removeEventListener('keydown', onKey);
+      document.body.classList.remove('modal-open');
+      // Allow the slide-out transition to play before we yank the DOM.
+      setTimeout(() => {
+        backdrop.remove();
+        panel.remove();
+      }, 200);
+      if (typeof onClose === 'function') onClose(reason || 'close');
+    }
+    function onKey(e) {
+      if (e.key === 'Escape') close('dismiss');
+    }
+    document.addEventListener('keydown', onKey);
+    backdrop.addEventListener('click', () => close('dismiss'));
+    panel.querySelector('.slide-over-close').addEventListener('click', () => close('dismiss'));
+
+    panel.querySelectorAll('[data-slide-action]').forEach((btn) => {
+      const i = parseInt(btn.getAttribute('data-slide-action'), 10);
+      const a = (actions || [])[i];
+      if (!a || typeof a.onClick !== 'function') return;
+      btn.addEventListener('click', async () => {
+        const r = a.onClick({ close, root: panel, body: bodyEl });
+        if (r && typeof r.then === 'function') {
+          btn.disabled = true;
+          try { await r; } finally { btn.disabled = false; }
+        }
+      });
+    });
+
+    return { close, root: panel, body: bodyEl };
+  },
+
+  // bulkBar renders the floating, pill-shaped selection bar used by
+  // the redesigned findings list. Returns an HTML string with a hidden
+  // class when count is 0; pages toggle visibility by re-rendering or
+  // by flipping .hidden directly. action.danger styles as btn-danger,
+  // action.primary as btn-primary, otherwise ghost.
+  bulkBar({ count, actions }) {
+    const hidden = count > 0 ? '' : ' hidden';
+    const btns = (actions || []).map((a, i) => {
+      const cls = a.danger ? 'btn btn-danger' : (a.primary ? 'btn btn-primary' : 'btn btn-ghost');
+      return `<button type="button" class="${cls}" data-bulk-action="${i}">${escapeHtml(a.label)}</button>`;
+    }).join('');
+    return `<div class="bulk-bar${hidden}">
+      <span class="bulk-bar-count"><strong>${count || 0}</strong>selected</span>
+      <span class="bulk-bar-actions">${btns}</span>
+    </div>`;
+  },
 };
+
+// Severity level whitelist for severityPill. Kept as a frozen object
+// so an unknown level can short-circuit to 'info' without spelling out
+// the five branches in the helper.
+const SEVERITY_LEVELS = Object.freeze({
+  critical: true, high: true, medium: true, low: true, info: true,
+});
+
+// Inline SVG path data for the foundation icon set. Each entry is the
+// inner markup of a 24×24 viewBox <svg> with stroke=currentColor and
+// stroke-width=2 — Components.icon() wraps these into a sized <svg>.
+// Add new glyphs here, not at call sites.
+const ICONS = Object.freeze({
+  x:              '<line x1="6" y1="6" x2="18" y2="18"/><line x1="6" y1="18" x2="18" y2="6"/>',
+  search:         '<circle cx="11" cy="11" r="7"/><line x1="20" y1="20" x2="16.65" y2="16.65"/>',
+  plus:           '<line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>',
+  'chevron-down': '<polyline points="6 9 12 15 18 9"/>',
+  'chevron-right':'<polyline points="9 6 15 12 9 18"/>',
+  check:          '<polyline points="5 12 10 17 19 7"/>',
+  clock:          '<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>',
+  alert:          '<path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>',
+  copy:           '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>',
+});
 
 function pad2(n) { return String(n).padStart(2, '0'); }
 


### PR DESCRIPTION
## Summary

PR1 del sprint UI v2 — foundation only, sin cambios visibles para el usuario. Sienta las bases para los 11 PRs siguientes.

- **CSS tokens**: `--ink-{900..600}` aliasados a los `--bg-*` existentes, `--brand` aliasado a `--accent`, `--status-{open|ack|resolved|fp|ignored}` net-new para finding triage. Cero cambios en tokens preexistentes.
- **Component styles**: `.pill` + `.sev-pill-*` + `.status-pill-*`, `.filter-chip` (con ✕), `.kbd`, `.icon-{12,14,16}`, `.slide-over*` (backdrop + panel + header/body/footer), `.bulk-bar` (la versión floating distinta al legacy `.bulk-actions-bar`).
- **JS helpers** en `Components`: `severityPill`, `statusPill`, `filterChip`, `kbd`, `icon` (+ registro `ICONS` con 9 glifos seed), `slideOver` (Esc + click backdrop dismiss, retorna `{ close, root, body }`), `bulkBar`. Los helpers viejos (`severityBadge`, `statusBadge`, `bulkActionsBar`) intactos para páginas no migradas.
- **Snapshot test** Go en `internal/webui/foundation_assets_test.go` que valida sobre el `embed.FS` la presencia de cada token, clase, helper e icono. Sustituye al "unit test por helper / snapshot CSS" del issue mientras no haya runner JS en el repo.

## Test plan

- [x] `go test ./internal/webui/... -race -count=1` pasa.
- [x] `go test ./internal/webui/... -tags=integration -race -count=1` pasa.
- [x] `go test ./... -race -short` pasa (toda la suite).
- [x] `go build ./...` pasa.
- [x] `golangci-lint run ./...` 0 issues.
- [x] `go test -run TestFoundation -v` (snapshot tokens + helpers + icons) pasa.
- [ ] Smoke manual del agente (`surfbot ui`): la SPA carga y los pages existentes se ven sin regresión visual.

Closes #34
