### PR TITLE
webui: ui v2 dashboard reframe — KPI quad + activity feed (#36)

### DIFF
--- a/internal/webui/dashboard_route_test.go
+++ b/internal/webui/dashboard_route_test.go
@@ -1,0 +1,72 @@
+package webui
+
+// PR3 #36 dashboard reframe — the rewritten /dashboard SPA pulls every
+// KPI from /api/v1/overview, so dropping a field here would silently
+// blank a card on the new layout. This test pins the JSON envelope
+// shape against what dashboard.js consumes today; treat a failure as a
+// signal to update the page in the same commit, not as license to
+// loosen the assertion.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverviewBackwardsCompatForDashboard(t *testing.T) {
+	h, s := newTestHandler(t)
+	seedTestData(t, s)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/overview", nil)
+	w := httptest.NewRecorder()
+	h.handleOverview(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+
+	// Top-level keys consumed by dashboard.js. score_history is
+	// optional and only present when a future PR wires it up.
+	required := []string{
+		"security_score",
+		"findings_by_severity",
+		"total_assets",
+		"assets_by_type",
+		"last_scan",
+		"changes_since_last",
+	}
+	for _, k := range required {
+		_, ok := raw[k]
+		assert.True(t, ok, "dashboard requires %q in /overview response", k)
+	}
+
+	last, ok := raw["last_scan"].(map[string]any)
+	require.True(t, ok, "last_scan must be an object after seed")
+	for _, k := range []string{"id", "target", "status", "duration_seconds", "finished_at", "target_state", "delta", "work"} {
+		_, has := last[k]
+		assert.True(t, has, "dashboard reads last_scan.%s", k)
+	}
+}
+
+// score_history is the optional sparkline source. Today the handler
+// doesn't emit it; the test pins that contract so adding it later is a
+// deliberate, additive change rather than a stealth schema bump.
+func TestOverviewOmitsScoreHistoryUntilWired(t *testing.T) {
+	h, s := newTestHandler(t)
+	seedTestData(t, s)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/overview", nil)
+	w := httptest.NewRecorder()
+	h.handleOverview(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+
+	_, has := raw["score_history"]
+	assert.False(t, has, "score_history should stay absent until P1.1 wires the backend")
+}

--- a/internal/webui/foundation_assets_test.go
+++ b/internal/webui/foundation_assets_test.go
@@ -75,14 +75,90 @@ func TestFoundationComponentHelpers(t *testing.T) {
 	}
 
 	// The icon registry must list at least the seed glyphs so PR2 can
-	// rely on them without re-discovering whether they exist.
+	// rely on them without re-discovering whether they exist. PR3 #36
+	// added `refresh` for the dashboard header — listed here so the
+	// next maintainer doesn't strip it during a refactor.
 	icons := []string{
 		"x:", "search:", "plus:",
 		"'chevron-down':", "'chevron-right':",
 		"check:", "clock:", "alert:", "copy:",
+		"refresh:",
 	}
 	for _, ic := range icons {
 		assert.True(t, strings.Contains(js, ic),
 			"foundation icon %q missing from components.js ICONS registry", ic)
+	}
+}
+
+// PR3 #36 dashboard reframe. The new dashboard.js drops the agent-info
+// block and the .card-grid / .score-container / .detail-grid scaffolding
+// in favor of KPI buttons and the .dash-* + .kpi-* foundation. These
+// guards catch a partial migration where someone accidentally
+// re-introduces a legacy class while iterating on the page.
+
+func TestDashboardLegacyArtifactsRemoved(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/pages/dashboard.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	legacy := []string{
+		// IDs / function names removed by PR3.
+		"dashboard-run-scan-btn",
+		"renderLastScanCard",
+		"renderChangesCard",
+		"formatAssetTypes",
+		// Legacy CSS classes — these still exist in style.css for
+		// unmigrated pages, but the dashboard must not reference them.
+		"card-grid",
+		"score-container",
+		"detail-grid",
+	}
+	for _, s := range legacy {
+		assert.False(t, strings.Contains(js, s),
+			"legacy artifact %q must not appear in dashboard.js after PR3 #36", s)
+	}
+}
+
+func TestDashboardUsesFoundationHelpers(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/pages/dashboard.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	required := []string{
+		"Components.statusPill(",
+		"Components.icon(",
+		"Components.timeAgo(",
+		"Components.formatDuration(",
+		// New foundation classes the dashboard depends on.
+		"dash-grid",
+		"kpi-card",
+		"activity-list",
+	}
+	for _, s := range required {
+		assert.True(t, strings.Contains(js, s),
+			"dashboard.js must use foundation helper/class %q", s)
+	}
+}
+
+// TestDashboardCSSScaffolding gates the CSS classes the rewritten
+// dashboard page hard-codes. Lives next to the JS guard so a single
+// failed test makes the missing piece obvious.
+func TestDashboardCSSScaffolding(t *testing.T) {
+	data, err := staticFS.ReadFile("static/css/style.css")
+	require.NoError(t, err)
+	css := string(data)
+
+	classes := []string{
+		".dash-grid", ".dash-col-3", ".dash-col-4", ".dash-col-8",
+		".kpi-card", ".kpi-label", ".kpi-number", ".kpi-stacked-bar",
+		".kpi-counts", ".kpi-mini-pill", ".kpi-trend",
+		".sparkline", ".sparkline-bar",
+		".dash-panel", ".dash-panel-header", ".dash-panel-body",
+		".dash-tab", ".activity-item", ".activity-icon",
+		".dash-list-item", ".dash-status-dot",
+	}
+	for _, c := range classes {
+		assert.True(t, strings.Contains(css, c),
+			"dashboard CSS class %q missing from style.css", c)
 	}
 }

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -2003,3 +2003,286 @@ tr.row-selected { background: rgba(0,229,153,0.06); }
 .bulk-bar-count strong { color: var(--brand); margin-right: 4px; }
 .bulk-bar-actions { display: flex; gap: 6px; align-items: center; }
 
+/* === Dashboard reframe (UI v2 PR3 #36) ============================
+ * KPI quad + activity feed + side panels. The legacy .card/.card-grid
+ * vocabulary stays in style.css for unmigrated pages; the dashboard
+ * uses .dash-* and .kpi-* classes exclusively.
+ * ================================================================= */
+
+.dash-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 16px;
+  margin-bottom: 16px;
+}
+.dash-col-3 { grid-column: span 3; }
+.dash-col-4 { grid-column: span 4; }
+.dash-col-8 { grid-column: span 8; }
+
+@media (max-width: 1200px) {
+  .dash-col-3 { grid-column: span 6; }
+}
+@media (max-width: 768px) {
+  .dash-col-3, .dash-col-4, .dash-col-8 { grid-column: span 12; }
+}
+
+.kpi-card {
+  background: var(--ink-800);
+  border: 1px solid var(--ink-600);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 168px;
+}
+button.kpi-card {
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  width: 100%;
+  transition: background 0.12s, border-color 0.12s;
+}
+button.kpi-card:hover { background: var(--ink-700); }
+button.kpi-card:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.kpi-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.kpi-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.kpi-number {
+  font-size: 32px;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  line-height: 1;
+}
+.kpi-suffix {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-left: 4px;
+}
+.kpi-foot {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.kpi-trend {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px 6px;
+  border-radius: 9999px;
+  font-size: 11px;
+  font-weight: 500;
+}
+.kpi-trend-up { color: var(--sev-low); background: rgba(0,229,153,0.15); }
+.kpi-trend-down { color: var(--sev-critical); background: var(--sev-critical-bg); }
+.kpi-trend-flat { color: var(--text-muted); background: var(--ink-700); }
+
+.sparkline {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 32px;
+  width: 100%;
+}
+.sparkline-bar {
+  flex: 1;
+  min-height: 2px;
+  background: rgba(0,229,153,0.3);
+  border-radius: 1px;
+}
+
+.kpi-stacked-bar {
+  display: flex;
+  height: 8px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--ink-700);
+}
+.kpi-stacked-seg { height: 100%; }
+.kpi-counts {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 4px;
+  font-size: 11px;
+}
+.kpi-counts span strong { font-weight: 600; }
+
+.kpi-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.kpi-mini-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  background: var(--ink-700);
+  border: 1px solid var(--ink-600);
+  font-size: 11px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.dash-panel {
+  background: var(--ink-800);
+  border: 1px solid var(--ink-600);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+}
+.dash-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--ink-700);
+}
+.dash-panel-header h3 {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+.dash-panel-sub {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.dash-panel-body { padding: 8px 0; }
+
+.dash-tabs { display: inline-flex; gap: 4px; }
+.dash-tab {
+  background: transparent;
+  border: 0;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.dash-tab.active { color: var(--brand); background: rgba(0,229,153,0.1); }
+.dash-tab:hover:not(.active) { color: var(--text-primary); }
+
+.activity-list { list-style: none; margin: 0; padding: 0; }
+.activity-item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 12px 16px;
+  border-top: 1px solid var(--ink-700);
+  cursor: pointer;
+}
+.activity-item:first-child { border-top: 0; }
+.activity-item:hover { background: var(--ink-900); }
+.activity-icon {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+}
+.activity-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.activity-title {
+  font-size: 13px;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+.activity-detail {
+  font-size: 12px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.activity-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.activity-when { font-size: 11px; color: var(--text-muted); }
+.activity-cta {
+  font-size: 11px;
+  color: var(--brand);
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: none;
+}
+.activity-cta:hover { color: var(--brand-strong); }
+
+.dash-list { list-style: none; margin: 0; padding: 0; }
+.dash-list-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-top: 1px solid var(--ink-700);
+  cursor: pointer;
+}
+.dash-list-item:first-child { border-top: 0; }
+.dash-list-item:hover { background: var(--ink-900); }
+.dash-list-name {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dash-list-meta { font-size: 11px; color: var(--text-muted); }
+
+.dash-skeleton {
+  background: var(--ink-700);
+  height: 12px;
+  border-radius: 4px;
+  animation: dash-pulse 1.4s ease-in-out infinite;
+}
+@keyframes dash-pulse {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 0.3; }
+}
+
+.dash-empty {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.dash-empty p { margin-top: 4px; }
+.dash-empty .btn { margin-top: 12px; }
+
+.dash-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.dash-status-dot-active { background: var(--brand); }
+.dash-status-dot-paused { background: var(--status-ack); }
+

--- a/internal/webui/static/js/components.js
+++ b/internal/webui/static/js/components.js
@@ -753,6 +753,7 @@ const ICONS = Object.freeze({
   clock:          '<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>',
   alert:          '<path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>',
   copy:           '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>',
+  refresh:        '<polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"/>',
 });
 
 function pad2(n) { return String(n).padStart(2, '0'); }

--- a/internal/webui/static/js/pages/dashboard.js
+++ b/internal/webui/static/js/pages/dashboard.js
@@ -1,6 +1,6 @@
 // Dashboard page — UI v2 (PR3 #36). KPI quad of clickable security-
 // posture cards above an activity feed composed client-side from
-// /scans + /findings + last_scan.delta, plus Top Targets and Próximos
+// /scans + /findings + last_scan.delta, plus Top Targets and Upcoming
 // scans panels. Agent diagnostics live in the sidebar footer (PR2 #35).
 
 const SEV_ORDER = ['critical', 'high', 'medium', 'low', 'info'];
@@ -68,7 +68,7 @@ const DashboardPage = {
   },
 
   _header() {
-    return `<div class="page-header" style="display:flex;align-items:flex-end;gap:16px"><div style="flex:1"><h2>Dashboard</h2><p>Postura de seguridad — <span id="dash-subtitle"></span></p></div>
+    return `<div class="page-header" style="display:flex;align-items:flex-end;gap:16px"><div style="flex:1"><h2>Dashboard</h2><p>Security posture — <span id="dash-subtitle"></span></p></div>
       <div style="display:flex;gap:8px"><button type="button" class="btn btn-ghost" id="dash-refresh-btn" aria-label="Refresh dashboard">${Components.icon('refresh', 14)} Refresh</button>
       <button type="button" class="btn btn-accent" id="dash-runscan-btn">Run scan</button></div></div>`;
   },
@@ -80,7 +80,7 @@ const DashboardPage = {
     if (hist && hist.length > 0) {
       const max = Math.max(1, ...hist.map(h => h.score || 0));
       const bars = hist.slice(-16).map(h => `<span class="sparkline-bar" style="height:${Math.max(8, Math.round(((h.score || 0) / max) * 100))}%"></span>`).join('');
-      extras = `<div class="sparkline" aria-hidden="true">${bars}</div><div class="kpi-foot">últimos ${hist.length} días</div>`;
+      extras = `<div class="sparkline" aria-hidden="true">${bars}</div><div class="kpi-foot">last ${hist.length} days</div>`;
     }
     if (hist && hist.length >= 2) {
       const delta = (hist[hist.length - 1].score || 0) - (hist[hist.length - 2].score || 0);
@@ -166,7 +166,7 @@ const DashboardPage = {
     }).join('');
     return `<div class="dash-panel">
       <div class="dash-panel-header">
-        <div><h3>Activity</h3><div class="dash-panel-sub">eventos de los últimos 7 días</div></div>
+        <div><h3>Activity</h3><div class="dash-panel-sub">events from the last 7 days</div></div>
         <div class="dash-tabs" role="tablist">${tabsHtml}</div>
       </div>
       <div class="dash-panel-body" id="dash-activity-body">${this._activityList(d)}</div>
@@ -280,7 +280,7 @@ const DashboardPage = {
             </div>${action}</li>`;
         }).join('')}</ul>`;
     return `<div class="dash-panel">
-      <div class="dash-panel-header"><h3>Próximos scans</h3><a href="#/schedules" class="dash-panel-sub" style="color:var(--brand)">Schedules →</a></div>
+      <div class="dash-panel-header"><h3>Upcoming scans</h3><a href="#/schedules" class="dash-panel-sub" style="color:var(--brand)">Schedules →</a></div>
       <div class="dash-panel-body">${body}</div></div>`;
   },
 
@@ -320,7 +320,7 @@ const DashboardPage = {
     const update = () => {
       const el = document.getElementById('dash-subtitle');
       if (!el) { clearInterval(this._subtitleTimer); this._subtitleTimer = null; return; }
-      el.textContent = 'actualizado ' + Components.timeAgo(this._state.fetchedAt.toISOString());
+      el.textContent = 'updated ' + Components.timeAgo(this._state.fetchedAt.toISOString());
     };
     update();
     if (this._subtitleTimer) clearInterval(this._subtitleTimer);

--- a/internal/webui/static/js/pages/dashboard.js
+++ b/internal/webui/static/js/pages/dashboard.js
@@ -1,219 +1,349 @@
-// Dashboard page
+// Dashboard page — UI v2 (PR3 #36). KPI quad of clickable security-
+// posture cards above an activity feed composed client-side from
+// /scans + /findings + last_scan.delta, plus Top Targets and Próximos
+// scans panels. Agent diagnostics live in the sidebar footer (PR2 #35).
+
+const SEV_ORDER = ['critical', 'high', 'medium', 'low', 'info'];
+const SEV_LABEL = { critical: 'Crit', high: 'High', medium: 'Med', low: 'Low', info: 'Info' };
+const SCAN_STATUS_TO_PILL = { completed: 'resolved', running: 'ack', failed: 'open', cancelled: 'fp' };
+const TONE_STYLE = {
+  brand:    'background:rgba(0,229,153,0.15);color:var(--brand)',
+  resolved: 'background:var(--status-resolved-bg);color:var(--status-resolved)',
+  critical: 'background:var(--sev-critical-bg);color:var(--sev-critical)',
+  high:     'background:var(--sev-high-bg);color:var(--sev-high)',
+  medium:   'background:var(--sev-medium-bg);color:var(--sev-medium)',
+  low:      'background:var(--sev-low-bg);color:var(--sev-low)',
+  info:     'background:var(--sev-info-bg);color:var(--sev-info)',
+  fp:       'background:var(--status-fp-bg);color:var(--status-fp)' };
+
 const DashboardPage = {
+  _state: null,
+  _filterTab: 'all',
+  _subtitleTimer: null,
+
   async render(app) {
-    app.innerHTML = '<div class="loading">Loading dashboard...</div>';
-
+    if (this._subtitleTimer) { clearInterval(this._subtitleTimer); this._subtitleTimer = null; }
+    app.innerHTML = this._skeleton();
     try {
-      const data = await API.overview();
-      app.innerHTML = this.template(data);
-      updateSidebarBadge(data.findings_by_severity);
-      updateLastRefresh();
-      // PR2 #35: the SPEC-X3.1 agent card is gone from the dashboard.
-      // It now lives compact in the sidebar footer (mounted by app.js)
-      // so the user sees agent state from every route.
-
-      // SPEC-SCHED1.4c R5: restore the "Run scan now" button removed
-      // with the /api/daemon/trigger endpoint in 1.4a. Opens the 1.4b
-      // ad-hoc modal with no prefill — same behavior as the sidebar
-      // button, but in the more visible dashboard header location.
-      const runBtn = document.getElementById('dashboard-run-scan-btn');
-      if (runBtn) runBtn.addEventListener('click', () => {
-        if (typeof AdHocPage !== 'undefined' && AdHocPage.open) AdHocPage.open();
-      });
+      this._state = await this._fetchAll();
+      app.innerHTML = this.template(this._state);
+      updateSidebarBadge(this._state.overview.findings_by_severity);
+      this._bind(app);
+      this._startSubtitleTimer();
     } catch (err) {
       app.innerHTML = Components.emptyState('Error', 'Failed to load dashboard: ' + err.message);
     }
   },
 
-  template(d) {
-    const scoreClass = Components.scoreClass(d.security_score);
-
-    const breakdownHtml = d.score_breakdown && d.score_breakdown.length > 0
-      ? `<div class="score-breakdown">${d.score_breakdown.map(b =>
-          `<span style="color:${Components.sevColor(b.severity)}">-${b.penalty} (${b.count} ${b.severity})</span>`
-        ).join('')}</div>`
-      : '<div class="score-breakdown">No findings</div>';
-
-    const lastScanHtml = d.last_scan
-      ? renderLastScanCard(d.last_scan)
-      : '<p class="text-muted">No scans yet. Run <code>surfbot scan &lt;target&gt;</code> to get started.</p>';
-
-    // changes_since_last reads ScanDelta from the persisted scan row (no
-    // longer recomputed from asset_changes). new_findings is now correct
-    // — the previous getChangeSummary always returned 0 here.
-    const changesHtml = renderChangesCard(d.changes_since_last);
-
-    return `
-      <div class="page-header">
-        <h2>Dashboard</h2>
-        <p>Security posture overview</p>
-        <div style="margin-left:auto">
-          <button type="button" class="btn btn-accent" id="dashboard-run-scan-btn" data-action="run-scan-now">Run scan now</button>
-        </div>
-      </div>
-
-      <div class="refresh-bar">
-        <span id="last-refresh"></span>
-        <button class="refresh-btn" onclick="Router.navigate()">Refresh</button>
-      </div>
-
-      <div class="card-grid">
-        <div class="card">
-          <div class="score-container">
-            <div class="score-value ${scoreClass}">${d.security_score}</div>
-            <div class="score-label">Security Score</div>
-            ${breakdownHtml}
-          </div>
-        </div>
-        <div class="card">
-          <div class="card-label">Findings by Severity</div>
-          ${Components.severityBars(d.findings_by_severity)}
-        </div>
-        <div class="card">
-          <div class="card-label">Unique Findings</div>
-          <div class="card-value">${d.unique_findings != null ? d.unique_findings : d.total_findings}</div>
-          ${d.unique_findings != null && d.unique_findings !== d.total_findings
-            ? `<div class="card-sub">${d.total_findings} total across all ports</div>`
-            : ''}
-        </div>
-        <div class="card">
-          <div class="card-label">Total Assets</div>
-          <div class="card-value">${d.total_assets}</div>
-          <div class="card-sub">${formatAssetTypes(d.assets_by_type)}</div>
-        </div>
-      </div>
-
-      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
-        <div class="card">
-          <div class="card-label">Last Scan</div>
-          ${lastScanHtml}
-        </div>
-        <div class="card">
-          <div class="card-label">Changes Since Last Scan</div>
-          ${changesHtml || '<p class="text-muted">No changes detected</p>'}
-        </div>
-      </div>
-
-      <div class="card" style="margin-top:16px">
-        <div class="card-label">Agent Info</div>
-        <div class="detail-grid" style="margin-top:8px">
-          <span class="detail-label">Version</span>
-          <span class="detail-value mono">${d.agent.version}</span>
-          <span class="detail-label">Database</span>
-          <span class="detail-value mono">${escapeHtml(d.agent.db_path)}</span>
-          <span class="detail-label">DB Size</span>
-          <span class="detail-value">${Components.formatBytes(d.agent.db_size_bytes)}</span>
-          <span class="detail-label">Targets</span>
-          <span class="detail-value">${d.agent.targets_count}</span>
-        </div>
-      </div>
-    `;
+  // /upcoming silently skips paused schedules and returns IDs only;
+  // /schedules recovers names + the paused list. Non-overview reads
+  // degrade to empty so an older daemon doesn't blank the dashboard.
+  async _fetchAll() {
+    const [overview, scans, findings, targets, upcoming, schedules] = await Promise.all([
+      API.overview(),
+      API.scans({ limit: 20 }).catch(() => ({ scans: [] })),
+      API.findings({ status: 'open', limit: 20 }).catch(() => ({ findings: [] })),
+      API.targets().catch(() => ({ targets: [] })),
+      API.upcomingSchedules({ limit: 5 }).catch(() => ({ items: [] })),
+      API.listSchedules({ limit: 250 }).catch(() => ({ items: [] })),
+    ]);
+    return {
+      overview, scans: scans.scans || [], findings: findings.findings || [],
+      targets: targets.targets || [], upcoming: upcoming.items || [],
+      schedules: schedules.items || [], fetchedAt: new Date(),
+    };
   },
+
+  _skeleton() {
+    const cell = `<div class="dash-col-3 kpi-card"><div class="dash-skeleton" style="width:60%"></div><div class="dash-skeleton" style="width:40%;height:32px;margin-top:12px"></div></div>`;
+    return `<div class="dash-grid">${cell.repeat(4)}</div>`;
+  },
+
+  template(d) {
+    return `${this._header()}<div class="dash-grid">${this._kpiRiskScore(d.overview)}${this._kpiOpenFindings(d.overview)}${this._kpiAssets(d.overview)}${this._kpiLastScan(d.overview)}</div>
+      <div class="dash-grid">
+        <div class="dash-col-8">${this._activityPanel(d)}</div>
+        <div class="dash-col-4" style="display:flex;flex-direction:column;gap:16px">${this._topTargetsPanel(d)}${this._upcomingPanel(d)}</div>
+      </div>`;
+  },
+
+  _header() {
+    return `<div class="page-header" style="display:flex;align-items:flex-end;gap:16px"><div style="flex:1"><h2>Dashboard</h2><p>Postura de seguridad — <span id="dash-subtitle"></span></p></div>
+      <div style="display:flex;gap:8px"><button type="button" class="btn btn-ghost" id="dash-refresh-btn" aria-label="Refresh dashboard">${Components.icon('refresh', 14)} Refresh</button>
+      <button type="button" class="btn btn-accent" id="dash-runscan-btn">Run scan</button></div></div>`;
+  },
+
+  _kpiRiskScore(ov) {
+    const score = ov.security_score, cls = Components.scoreClass(score);
+    const hist = Array.isArray(ov.score_history) ? ov.score_history : null;
+    let extras = '', trend = '';
+    if (hist && hist.length > 0) {
+      const max = Math.max(1, ...hist.map(h => h.score || 0));
+      const bars = hist.slice(-16).map(h => `<span class="sparkline-bar" style="height:${Math.max(8, Math.round(((h.score || 0) / max) * 100))}%"></span>`).join('');
+      extras = `<div class="sparkline" aria-hidden="true">${bars}</div><div class="kpi-foot">últimos ${hist.length} días</div>`;
+    }
+    if (hist && hist.length >= 2) {
+      const delta = (hist[hist.length - 1].score || 0) - (hist[hist.length - 2].score || 0);
+      const tcls = delta > 0 ? 'kpi-trend-up' : delta < 0 ? 'kpi-trend-down' : 'kpi-trend-flat';
+      trend = `<span class="kpi-trend ${tcls}">${delta > 0 ? '+' : ''}${delta}</span>`;
+    }
+    return this._kpiButton('kpi-risk',
+      `Risk score ${score} of 100. Click to view findings sorted by CVSS.`,
+      "location.hash='#/findings?sort=cvss-desc'",
+      `<div class="kpi-header"><span class="kpi-label">Risk Score</span>${trend}</div>
+       <div><span class="kpi-number ${cls}">${score}</span><span class="kpi-suffix">/100</span></div>${extras}`);
+  },
+
+  _kpiOpenFindings(ov) {
+    const sev = ov.findings_by_severity || {};
+    const total = SEV_ORDER.reduce((s, k) => s + (sev[k] || 0), 0);
+    const stacked = total > 0 ? SEV_ORDER.map(k => {
+      const v = sev[k] || 0;
+      return v === 0 ? '' : `<span class="kpi-stacked-seg" style="width:${(v/total)*100}%;background:var(--sev-${k})"></span>`;
+    }).join('') : '';
+    const counts = total > 0
+      ? `<div class="kpi-counts">${SEV_ORDER.map(k => `<span style="color:var(--sev-${k})"><strong>${sev[k] || 0}</strong> ${SEV_LABEL[k]}</span>`).join('')}</div>`
+      : `<div class="kpi-foot" style="text-align:center">no open findings</div>`;
+    return this._kpiButton('kpi-findings',
+      `${total} open findings. Click to view findings list.`,
+      "location.hash='#/findings?status=open'",
+      `<div class="kpi-header"><span class="kpi-label">Open Findings</span></div>
+       <div><span class="kpi-number">${total}</span><span class="kpi-suffix">unique</span></div>
+       <div class="kpi-stacked-bar" aria-hidden="true">${stacked}</div>${counts}`);
+  },
+
+  _kpiAssets(ov) {
+    const total = ov.total_assets || 0;
+    const sorted = Object.entries(ov.assets_by_type || {}).sort((a, b) => b[1] - a[1]);
+    const top4 = sorted.slice(0, 4), rest = sorted.length - top4.length;
+    const pills = top4.map(([k, v]) => `<span class="kpi-mini-pill">${this._fmtNum(v)} ${escapeHtml(k)}</span>`).join('')
+      + (rest > 0 ? `<span class="kpi-mini-pill">+${rest}</span>` : '');
+    const dis = (ov.changes_since_last && ov.changes_since_last.disappeared_assets) || 0;
+    const disPill = dis > 0 ? `<span class="pill sev-pill-critical"><span class="pill-dot"></span>−${dis} disappeared</span>` : '';
+    return this._kpiButton('kpi-assets',
+      `${total} discovered assets. Click to view asset inventory.`,
+      "location.hash='#/assets'",
+      `<div class="kpi-header"><span class="kpi-label">Discovered Assets</span></div>
+       <div style="display:flex;align-items:baseline;gap:8px;flex-wrap:wrap"><span class="kpi-number">${this._fmtNum(total)}</span>${disPill}</div>
+       <div class="kpi-pills">${pills}</div>`);
+  },
+
+  _kpiLastScan(ov) {
+    const s = ov.last_scan;
+    if (!s) {
+      return `<div class="dash-col-3 kpi-card">
+        <div class="kpi-header"><span class="kpi-label">Last Scan</span></div>
+        <div class="dash-empty"><strong style="color:var(--text-secondary)">No scans yet</strong><p>Run <code>surfbot scan &lt;target&gt;</code> to get started.</p></div>
+      </div>`;
+    }
+    // changes_since_last carries the flat new_findings count; last_scan.delta
+    // is the per-severity map (see internal/model/scan.go ScanDelta).
+    const newF = (ov.changes_since_last && ov.changes_since_last.new_findings) || 0;
+    const subs = (s.target_state && s.target_state.assets_by_type && s.target_state.assets_by_type.subdomain) || 0;
+    const tools = (s.work && s.work.tools_run) || 0;
+    const pill = Components.statusPill(SCAN_STATUS_TO_PILL[s.status] || 'fp');
+    return this._kpiButton('kpi-last-scan',
+      `Last scan of ${s.target} ${s.status}. Click to view detail.`,
+      `location.hash='#/scans/${encodeURIComponent(s.id)}'`,
+      `<div class="kpi-header"><span class="kpi-label">Last Scan</span>${pill}</div>
+       <div class="mono" style="font-size:13px;color:var(--text-primary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${escapeHtml(s.target)}</div>
+       <div class="kpi-foot">${escapeHtml(this._scanTypeLabel(s))} · ${Components.formatDuration(s.duration_seconds)} · ${Components.timeAgo(s.finished_at)}</div>
+       <div class="kpi-foot">${newF} new finding${newF === 1 ? '' : 's'} · ${subs} subdomains · ${tools} tools</div>
+       <div style="font-size:11px;color:var(--brand)">View detail →</div>`);
+  },
+
+  _scanTypeLabel(s) {
+    return s.type ? s.type.charAt(0).toUpperCase() + s.type.slice(1) + ' scan' : 'Scan';
+  },
+
+  _kpiButton(id, label, onClick, body) { return `<button type="button" class="dash-col-3 kpi-card" id="${id}" aria-label="${escapeHtml(label)}" onclick="${onClick}">${body}</button>`; },
+
+  _activityPanel(d) {
+    const tabsHtml = ['all', 'findings', 'scans', 'changes'].map(t => {
+      const cls = t === this._filterTab ? 'dash-tab active' : 'dash-tab';
+      const label = t === 'all' ? 'All' : t.charAt(0).toUpperCase() + t.slice(1);
+      return `<button type="button" class="${cls}" data-activity-tab="${t}">${label}</button>`;
+    }).join('');
+    return `<div class="dash-panel">
+      <div class="dash-panel-header">
+        <div><h3>Activity</h3><div class="dash-panel-sub">eventos de los últimos 7 días</div></div>
+        <div class="dash-tabs" role="tablist">${tabsHtml}</div>
+      </div>
+      <div class="dash-panel-body" id="dash-activity-body">${this._activityList(d)}</div>
+    </div>`;
+  },
+
+  _activityList(d) {
+    const events = this._composeEvents(d);
+    const filtered = this._filterTab === 'all' ? events : events.filter(e => e.tab === this._filterTab);
+    if (filtered.length === 0) return `<div class="dash-empty">No activity in the last 7 days.</div>`;
+    return `<ul class="activity-list">${filtered.map(ev => this._activityRow(ev)).join('')}</ul>`;
+  },
+
+  _composeEvents(d) {
+    const cutoff = Date.now() - 7 * 24 * 3600 * 1000;
+    const out = [];
+    const scanHref = id => `#/scans/${encodeURIComponent(id)}`;
+    (d.scans || []).forEach(s => {
+      if (s.status === 'running' && s.started_at) {
+        const at = new Date(s.started_at).getTime();
+        if (at >= cutoff) out.push({ tab: 'scans', at, icon: 'clock', tone: 'brand',
+          title: 'Scan started', detail: `${s.target} · ${this._scanTypeLabel(s)}`,
+          cta: 'View live →', href: scanHref(s.id) });
+        return;
+      }
+      if (!s.finished_at) return;
+      const at = new Date(s.finished_at).getTime();
+      if (at < cutoff) return;
+      if (s.status === 'completed') {
+        const newF = sumSeverityMap(s.delta && s.delta.new_findings);
+        out.push({ tab: 'scans', at, icon: 'check', tone: 'resolved', title: 'Scan completed',
+          detail: `${s.target} · ${Components.formatDuration(s.duration_seconds)} · ${newF} new finding${newF === 1 ? '' : 's'}`,
+          cta: 'Open report →', href: scanHref(s.id) });
+      } else if (s.status === 'failed') {
+        out.push({ tab: 'scans', at, icon: 'alert', tone: 'critical', title: 'Scan failed',
+          detail: `${s.target}${s.error ? ' · ' + s.error : ''}`,
+          cta: 'View error →', href: scanHref(s.id) });
+      } else if (s.status === 'cancelled') {
+        out.push({ tab: 'scans', at, icon: 'x', tone: 'fp', title: 'Scan cancelled',
+          detail: s.target, cta: 'View →', href: scanHref(s.id) });
+      }
+    });
+    // Skip low/info findings so a chatty scanner doesn't bury scan/change events.
+    (d.findings || []).forEach(f => {
+      const at = new Date(f.first_seen).getTime();
+      if (!at || at < cutoff) return;
+      if (f.severity !== 'critical' && f.severity !== 'high' && f.severity !== 'medium') return;
+      const cta = (f.severity === 'critical' || f.severity === 'high') ? 'Triage →' : 'View →';
+      out.push({ tab: 'findings', at, icon: 'alert', tone: f.severity,
+        title: `New ${f.severity} finding`,
+        detail: `${f.title || f.template_name || 'Untitled'}${f.asset_value ? ' · ' + f.asset_value : ''}`,
+        cta, href: `#/findings/${encodeURIComponent(f.id)}` });
+    });
+    const last = d.overview.last_scan, ch = d.overview.changes_since_last;
+    if (last && last.finished_at && ch) {
+      const at = new Date(last.finished_at).getTime();
+      if (at >= cutoff) {
+        const dis = ch.disappeared_assets || 0, add = ch.new_assets || 0;
+        if (dis > 0) out.push({ tab: 'changes', at, icon: 'alert', tone: 'critical',
+          title: `${dis} asset${dis === 1 ? '' : 's'} disappeared`,
+          detail: `${last.target} · review for offboarding`, cta: 'View diff →', href: '#/assets' });
+        if (add > 0) out.push({ tab: 'changes', at: at - 1, icon: 'plus', tone: 'medium',
+          title: `${add} new asset${add === 1 ? '' : 's'}`,
+          detail: `${last.target} · auto-added to scope`, cta: 'View →', href: '#/assets' });
+      }
+    }
+    out.sort((a, b) => b.at - a.at);
+    return out.slice(0, 20);
+  },
+
+  _activityRow(ev) {
+    const tone = TONE_STYLE[ev.tone] || TONE_STYLE.info;
+    return `<li class="activity-item" data-href="${escapeHtml(ev.href)}">
+      <span class="activity-icon" style="${tone}">${Components.icon(ev.icon, 14)}</span>
+      <div class="activity-body"><span class="activity-title">${escapeHtml(ev.title)}</span><span class="activity-detail">${escapeHtml(ev.detail)}</span></div>
+      <div class="activity-meta"><span class="activity-when">${Components.timeAgo(new Date(ev.at).toISOString())}</span><a class="activity-cta" href="${escapeHtml(ev.href)}">${escapeHtml(ev.cta)}</a></div>
+    </li>`;
+  },
+
+  _topTargetsPanel(d) {
+    const targets = (d.targets || []).slice().sort((a, b) => (b.finding_count || 0) - (a.finding_count || 0)).slice(0, 4);
+    const body = targets.length === 0
+      ? `<div class="dash-empty">No targets yet.<a class="btn btn-accent btn-sm" href="#/targets">Add target</a></div>`
+      : `<ul class="dash-list">${targets.map(t => `<li class="dash-list-item" onclick="location.hash='#/targets/${encodeURIComponent(t.id)}'"><span class="dash-list-name">${escapeHtml(t.value)}</span><span class="dash-list-meta">${this._fmtNum(t.asset_count || 0)} assets</span><span class="kpi-mini-pill">${t.finding_count || 0} findings</span></li>`).join('')}</ul>`;
+    return `<div class="dash-panel"><div class="dash-panel-header"><h3>Targets</h3><a href="#/targets" class="dash-panel-sub" style="color:var(--brand)">Manage →</a></div><div class="dash-panel-body">${body}</div></div>`;
+  },
+
+  _upcomingPanel(d) {
+    const byID = {}, tgtByID = {};
+    (d.schedules || []).forEach(s => { byID[s.id] = s; });
+    (d.targets || []).forEach(t => { tgtByID[t.id] = t; });
+    const tgtName = id => (tgtByID[id] && tgtByID[id].value) || id;
+    const items = (d.upcoming || []).slice(0, 3).map(u => ({
+      id: u.schedule_id, targetValue: tgtName(u.target_id),
+      scheduleName: (byID[u.schedule_id] && byID[u.schedule_id].name) || 'Schedule',
+      firesAt: u.fires_at, paused: false,
+    })).concat((d.schedules || []).filter(s => !s.enabled).slice(0, 2).map(s => ({
+      id: s.id, targetValue: tgtName(s.target_id),
+      scheduleName: s.name, firesAt: null, paused: true,
+    }))).slice(0, 3);
+    const body = items.length === 0
+      ? `<div class="dash-empty">No scheduled scans.<a class="btn btn-accent btn-sm" href="#/schedules">Add schedule</a></div>`
+      : `<ul class="dash-list">${items.map(it => {
+          const dotCls = it.paused ? 'dash-status-dot-paused' : 'dash-status-dot-active';
+          const when = it.paused ? 'Paused' : Components.nextRun(it.firesAt);
+          const action = it.paused ? `<button type="button" class="btn btn-ghost btn-sm" data-resume-id="${escapeHtml(it.id)}">Resume</button>` : '';
+          return `<li class="dash-list-item"><span class="dash-status-dot ${dotCls}"></span>
+            <div style="flex:1;min-width:0">
+              <div class="mono" style="font-size:12px">${escapeHtml(it.targetValue)} · ${escapeHtml(it.scheduleName)}</div>
+              <div class="dash-list-meta">${when}</div>
+            </div>${action}</li>`;
+        }).join('')}</ul>`;
+    return `<div class="dash-panel">
+      <div class="dash-panel-header"><h3>Próximos scans</h3><a href="#/schedules" class="dash-panel-sub" style="color:var(--brand)">Schedules →</a></div>
+      <div class="dash-panel-body">${body}</div></div>`;
+  },
+
+  _bind(app) {
+    const refresh = app.querySelector('#dash-refresh-btn');
+    if (refresh) refresh.addEventListener('click', () => this.render(app));
+    const runBtn = app.querySelector('#dash-runscan-btn');
+    if (runBtn) runBtn.addEventListener('click', () => {
+      if (typeof AdHocPage !== 'undefined' && AdHocPage.open) AdHocPage.open();
+    });
+    app.querySelectorAll('[data-activity-tab]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        this._filterTab = btn.getAttribute('data-activity-tab');
+        const body = app.querySelector('#dash-activity-body');
+        if (body) body.innerHTML = this._activityList(this._state);
+        app.querySelectorAll('[data-activity-tab]').forEach(b =>
+          b.classList.toggle('active', b.getAttribute('data-activity-tab') === this._filterTab));
+      });
+    });
+    // Whole row navigates. The CTA <a> bubbles to the same handler so
+    // either click hits the same hash; no stopPropagation needed except
+    // for the Resume button which must NOT navigate.
+    app.querySelectorAll('.activity-item[data-href]').forEach(li => {
+      li.addEventListener('click', () => { location.hash = li.getAttribute('data-href'); });
+    });
+    app.querySelectorAll('[data-resume-id]').forEach(btn => {
+      btn.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        btn.disabled = true;
+        try { await API.resumeSchedule(btn.getAttribute('data-resume-id')); this.render(app); }
+        catch (err) { btn.disabled = false; alert('Resume failed: ' + err.message); }
+      });
+    });
+  },
+
+  _startSubtitleTimer() {
+    const update = () => {
+      const el = document.getElementById('dash-subtitle');
+      if (!el) { clearInterval(this._subtitleTimer); this._subtitleTimer = null; return; }
+      el.textContent = 'actualizado ' + Components.timeAgo(this._state.fetchedAt.toISOString());
+    };
+    update();
+    if (this._subtitleTimer) clearInterval(this._subtitleTimer);
+    this._subtitleTimer = setInterval(update, 30000);
+  },
+
+  _fmtNum(n) { return typeof Intl !== 'undefined' ? new Intl.NumberFormat().format(n) : String(n); },
 };
 
-function formatAssetTypes(types) {
-  if (!types) return '';
-  return Object.entries(types)
-    .map(([k, v]) => `${v} ${k}`)
-    .join(', ');
+// sumSeverityMap collapses a {critical, high, medium, low, info} count
+// map (model.ScanDelta.NewFindings shape) into a single int.
+function sumSeverityMap(m) {
+  if (!m) return 0;
+  return SEV_ORDER.reduce((s, k) => s + (m[k] || 0), 0);
 }
 
-// renderLastScanCard renders the dashboard's "Last Scan" card. Reads
-// last_scan.target_state for asset/finding counts so the user sees the
-// shape of the target the scan observed, not just a flat findings number.
-function renderLastScanCard(s) {
-  const state = s.target_state || {};
-  const assets = state.assets_by_type || {};
-  const ports = state.ports_by_status || {};
-
-  // Compose a single-line "what the target looks like" summary. Skip
-  // zero-valued buckets so the line stays readable.
-  const stateParts = [];
-  if (assets.subdomain > 0) stateParts.push(`${assets.subdomain} subdomain${assets.subdomain === 1 ? '' : 's'}`);
-  if ((assets.ipv4 || 0) + (assets.ipv6 || 0) > 0) stateParts.push(`${(assets.ipv4 || 0) + (assets.ipv6 || 0)} IPs`);
-  if (ports.open > 0) {
-    let portsLine = `${ports.open} open port${ports.open === 1 ? '' : 's'}`;
-    if (ports.filtered > 0) portsLine += ` (${ports.filtered} filtered)`;
-    stateParts.push(portsLine);
-  }
-  if (assets.url > 0) stateParts.push(`${assets.url} endpoint${assets.url === 1 ? '' : 's'}`);
-  if (assets.technology > 0) stateParts.push(`${assets.technology} tech`);
-
-  const stateLine = stateParts.length > 0
-    ? `<div class="text-muted" style="font-size:13px;margin-top:4px">${stateParts.join(' · ')}</div>`
-    : '';
-
-  const work = s.work || {};
-  const workLine = work.tools_run > 0
-    ? `<div class="text-muted" style="font-size:12px;margin-top:4px">${work.tools_run} tools${work.tools_failed > 0 ? `, ${work.tools_failed} failed` : ''}</div>`
-    : '';
-
-  return `<div class="detail-grid">
-    <span class="detail-label">Target</span>
-    <span class="detail-value mono">${escapeHtml(s.target)}</span>
-    <span class="detail-label">Status</span>
-    <span class="detail-value">${Components.statusBadge(s.status)}</span>
-    <span class="detail-label">Duration</span>
-    <span class="detail-value">${Components.formatDuration(s.duration_seconds)}</span>
-    <span class="detail-label">Findings open</span>
-    <span class="detail-value">${s.findings_count}</span>
-    <span class="detail-label">Finished</span>
-    <span class="detail-value">${Components.timeAgo(s.finished_at)}</span>
-  </div>${stateLine}${workLine}`;
-}
-
-// renderChangesCard renders the "Changes Since Last Scan" card. Reads from
-// the persisted ScanDelta (same source as the CLI's PrintChangeSummary), so
-// dashboard and CLI report the same numbers.
-function renderChangesCard(c) {
-  if (!c) return '';
-  if (c.is_baseline) {
-    return '<p class="text-muted" style="margin:8px 0 0">Baseline scan — first run. Subsequent scans will show what changed.</p>';
-  }
-  const total = (c.new_assets || 0) + (c.disappeared_assets || 0) + (c.modified_assets || 0)
-              + (c.new_findings || 0) + (c.resolved_findings || 0);
-  if (total === 0) {
-    return '<p class="text-muted" style="margin:8px 0 0">No changes since last scan.</p>';
-  }
-
-  const cells = [];
-  if ((c.new_assets || 0) > 0) {
-    cells.push(`<div><span style="font-size:20px;font-weight:700;color:var(--success)">+${c.new_assets}</span><br><span class="text-muted" style="font-size:12px">New assets</span></div>`);
-  }
-  if ((c.disappeared_assets || 0) > 0) {
-    cells.push(`<div><span style="font-size:20px;font-weight:700;color:var(--danger)">−${c.disappeared_assets}</span><br><span class="text-muted" style="font-size:12px">Disappeared</span></div>`);
-  }
-  if ((c.modified_assets || 0) > 0) {
-    cells.push(`<div><span style="font-size:20px;font-weight:700;color:var(--sev-medium)">~${c.modified_assets}</span><br><span class="text-muted" style="font-size:12px">Modified</span></div>`);
-  }
-  if ((c.new_findings || 0) > 0) {
-    cells.push(`<div><span style="font-size:20px;font-weight:700;color:var(--success)">+${c.new_findings}</span><br><span class="text-muted" style="font-size:12px">New findings</span></div>`);
-  }
-  if ((c.resolved_findings || 0) > 0) {
-    cells.push(`<div><span style="font-size:20px;font-weight:700;color:var(--success)">✓${c.resolved_findings}</span><br><span class="text-muted" style="font-size:12px">Resolved</span></div>`);
-  }
-  return `<div style="display:flex;gap:24px;padding:8px 0;flex-wrap:wrap">${cells.join('')}</div>`;
-}
-
+// Sidebar findings badge — kept on the dashboard owner because it's the
+// page that always loads /overview. Hidden when crit+high = 0.
 function updateSidebarBadge(sevCounts) {
   if (!sevCounts) return;
-  const critical = sevCounts.critical || 0;
-  const high = sevCounts.high || 0;
-  const total = critical + high;
+  const total = (sevCounts.critical || 0) + (sevCounts.high || 0);
   const el = document.getElementById('findings-badge');
-  if (el) {
-    if (total > 0) {
-      el.textContent = total;
-      el.style.display = '';
-    } else {
-      el.style.display = 'none';
-    }
-  }
-}
-
-function updateLastRefresh() {
-  const el = document.getElementById('last-refresh');
-  if (el) {
-    el.textContent = 'Updated: ' + new Date().toLocaleTimeString();
-  }
+  if (!el) return;
+  if (total > 0) { el.textContent = total; el.style.display = ''; }
+  else { el.style.display = 'none'; }
 }


### PR DESCRIPTION
Closes #36.

## Summary

Replaces the agent-diagnostics-first dashboard with a KPI-first reframe per the UI v2 sprint (PR3). Above-the-fold is now four clickable cards (Risk Score, Open Findings, Discovered Assets, Last Scan); below sits a 7-day activity feed composed in the client from `/scans` + `/findings` + `last_scan.delta`, with side panels for Top Targets and Próximos scans (with a Resume affordance for paused schedules).

## Notable choices

- **No `score_history` backend yet.** Sparkline + trend pill render only when `score_history` is present; the rest of the Risk Score card degrades cleanly. `dashboard_route_test.go` pins `score_history` as deliberately absent until a follow-up wires it.
- **Activity feed is client-composed.** The issue's `/api/v1/activity` endpoint isn't built; events are merged from existing endpoints with a 7-day cutoff and capped at 20 items. New low/info findings are filtered out so chatty scanners can't bury scan/change events.
- **Próximos scans surfaces paused schedules.** `/schedules/upcoming` silently skips paused schedules and returns IDs only, so we also fetch `/schedules` once to recover names + the paused list. No N+1.
- **`finding_count` / `asset_count`** (singular) — the issue body said `findings_count`, the API returns the singular form; we go with the API.
- **Legacy `dashboard.js` vocabulary dropped.** No `<svg>` inline, no `.card-grid` / `.score-container` / `.detail-grid` / agent-info block. `agent_card.js` (245 LOC) stays for the PR12 cleanup audit.
- **Final dashboard.js LOC:** 349 (target ≤ 350).

## Test plan

- [x] `go test ./internal/webui/...` (existing + new tests pass)
- [x] `go test ./...` full suite green
- [x] `node -c dashboard.js` syntax-clean
- [x] `surfbot ui` boots, dashboard.js shipped, `style.css` includes `.dash-grid`
- [ ] Manual smoke in browser: KPIs render with seeded data; click drills through to `/findings?status=open`, `/findings?sort=cvss-desc`, `/assets`, `/scans/{id}`; Refresh re-fetches; Run scan opens AdHoc modal; activity tabs filter client-side
- [ ] First-run empty state: KPIs show 0 / `—`, Last Scan card shows the "No scans yet" copy
- [ ] Window resize ≤ 1200px collapses KPIs to 2-up; ≤ 768px stacks the side column below the feed

## Out of scope (explicit per issue)

- `score_history` backend endpoint (P1.1) — separate issue
- SSE / live KPIs, drag-drop widgets, mobile polish < 768px (P2)
- `pages/agent_card.js` deletion — PR12 cleanup
