### PR TITLE
webui: ui v2 sidebar reagrupada + topbar (#35)

### DIFF
--- a/internal/webui/sidebar_topbar_test.go
+++ b/internal/webui/sidebar_topbar_test.go
@@ -1,0 +1,226 @@
+package webui
+
+// UI v2 PR2 (#35) — sidebar grouping + topbar invariants. Same
+// string-presence approach as foundation_assets_test.go: catches the
+// common break modes (a refactor accidentally drops the Findings
+// badge, a typo on a group label, the Reports bucket sneaking back in
+// from a paste, a forgotten breadcrumb mapping) without standing up a
+// JS test runner. When PR3+ migrate the markup, update both the symbol
+// list and the call sites at the same time.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSidebarFiveGroupLabels(t *testing.T) {
+	data, err := staticFS.ReadFile("static/index.html")
+	require.NoError(t, err)
+	html := string(data)
+
+	groups := []string{"Insights", "Discover", "Detect", "Triage", "Configure"}
+	for _, g := range groups {
+		marker := `class="nav-group-label">` + g + `<`
+		assert.True(t, strings.Contains(html, marker),
+			"sidebar group label %q missing or unwrapped from .nav-group-label", g)
+	}
+
+	// PR2 acceptance: groups appear in the documented top-down order.
+	idx := -1
+	for _, g := range groups {
+		marker := `class="nav-group-label">` + g + `<`
+		next := strings.Index(html, marker)
+		require.GreaterOrEqual(t, next, 0, "group %q not found", g)
+		assert.Greater(t, next, idx, "group %q is out of order", g)
+		idx = next
+	}
+}
+
+func TestSidebarItemCount(t *testing.T) {
+	data, err := staticFS.ReadFile("static/index.html")
+	require.NoError(t, err)
+	html := string(data)
+
+	// Exactly 11 items in the new sidebar:
+	//   Insights:  Dashboard
+	//   Discover:  Targets, Assets, Changes
+	//   Detect:    Scans, Schedules, Templates
+	//   Triage:    Findings
+	//   Configure: Tools, Blackouts, Settings
+	// Counted via data-page= rather than class="nav-link because the
+	// latter also matches the .nav-links <ul> wrapper.
+	count := strings.Count(html, `data-page="`)
+	assert.Equal(t, 11, count, "sidebar must have exactly 11 nav-link entries (got %d)", count)
+
+	// Reports is a cloud-only feature (surfbot-web). It must never appear
+	// in the local agent's sidebar — guard against a future paste error.
+	assert.False(t, strings.Contains(html, `data-page="reports"`),
+		"Reports nav link must not appear in the agent sidebar (cloud-only feature)")
+	assert.False(t, strings.Contains(html, `>Reports<`),
+		"Reports label must not appear in the agent sidebar")
+}
+
+func TestSidebarItemPages(t *testing.T) {
+	data, err := staticFS.ReadFile("static/index.html")
+	require.NoError(t, err)
+	html := string(data)
+
+	pages := []string{
+		"dashboard", "targets", "assets", "changes",
+		"scans", "schedules", "templates",
+		"findings",
+		"tools", "blackouts", "settings",
+	}
+	for _, p := range pages {
+		marker := `data-page="` + p + `"`
+		assert.True(t, strings.Contains(html, marker),
+			"sidebar item with data-page=%q missing", p)
+	}
+}
+
+func TestTopbarMarkup(t *testing.T) {
+	data, err := staticFS.ReadFile("static/index.html")
+	require.NoError(t, err)
+	html := string(data)
+
+	// Topbar shell + slots. Each line is a load-bearing hook for app.js
+	// (breadcrumbs, scan indicator, button stubs).
+	hooks := []string{
+		`class="topbar"`,
+		`id="breadcrumbs"`,
+		`id="scan-indicator"`,
+		`id="scan-indicator-phase"`,
+		`id="topbar-cmdk-btn"`,
+		`id="topbar-new-btn"`,
+		`id="topbar-notif-btn"`,
+		`id="topbar-help-btn"`,
+		`class="kbd"`,
+	}
+	for _, h := range hooks {
+		assert.True(t, strings.Contains(html, h),
+			"topbar hook %q missing from index.html", h)
+	}
+
+	// Notif and help icons advertise the v0.6 ETA via title=. The
+	// acceptance criteria call out this specific copy — keep it
+	// consistent so the Tooltip test in any future Playwright pass can
+	// rely on it.
+	assert.GreaterOrEqual(t,
+		strings.Count(html, `title="Coming in v0.6"`), 2,
+		"notif and help icons must advertise the v0.6 ETA via title=")
+}
+
+func TestSidebarAgentStatusFooter(t *testing.T) {
+	data, err := staticFS.ReadFile("static/index.html")
+	require.NoError(t, err)
+	html := string(data)
+
+	// PR2 #35: the agent status moved from the dashboard into a
+	// compact footer slot inside the sidebar. The slot id is the
+	// hand-off point with AgentCard.mountCompact in app.js.
+	hooks := []string{
+		`id="agent-status-slot"`,
+		`class="agent-status-compact"`,
+	}
+	for _, h := range hooks {
+		assert.True(t, strings.Contains(html, h),
+			"sidebar compact agent status hook %q missing", h)
+	}
+}
+
+func TestTopbarStyles(t *testing.T) {
+	data, err := staticFS.ReadFile("static/css/style.css")
+	require.NoError(t, err)
+	css := string(data)
+
+	classes := []string{
+		".nav-group", ".nav-group-label",
+		".main-area",
+		".topbar", ".topbar-btn", ".topbar-icon-btn",
+		".breadcrumbs", ".breadcrumb-item", ".breadcrumb-sep",
+		".scan-indicator", ".scan-indicator-dot", ".scan-indicator-phase",
+		".agent-status-compact",
+	}
+	for _, cls := range classes {
+		assert.True(t, strings.Contains(css, cls),
+			"PR2 style hook %q missing from style.css", cls)
+	}
+
+	// Topbar sticks to the top of .main-area. The acceptance criteria
+	// call out "Topbar sticky" — keep the rule pinned so a refactor
+	// can't quietly drop it.
+	stickyBlock := strings.Index(css, ".topbar {")
+	require.GreaterOrEqual(t, stickyBlock, 0)
+	end := strings.Index(css[stickyBlock:], "}")
+	require.Greater(t, end, 0)
+	assert.Contains(t, css[stickyBlock:stickyBlock+end], "position: sticky",
+		".topbar must keep position: sticky for the PR2 acceptance criteria")
+}
+
+func TestAppBreadcrumbMapping(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/app.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	// The Breadcrumbs.MAP is the source of truth for the topbar crumb
+	// trail. Every list-route gets a [group, page] entry — pin them so
+	// a typo doesn't break the rendered path.
+	entries := []string{
+		`'/findings':`,
+		`'/assets':`,
+		`'/targets':`,
+		`'/changes':`,
+		`'/scans':`,
+		`'/schedules':`,
+		`'/templates':`,
+		`'/tools':`,
+		`'/blackouts':`,
+		`'/settings':`,
+	}
+	for _, e := range entries {
+		assert.True(t, strings.Contains(js, e),
+			"breadcrumb mapping for %q missing from app.js", e)
+	}
+
+	// Acceptance criteria: navigating to /findings yields
+	// "Surfbot / Triage / Findings". The mapping entry
+	// covers this; the explicit assertion is the human-readable guard.
+	assert.True(t, strings.Contains(js, `'Triage',    'Findings'`),
+		"breadcrumb mapping for /findings must be ['Triage', 'Findings']")
+}
+
+func TestAppScanIndicatorWired(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/app.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	hooks := []string{
+		"ScanIndicator",
+		"API.scanStatus()",
+		"scan-indicator",
+		"scan-indicator-phase",
+	}
+	for _, h := range hooks {
+		assert.True(t, strings.Contains(js, h),
+			"ScanIndicator hook %q missing from app.js", h)
+	}
+}
+
+func TestAgentCardMountCompact(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/pages/agent_card.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	hooks := []string{
+		"mountCompact(",
+		"refreshCompact(",
+		"compactTemplate(",
+	}
+	for _, h := range hooks {
+		assert.True(t, strings.Contains(js, h),
+			"AgentCard compact helper %q missing", h)
+	}
+}

--- a/internal/webui/sidebar_topbar_test.go
+++ b/internal/webui/sidebar_topbar_test.go
@@ -92,7 +92,9 @@ func TestTopbarMarkup(t *testing.T) {
 		`class="topbar"`,
 		`id="breadcrumbs"`,
 		`id="scan-indicator"`,
-		`id="scan-indicator-phase"`,
+		`id="scan-indicator-target"`,
+		`id="scan-indicator-tool"`,
+		`id="scan-indicator-pct"`,
 		`id="topbar-cmdk-btn"`,
 		`id="topbar-new-btn"`,
 		`id="topbar-notif-btn"`,
@@ -139,9 +141,10 @@ func TestTopbarStyles(t *testing.T) {
 	classes := []string{
 		".nav-group", ".nav-group-label",
 		".main-area",
-		".topbar", ".topbar-btn", ".topbar-icon-btn",
+		".topbar", ".topbar-btn", ".topbar-icon-btn", ".topbar-search",
 		".breadcrumbs", ".breadcrumb-item", ".breadcrumb-sep",
-		".scan-indicator", ".scan-indicator-dot", ".scan-indicator-phase",
+		".scan-indicator", ".scan-indicator-dot",
+		".scan-indicator-target", ".scan-indicator-tool", ".scan-indicator-pct",
 		".agent-status-compact",
 	}
 	for _, cls := range classes {
@@ -201,7 +204,9 @@ func TestAppScanIndicatorWired(t *testing.T) {
 		"ScanIndicator",
 		"API.scanStatus()",
 		"scan-indicator",
-		"scan-indicator-phase",
+		"scan-indicator-target",
+		"scan-indicator-tool",
+		"scan-indicator-pct",
 	}
 	for _, h := range hooks {
 		assert.True(t, strings.Contains(js, h),

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -1833,17 +1833,16 @@ tr.row-selected { background: rgba(0,229,153,0.06); }
 
 /* Topbar search opens the Cmd+K modal (PR9). Until then it's a stub
  * that visually reads as a wide input field — placeholder text on the
- * left, magnifier icon, ⌘K kbd anchored to the right edge. The
- * flex:1 + max-width pair lets it absorb the topbar's empty middle
- * without pushing the right-side controls off-screen on narrow
- * viewports. */
+ * left, magnifier icon, ⌘K kbd anchored to the right edge. With
+ * flex:1 and no max-width the search absorbs all the empty middle of
+ * the topbar so the right-side controls (+ New, scan indicator,
+ * notif/help) float to the right edge on every viewport width. */
 .topbar-search {
   display: flex;
   align-items: center;
   gap: 8px;
   flex: 1;
   min-width: 0;
-  max-width: 576px;
   height: 32px;
   padding: 0 12px;
   border-radius: var(--radius);

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -1772,8 +1772,6 @@ tr.row-selected { background: rgba(0,229,153,0.06); }
   flex-shrink: 0;
 }
 
-.topbar-spacer { flex: 1; }
-
 .breadcrumbs {
   display: flex;
   align-items: center;
@@ -1812,6 +1810,7 @@ tr.row-selected { background: rgba(0,229,153,0.06); }
   font-size: 13px;
   cursor: pointer;
   transition: background 0.15s, color 0.15s, border-color 0.15s;
+  flex-shrink: 0;
 }
 
 .topbar-btn:hover {
@@ -1823,17 +1822,55 @@ tr.row-selected { background: rgba(0,229,153,0.06); }
   margin-left: 4px;
 }
 
-.topbar-new {
-  background: var(--accent);
-  color: #0d1117;
-  border-color: var(--accent);
-  font-weight: 600;
+/* "+ New" matches the wireframe ghost shape (dark + border, green
+ * tinted hover) instead of solid primary green so it doesn't compete
+ * visually with the active-scan pill. The real "+ New" affordance
+ * lands in PR3. */
+.topbar-new:hover {
+  border-color: rgba(0,229,153,0.6);
+  color: var(--text-primary);
 }
 
-.topbar-new:hover {
-  background: var(--accent-hover);
-  color: #0d1117;
-  border-color: var(--accent-hover);
+/* Topbar search opens the Cmd+K modal (PR9). Until then it's a stub
+ * that visually reads as a wide input field — placeholder text on the
+ * left, magnifier icon, ⌘K kbd anchored to the right edge. The
+ * flex:1 + max-width pair lets it absorb the topbar's empty middle
+ * without pushing the right-side controls off-screen on narrow
+ * viewports. */
+.topbar-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+  max-width: 576px;
+  height: 32px;
+  padding: 0 12px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--ink-800, var(--bg-tertiary));
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.topbar-search:hover {
+  border-color: rgba(0,229,153,0.6);
+  color: var(--text-secondary);
+}
+
+.topbar-search-placeholder {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.topbar-search .kbd {
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 .topbar-icon-btn {
@@ -1855,17 +1892,28 @@ tr.row-selected { background: rgba(0,229,153,0.06); }
   border-color: var(--border);
 }
 
+/* Active-scan pill in the topbar. Reads "<target> · <tool> <pct>%"
+ * — the pulsing dot already conveys "running", so no redundant label.
+ * Anchored as <a href="#/scans"> so a click opens the scan list. */
 .scan-indicator {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   padding: 4px 10px;
   border-radius: 9999px;
   background: rgba(0,229,153,0.1);
   border: 1px solid rgba(0,229,153,0.3);
-  color: var(--accent);
+  color: var(--text-secondary);
   font-size: 12px;
   font-weight: 500;
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.scan-indicator:hover {
+  border-color: rgba(0,229,153,0.6);
+  color: var(--text-primary);
 }
 
 .scan-indicator.hidden { display: none; }
@@ -1876,11 +1924,16 @@ tr.row-selected { background: rgba(0,229,153,0.06); }
   border-radius: 50%;
   background: var(--accent);
   animation: phase-pulse 2s ease-in-out infinite;
+  flex-shrink: 0;
 }
 
-.scan-indicator-phase {
-  color: var(--text-secondary);
-  font-weight: 400;
+.scan-indicator-target { color: var(--text-secondary); }
+.scan-indicator-sep    { color: var(--text-muted); }
+.scan-indicator-tool   { color: var(--text-secondary); }
+
+.scan-indicator-pct {
+  color: var(--accent);
+  font-weight: 600;
 }
 
 /* Compact agent status pinned in the sidebar footer. The big
@@ -1918,8 +1971,12 @@ tr.row-selected { background: rgba(0,229,153,0.06); }
   .topbar { padding: 8px 12px; gap: 6px; }
   .topbar-btn-label { display: none; }
   .topbar-btn .kbd { display: none; }
+  .topbar-search .kbd { display: none; }
+  .topbar-search-placeholder { display: none; }
   .breadcrumbs { font-size: 12px; }
-  .scan-indicator-phase { display: none; }
+  .scan-indicator-target,
+  .scan-indicator-sep,
+  .scan-indicator-tool { display: none; }
 }
 
 /* --- Bulk bar (UI v2 floating shape) -------------------------------

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -1707,6 +1707,221 @@ tr.row-selected { background: rgba(0,229,153,0.06); }
   flex-shrink: 0;
 }
 
+/* === UI v2 PR2 — sidebar grouping + topbar (#35) ====================
+ * 11 nav items split across 5 buckets (Insights / Discover / Detect /
+ * Triage / Configure). New topbar above .content carries breadcrumbs,
+ * a Cmd+K search stub, "+ New" stub, an active-scan indicator, and
+ * notif/help icons. The agent status moves out of the dashboard into a
+ * compact sidebar footer. Older .nav-link / .sidebar-footer styles in
+ * the SPEC-X3.1 block above still apply — these only fill in the new
+ * shapes.
+ * =================================================================== */
+
+.nav-groups {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.nav-group {
+  padding: 0 8px;
+}
+
+.nav-group + .nav-group {
+  margin-top: 8px;
+}
+
+.nav-group-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: 6px 12px 4px;
+}
+
+/* The legacy .nav-links rule sets flex:1 / padding:8px which no longer
+ * applies inside .nav-group. Reset within groups. */
+.nav-group .nav-links {
+  list-style: none;
+  padding: 0;
+  flex: initial;
+}
+
+.main-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 24px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  flex-shrink: 0;
+}
+
+.topbar-spacer { flex: 1; }
+
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.breadcrumb-item {
+  color: var(--text-secondary);
+}
+
+.breadcrumb-item.breadcrumb-current {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.breadcrumb-sep {
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+
+.topbar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.topbar-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.topbar-btn .kbd {
+  margin-left: 4px;
+}
+
+.topbar-new {
+  background: var(--accent);
+  color: #0d1117;
+  border-color: var(--accent);
+  font-weight: 600;
+}
+
+.topbar-new:hover {
+  background: var(--accent-hover);
+  color: #0d1117;
+  border-color: var(--accent-hover);
+}
+
+.topbar-icon-btn {
+  display: inline-grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius);
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.topbar-icon-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border);
+}
+
+.scan-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border-radius: 9999px;
+  background: rgba(0,229,153,0.1);
+  border: 1px solid rgba(0,229,153,0.3);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.scan-indicator.hidden { display: none; }
+
+.scan-indicator-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: phase-pulse 2s ease-in-out infinite;
+}
+
+.scan-indicator-phase {
+  color: var(--text-secondary);
+  font-weight: 400;
+}
+
+/* Compact agent status pinned in the sidebar footer. The big
+ * dashboard card from SPEC-X3.1 is gone — the status now lives next to
+ * "Run scan now" so it's visible from every page without taking
+ * dashboard real estate. Full audit deferred to #45. */
+.agent-status-compact {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.agent-status-compact .agent-dot {
+  width: 8px;
+  height: 8px;
+}
+
+.agent-status-version {
+  color: var(--text-secondary);
+}
+
+.agent-status-uptime { font-size: 10px; }
+
+@media (max-width: 768px) {
+  .nav-group-label { display: none; }
+  .nav-group { padding: 0 4px; }
+  .agent-status-compact .agent-status-version,
+  .agent-status-compact .agent-status-uptime { display: none; }
+  .topbar { padding: 8px 12px; gap: 6px; }
+  .topbar-btn-label { display: none; }
+  .topbar-btn .kbd { display: none; }
+  .breadcrumbs { font-size: 12px; }
+  .scan-indicator-phase { display: none; }
+}
+
 /* --- Bulk bar (UI v2 floating shape) -------------------------------
  * Distinct from the legacy .bulk-actions-bar (rectangular sticky
  * bottom). This one is a pill-shaped floater meant for the findings

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -103,21 +103,22 @@
         <nav class="breadcrumbs" id="breadcrumbs" aria-label="Breadcrumb">
           <span class="breadcrumb-item">Surfbot</span>
         </nav>
-        <div class="topbar-spacer"></div>
-        <div class="scan-indicator hidden" id="scan-indicator" role="status" aria-live="polite">
-          <span class="scan-indicator-dot"></span>
-          <span class="scan-indicator-label">Scan running</span>
-          <span class="scan-indicator-phase" id="scan-indicator-phase"></span>
-        </div>
-        <button type="button" class="topbar-btn topbar-cmdk" id="topbar-cmdk-btn" aria-label="Search (coming soon)">
+        <button type="button" class="topbar-search" id="topbar-cmdk-btn" aria-label="Search (coming soon)">
           <svg class="icon icon-14" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><line x1="20" y1="20" x2="16.65" y2="16.65"/></svg>
-          <span class="topbar-btn-label">Search</span>
+          <span class="topbar-search-placeholder">Search findings, assets, scans…</span>
           <kbd class="kbd">⌘K</kbd>
         </button>
-        <button type="button" class="topbar-btn topbar-new btn-primary" id="topbar-new-btn" aria-label="New (coming soon)">
-          <svg class="icon icon-14" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        <button type="button" class="topbar-btn topbar-new" id="topbar-new-btn" aria-label="New (coming soon)">
+          <svg class="icon icon-14" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
           <span class="topbar-btn-label">New</span>
         </button>
+        <a href="#/scans" class="scan-indicator hidden" id="scan-indicator" role="status" aria-live="polite" aria-label="Active scan — click to view">
+          <span class="scan-indicator-dot"></span>
+          <span class="scan-indicator-target" id="scan-indicator-target"></span>
+          <span class="scan-indicator-sep" aria-hidden="true">·</span>
+          <span class="scan-indicator-tool" id="scan-indicator-tool"></span>
+          <span class="scan-indicator-pct" id="scan-indicator-pct"></span>
+        </a>
         <button type="button" class="topbar-icon-btn" id="topbar-notif-btn" title="Coming in v0.6" aria-label="Notifications (coming in v0.6)">
           <svg class="icon icon-16" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 01-3.46 0"/></svg>
         </button>

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -17,61 +17,118 @@
           <span class="logo-text">Surfbot</span>
         </a>
       </div>
-      <ul class="nav-links">
-        <li><a href="#/" class="nav-link active" data-page="dashboard">
-          <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm0 6a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H4a1 1 0 01-1-1v-6zm10 0a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"/></svg>
-          <span class="nav-label">Dashboard</span>
-        </a></li>
-        <li><a href="#/findings" class="nav-link" data-page="findings">
-          <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
-          <span class="nav-label">Findings</span>
-          <span class="nav-badge" id="findings-badge" style="display:none"></span>
-        </a></li>
-        <li><a href="#/assets" class="nav-link" data-page="assets">
-          <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path d="M3 12v3c0 1.657 3.134 3 7 3s7-1.343 7-3v-3c0 1.657-3.134 3-7 3s-7-1.343-7-3z"/><path d="M3 7v3c0 1.657 3.134 3 7 3s7-1.343 7-3V7c0 1.657-3.134 3-7 3S3 8.657 3 7z"/><path d="M17 5c0 1.657-3.134 3-7 3S3 6.657 3 5s3.134-3 7-3 7 1.343 7 3z"/></svg>
-          <span class="nav-label">Assets</span>
-        </a></li>
-        <li><a href="#/scans" class="nav-link" data-page="scans">
-          <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"/></svg>
-          <span class="nav-label">Scans</span>
-        </a></li>
-        <li><a href="#/targets" class="nav-link" data-page="targets">
-          <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm0-2a6 6 0 100-12 6 6 0 000 12zm0-2a4 4 0 100-8 4 4 0 000 8zm0-2a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/></svg>
-          <span class="nav-label">Targets</span>
-        </a></li>
-        <li><a href="#/tools" class="nav-link" data-page="tools">
-          <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.062 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/></svg>
-          <span class="nav-label">Tools</span>
-        </a></li>
-        <li><a href="#/timeline" class="nav-link" data-page="timeline">
-          <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"/></svg>
-          <span class="nav-label">Timeline</span>
-        </a></li>
-        <li><a href="#/schedules" class="nav-link" data-page="schedules">
-          <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd"/></svg>
-          <span class="nav-label">Schedules</span>
-        </a></li>
-        <li><a href="#/templates" class="nav-link" data-page="templates">
-          <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/><path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/></svg>
-          <span class="nav-label">Templates</span>
-        </a></li>
-        <li><a href="#/blackouts" class="nav-link" data-page="blackouts">
-          <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z" clip-rule="evenodd"/><path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z"/></svg>
-          <span class="nav-label">Blackouts</span>
-        </a></li>
-        <li><a href="#/settings/defaults" class="nav-link" data-page="settings-defaults">
-          <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.062 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/></svg>
-          <span class="nav-label">Defaults</span>
-        </a></li>
-      </ul>
+      <div class="nav-groups">
+        <div class="nav-group">
+          <div class="nav-group-label">Insights</div>
+          <ul class="nav-links">
+            <li><a href="#/" class="nav-link active" data-page="dashboard">
+              <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm0 6a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H4a1 1 0 01-1-1v-6zm10 0a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"/></svg>
+              <span class="nav-label">Dashboard</span>
+            </a></li>
+          </ul>
+        </div>
+        <div class="nav-group">
+          <div class="nav-group-label">Discover</div>
+          <ul class="nav-links">
+            <li><a href="#/targets" class="nav-link" data-page="targets">
+              <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm0-2a6 6 0 100-12 6 6 0 000 12zm0-2a4 4 0 100-8 4 4 0 000 8zm0-2a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/></svg>
+              <span class="nav-label">Targets</span>
+            </a></li>
+            <li><a href="#/assets" class="nav-link" data-page="assets">
+              <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path d="M3 12v3c0 1.657 3.134 3 7 3s7-1.343 7-3v-3c0 1.657-3.134 3-7 3s-7-1.343-7-3z"/><path d="M3 7v3c0 1.657 3.134 3 7 3s7-1.343 7-3V7c0 1.657-3.134 3-7 3S3 8.657 3 7z"/><path d="M17 5c0 1.657-3.134 3-7 3S3 6.657 3 5s3.134-3 7-3 7 1.343 7 3z"/></svg>
+              <span class="nav-label">Assets</span>
+            </a></li>
+            <li><a href="#/changes" class="nav-link" data-page="changes">
+              <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 5a2 2 0 012-2h8a2 2 0 012 2v9a2 2 0 01-2 2h-3l-3 3v-3H6a2 2 0 01-2-2V5zm3 3a1 1 0 011-1h6a1 1 0 110 2H8a1 1 0 01-1-1zm0 3a1 1 0 011-1h4a1 1 0 110 2H8a1 1 0 01-1-1z" clip-rule="evenodd"/></svg>
+              <span class="nav-label">Changes</span>
+            </a></li>
+          </ul>
+        </div>
+        <div class="nav-group">
+          <div class="nav-group-label">Detect</div>
+          <ul class="nav-links">
+            <li><a href="#/scans" class="nav-link" data-page="scans">
+              <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"/></svg>
+              <span class="nav-label">Scans</span>
+            </a></li>
+            <li><a href="#/schedules" class="nav-link" data-page="schedules">
+              <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd"/></svg>
+              <span class="nav-label">Schedules</span>
+            </a></li>
+            <li><a href="#/templates" class="nav-link" data-page="templates">
+              <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/><path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/></svg>
+              <span class="nav-label">Templates</span>
+            </a></li>
+          </ul>
+        </div>
+        <div class="nav-group">
+          <div class="nav-group-label">Triage</div>
+          <ul class="nav-links">
+            <li><a href="#/findings" class="nav-link" data-page="findings">
+              <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+              <span class="nav-label">Findings</span>
+              <span class="nav-badge" id="findings-badge" style="display:none"></span>
+            </a></li>
+          </ul>
+        </div>
+        <div class="nav-group">
+          <div class="nav-group-label">Configure</div>
+          <ul class="nav-links">
+            <li><a href="#/tools" class="nav-link" data-page="tools">
+              <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.062 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/></svg>
+              <span class="nav-label">Tools</span>
+            </a></li>
+            <li><a href="#/blackouts" class="nav-link" data-page="blackouts">
+              <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z" clip-rule="evenodd"/><path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z"/></svg>
+              <span class="nav-label">Blackouts</span>
+            </a></li>
+            <li><a href="#/settings/defaults" class="nav-link" data-page="settings">
+              <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd"/></svg>
+              <span class="nav-label">Settings</span>
+            </a></li>
+          </ul>
+        </div>
+      </div>
       <div class="sidebar-footer">
         <button type="button" class="btn btn-accent" id="nav-adhoc-btn" style="width:100%;margin-bottom:8px">Run scan now</button>
-        <span class="agent-version" id="agent-version"></span>
+        <div id="agent-status-slot" class="agent-status-compact">
+          <span class="agent-dot" aria-hidden="true"></span>
+          <span class="agent-status-version" id="agent-version">—</span>
+          <span class="agent-status-uptime text-muted" id="agent-uptime"></span>
+        </div>
       </div>
     </nav>
-    <main class="content" id="app">
-      <div class="loading">Loading...</div>
-    </main>
+    <div class="main-area">
+      <header class="topbar" role="banner">
+        <nav class="breadcrumbs" id="breadcrumbs" aria-label="Breadcrumb">
+          <span class="breadcrumb-item">Surfbot</span>
+        </nav>
+        <div class="topbar-spacer"></div>
+        <div class="scan-indicator hidden" id="scan-indicator" role="status" aria-live="polite">
+          <span class="scan-indicator-dot"></span>
+          <span class="scan-indicator-label">Scan running</span>
+          <span class="scan-indicator-phase" id="scan-indicator-phase"></span>
+        </div>
+        <button type="button" class="topbar-btn topbar-cmdk" id="topbar-cmdk-btn" aria-label="Search (coming soon)">
+          <svg class="icon icon-14" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><line x1="20" y1="20" x2="16.65" y2="16.65"/></svg>
+          <span class="topbar-btn-label">Search</span>
+          <kbd class="kbd">⌘K</kbd>
+        </button>
+        <button type="button" class="topbar-btn topbar-new btn-primary" id="topbar-new-btn" aria-label="New (coming soon)">
+          <svg class="icon icon-14" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          <span class="topbar-btn-label">New</span>
+        </button>
+        <button type="button" class="topbar-icon-btn" id="topbar-notif-btn" title="Coming in v0.6" aria-label="Notifications (coming in v0.6)">
+          <svg class="icon icon-16" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 01-3.46 0"/></svg>
+        </button>
+        <button type="button" class="topbar-icon-btn" id="topbar-help-btn" title="Coming in v0.6" aria-label="Help (coming in v0.6)">
+          <svg class="icon icon-16" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        </button>
+      </header>
+      <main class="content" id="app">
+        <div class="loading">Loading...</div>
+      </main>
+    </div>
   </div>
 
   <script src="/js/api.js"></script>

--- a/internal/webui/static/js/app.js
+++ b/internal/webui/static/js/app.js
@@ -34,12 +34,17 @@ const Router = {
       link.classList.remove('active');
       const page = link.getAttribute('data-page');
       if (hash === '#/' && page === 'dashboard') link.classList.add('active');
-      else if (hash.startsWith('#/' + page)) link.classList.add('active');
+      else if (page !== 'dashboard' && hash.startsWith('#/' + page)) link.classList.add('active');
     });
 
-    // Stop the AgentCard poll loop on every navigation. Dashboard
-    // re-mounts it; every other route leaves it stopped so the
-    // background fetch does not leak across pages.
+    // PR2 #35: refresh breadcrumbs in the topbar based on the new hash.
+    // Mapping is hash-prefix → [groupLabel, pageLabel]. Detail routes
+    // inherit their list parent (e.g. #/findings/abc → "Findings").
+    Breadcrumbs.update(hash);
+
+    // Stop the AgentCard *dashboard* poll loop on every navigation. The
+    // sidebar compact AgentCard runs on its own loop (mountCompact) and
+    // is not affected.
     if (typeof AgentCard !== 'undefined' && AgentCard.unmount) {
       AgentCard.unmount();
     }
@@ -56,6 +61,98 @@ const Router = {
   },
 };
 
+// PR2 #35: breadcrumbs in the topbar. Each list-route hash maps to a
+// `[group, page]` pair; the rendered crumb is `Surfbot / <group> /
+// <page>`. Detail routes (#/findings/abc-123) reuse the list crumb so
+// the user always sees the same path while drilling in.
+const Breadcrumbs = {
+  MAP: {
+    '/':           ['Insights',  'Dashboard'],
+    '/findings':   ['Triage',    'Findings'],
+    '/assets':     ['Discover',  'Assets'],
+    '/targets':    ['Discover',  'Targets'],
+    '/changes':    ['Discover',  'Changes'],
+    '/scans':      ['Detect',    'Scans'],
+    '/schedules':  ['Detect',    'Schedules'],
+    '/templates':  ['Detect',    'Templates'],
+    '/timeline':   ['Detect',    'Timeline'],
+    '/tools':      ['Configure', 'Tools'],
+    '/blackouts':  ['Configure', 'Blackouts'],
+    '/settings':   ['Configure', 'Settings'],
+  },
+
+  resolve(hash) {
+    const path = (hash || '#/').replace(/^#/, '').split('?')[0];
+    if (path === '/' || path === '') return this.MAP['/'];
+    // Match the longest prefix so /findings/abc inherits /findings.
+    const keys = Object.keys(this.MAP).filter(k => k !== '/');
+    keys.sort((a, b) => b.length - a.length);
+    for (const k of keys) {
+      if (path === k || path.startsWith(k + '/')) return this.MAP[k];
+    }
+    return null;
+  },
+
+  update(hash) {
+    const root = document.getElementById('breadcrumbs');
+    if (!root) return;
+    const crumbs = ['Surfbot'];
+    const resolved = this.resolve(hash);
+    if (resolved) crumbs.push(resolved[0], resolved[1]);
+    const parts = [];
+    crumbs.forEach((c, i) => {
+      const last = i === crumbs.length - 1;
+      const cls = last ? 'breadcrumb-item breadcrumb-current' : 'breadcrumb-item';
+      parts.push(`<span class="${cls}">${escapeHtml(c)}</span>`);
+      if (!last) parts.push('<span class="breadcrumb-sep" aria-hidden="true">/</span>');
+    });
+    root.innerHTML = parts.join('');
+  },
+};
+
+// PR2 #35: topbar scan indicator. Polls /scans/status every POLL_MS
+// regardless of route so the user sees scan state from any page. Hides
+// when no scan is running. Errors are swallowed — the indicator is a
+// nice-to-have, not a blocker, and the scans page already surfaces
+// fetch errors.
+const ScanIndicator = {
+  POLL_MS: 5000,
+  _timer: null,
+
+  start() {
+    this.refresh();
+    if (this._timer) clearInterval(this._timer);
+    this._timer = setInterval(() => this.refresh(), this.POLL_MS);
+  },
+
+  async refresh() {
+    try {
+      const s = await API.scanStatus();
+      this.update(s);
+    } catch (_) {
+      this.update(null);
+    }
+  },
+
+  update(status) {
+    const el = document.getElementById('scan-indicator');
+    const phaseEl = document.getElementById('scan-indicator-phase');
+    if (!el) return;
+    const scanning = !!(status && status.scanning);
+    if (!scanning) {
+      el.classList.add('hidden');
+      if (phaseEl) phaseEl.textContent = '';
+      return;
+    }
+    el.classList.remove('hidden');
+    if (!phaseEl) return;
+    const scan = status.scan || {};
+    const phase = scan.phase || '';
+    const pct = (scan.progress != null) ? Math.round(scan.progress) + '%' : '';
+    phaseEl.textContent = phase && pct ? phase + ' · ' + pct : (phase || pct);
+  },
+};
+
 function parseQueryParams() {
   const hash = location.hash;
   const qIdx = hash.indexOf('?');
@@ -67,11 +164,11 @@ function parseQueryParams() {
 
 const app = document.getElementById('app');
 
-// Load sidebar badge on init and keep it updated
+// Load sidebar badge on init and keep it updated. The compact agent
+// status mounts independently via AgentCard.mountCompact so the
+// version + uptime stay live across navigation.
 function loadSidebarBadge() {
   API.overview().then(data => {
-    const el = document.getElementById('agent-version');
-    if (el) el.textContent = 'v' + data.agent.version;
     updateSidebarBadge(data.findings_by_severity);
   }).catch(() => {});
 }
@@ -81,6 +178,17 @@ document.addEventListener('DOMContentLoaded', () => {
   Router.navigate();
   loadSidebarBadge();
 
+  // Compact agent status pinned in the sidebar footer. Polls
+  // independently of routes; PR2 (#35) replaces the big dashboard
+  // agent card.
+  const agentSlot = document.getElementById('agent-status-slot');
+  if (agentSlot && typeof AgentCard !== 'undefined' && AgentCard.mountCompact) {
+    AgentCard.mountCompact(agentSlot);
+  }
+
+  // Topbar scan indicator (PR2 #35).
+  ScanIndicator.start();
+
   // SPEC-SCHED1.4b R9: "Run scan now" opens the ad-hoc dispatcher
   // modal. The button is in the sidebar footer; wired once at load so
   // it works across all hash routes without re-binding on navigate.
@@ -88,4 +196,19 @@ document.addEventListener('DOMContentLoaded', () => {
   if (adhocBtn && typeof AdHocPage !== 'undefined') {
     adhocBtn.addEventListener('click', () => AdHocPage.open());
   }
+
+  // PR2 #35 stubs. Cmd+K and "+ New" are placeholders until PR9
+  // (search) and PR3 (dashboard reframe) wire real behavior. Notif and
+  // help icons stay disabled with a "Coming in v0.6" tooltip set in
+  // markup; no handler needed.
+  const cmdkBtn = document.getElementById('topbar-cmdk-btn');
+  if (cmdkBtn) cmdkBtn.addEventListener('click', () => {
+    // Placeholder — PR9 implements global search.
+  });
+  const newBtn = document.getElementById('topbar-new-btn');
+  if (newBtn) newBtn.addEventListener('click', () => {
+    // Placeholder — PR3 wires the "+ New" entry point. Falls back to
+    // the ad-hoc dispatcher so the button isn't dead in the meantime.
+    if (typeof AdHocPage !== 'undefined' && AdHocPage.open) AdHocPage.open();
+  });
 });

--- a/internal/webui/static/js/app.js
+++ b/internal/webui/static/js/app.js
@@ -136,20 +136,23 @@ const ScanIndicator = {
 
   update(status) {
     const el = document.getElementById('scan-indicator');
-    const phaseEl = document.getElementById('scan-indicator-phase');
+    const targetEl = document.getElementById('scan-indicator-target');
+    const toolEl = document.getElementById('scan-indicator-tool');
+    const pctEl = document.getElementById('scan-indicator-pct');
     if (!el) return;
     const scanning = !!(status && status.scanning);
     if (!scanning) {
       el.classList.add('hidden');
-      if (phaseEl) phaseEl.textContent = '';
+      if (targetEl) targetEl.textContent = '';
+      if (toolEl) toolEl.textContent = '';
+      if (pctEl) pctEl.textContent = '';
       return;
     }
     el.classList.remove('hidden');
-    if (!phaseEl) return;
     const scan = status.scan || {};
-    const phase = scan.phase || '';
-    const pct = (scan.progress != null) ? Math.round(scan.progress) + '%' : '';
-    phaseEl.textContent = phase && pct ? phase + ' · ' + pct : (phase || pct);
+    if (targetEl) targetEl.textContent = scan.target || '';
+    if (toolEl) toolEl.textContent = scan.phase || '';
+    if (pctEl) pctEl.textContent = (scan.progress != null) ? Math.round(scan.progress) + '%' : '';
   },
 };
 

--- a/internal/webui/static/js/pages/agent_card.js
+++ b/internal/webui/static/js/pages/agent_card.js
@@ -12,6 +12,7 @@
 const AgentCard = {
   POLL_MS: 8000,
   _timer: null,
+  _compactTimer: null,
   // "Scan now" was removed with SPEC-SCHED1.4a; target-anchored ad-hoc
   // dispatch via /api/v1/scans/ad-hoc lands on target pages in 1.4b.
 
@@ -23,13 +24,61 @@ const AgentCard = {
     this._timer = setInterval(() => this.refresh(el), this.POLL_MS);
   },
 
-  // unmount() stops the poll loop. Called by the dashboard route on
-  // navigation away. Idempotent.
+  // unmount() stops the dashboard poll loop. Called by the router on
+  // navigation away. Idempotent. Does not stop the compact sidebar
+  // loop — that one stays alive across routes.
   unmount() {
     if (this._timer) {
       clearInterval(this._timer);
       this._timer = null;
     }
+  },
+
+  // mountCompact(el) renders the sidebar footer status — just a status
+  // dot + version + uptime. PR2 #35 moved the agent status out of the
+  // dashboard so it's visible from every route. Polls on its own
+  // schedule and is not unmounted by route changes.
+  mountCompact(el) {
+    if (this._compactTimer) clearInterval(this._compactTimer);
+    this.refreshCompact(el);
+    this._compactTimer = setInterval(() => this.refreshCompact(el), this.POLL_MS);
+  },
+
+  async refreshCompact(el) {
+    if (!el) return;
+    try {
+      const data = await API.daemonStatus();
+      el.innerHTML = this.compactTemplate(data);
+    } catch (err) {
+      el.innerHTML = this.compactErrorTemplate();
+    }
+  },
+
+  compactTemplate(d) {
+    let dotCls = 'agent-dot-err';
+    let label = 'stopped';
+    if (d.installed && d.running) {
+      dotCls = 'agent-dot-ok';
+      label = 'running';
+    } else if (!d.installed) {
+      dotCls = 'agent-dot-warn';
+      label = 'not installed';
+    }
+    const version = d.version ? 'v' + d.version : '—';
+    const uptime = (d.installed && d.running)
+      ? this.formatUptime(d.uptime_seconds || 0)
+      : '';
+    const uptimeHtml = uptime
+      ? `<span class="agent-status-uptime" title="Uptime">${escapeHtml(uptime)}</span>`
+      : '';
+    return `<span class="agent-dot ${dotCls}" title="${escapeHtml(label)}" aria-label="Agent ${escapeHtml(label)}"></span>
+      <span class="agent-status-version" id="agent-version">${escapeHtml(version)}</span>
+      ${uptimeHtml}`;
+  },
+
+  compactErrorTemplate() {
+    return `<span class="agent-dot agent-dot-err" title="UI can't read agent state" aria-label="Agent state unknown"></span>
+      <span class="agent-status-version" id="agent-version">—</span>`;
   },
 
   skeleton() {

--- a/internal/webui/static/js/pages/dashboard.js
+++ b/internal/webui/static/js/pages/dashboard.js
@@ -8,10 +8,9 @@ const DashboardPage = {
       app.innerHTML = this.template(data);
       updateSidebarBadge(data.findings_by_severity);
       updateLastRefresh();
-      // SPEC-X3.1 — top-of-dashboard agent card. Mounts and starts its
-      // own poll loop, independent of the dashboard refresh.
-      const slot = document.getElementById('agent-card-slot');
-      if (slot && typeof AgentCard !== 'undefined') AgentCard.mount(slot);
+      // PR2 #35: the SPEC-X3.1 agent card is gone from the dashboard.
+      // It now lives compact in the sidebar footer (mounted by app.js)
+      // so the user sees agent state from every route.
 
       // SPEC-SCHED1.4c R5: restore the "Run scan now" button removed
       // with the /api/daemon/trigger endpoint in 1.4a. Opens the 1.4b
@@ -52,8 +51,6 @@ const DashboardPage = {
           <button type="button" class="btn btn-accent" id="dashboard-run-scan-btn" data-action="run-scan-now">Run scan now</button>
         </div>
       </div>
-
-      <div id="agent-card-slot"></div>
 
       <div class="refresh-bar">
         <span id="last-refresh"></span>


### PR DESCRIPTION
Closes #35

## Summary

PR2 of the UI v2 sprint: replace the flat 12-item sidebar with 5 hierarchical buckets and introduce the topbar shell that PR3+ build on.

### Sidebar — 11 items in 5 groups

- **Insights:** Dashboard
- **Discover:** Targets · Assets · Changes
- **Detect:** Scans · Schedules · Templates
- **Triage:** Findings (with severity badge)
- **Configure:** Tools · Blackouts · Settings

Reports is cloud-only (`surfbot-web`) and stays out. Timeline drops from the sidebar but remains routable directly. The Settings link points at `/settings/defaults` but renders as "Settings".

### Topbar (sticky)

- **Breadcrumbs** — `Surfbot / <group> / <page>`. Detail routes inherit their list parent (`/findings/abc-123` → `Triage / Findings`).
- **Cmd+K** search button — stub with `⌘K` kbd hint; PR9 wires real search.
- **+ New** primary button — falls back to the ad-hoc dispatcher until PR3.
- **Scan indicator** — pill with phase + progress, polls `/scans/status` every 5s, hidden when no scan running.
- **Notif / Help** icons — `title="Coming in v0.6"` tooltips, no handler.

### Agent status

Moved out of the dashboard into a compact sidebar footer (dot + version + uptime). `AgentCard.mountCompact` polls independently of routes so the status stays live everywhere. The legacy `mount`/`unmount` API is preserved for back-compat; full audit is deferred to #45.

### Tests

Following the PR1 pattern (Go string-presence checks on the embedded static assets) — no Playwright runner introduced. `internal/webui/sidebar_topbar_test.go` pins:

- 5 group labels in documented order
- exactly 11 `data-page=` entries
- no `Reports` label or `data-page="reports"`
- topbar markup, scan indicator slots, kbd, two `title="Coming in v0.6"` tooltips
- breadcrumb mapping for every list route, with `Triage / Findings` asserted explicitly
- `position: sticky` on `.topbar`
- `AgentCard.mountCompact` / `refreshCompact` / `compactTemplate`

## Test plan

- [x] `go test ./internal/webui/... -v` (all foundation + new presence tests pass)
- [x] `go test ./...` (no regressions)
- [x] `go build ./...`
- [x] `node -c` syntax check on edited JS files
- [ ] Manual smoke: open `surfbot ui`, navigate findings/assets/scans, verify breadcrumbs update, scan indicator appears during a running scan, agent dot heartbeats in sidebar