### PR TITLE
webui: ui v2 findings slide-over (PR4 #37)

### DIFF
--- a/internal/webui/foundation_assets_test.go
+++ b/internal/webui/foundation_assets_test.go
@@ -77,16 +77,98 @@ func TestFoundationComponentHelpers(t *testing.T) {
 	// The icon registry must list at least the seed glyphs so PR2 can
 	// rely on them without re-discovering whether they exist. PR3 #36
 	// added `refresh` for the dashboard header — listed here so the
-	// next maintainer doesn't strip it during a refactor.
+	// next maintainer doesn't strip it during a refactor. PR4 #37 added
+	// `external` for the finding slide-over reference links.
 	icons := []string{
 		"x:", "search:", "plus:",
 		"'chevron-down':", "'chevron-right':",
 		"check:", "clock:", "alert:", "copy:",
 		"refresh:",
+		"external:",
 	}
 	for _, ic := range icons {
 		assert.True(t, strings.Contains(js, ic),
 			"foundation icon %q missing from components.js ICONS registry", ic)
+	}
+
+	// PR4 #37 added cveLink and a toast helper. They live on the
+	// Components object so future pages can render CVE references and
+	// transient feedback without re-implementing the parser.
+	pr4Helpers := []string{
+		"cveLink(",
+		"toast(",
+	}
+	for _, h := range pr4Helpers {
+		assert.True(t, strings.Contains(js, h),
+			"PR4 helper %q missing from components.js", h)
+	}
+}
+
+// PR4 #37 — findings slide-over migration. The legacy detail-page
+// renderDetail / statusActionsHtml / changeStatusFromDetail / backLink
+// are gone; rows now open a Components.slideOver with severity/status
+// pills and the cveLink helper. These guards catch a partial migration.
+
+func TestFindingsLegacyArtifactsRemoved(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/pages/findings.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	legacy := []string{
+		"renderDetail",
+		"statusActionsHtml",
+		"changeStatusFromDetail",
+		"Components.backLink",
+		"Back to findings",
+	}
+	for _, s := range legacy {
+		assert.False(t, strings.Contains(js, s),
+			"legacy artifact %q must not appear in findings.js after PR4 #37", s)
+	}
+}
+
+func TestFindingsUsesFoundationHelpers(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/pages/findings.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	required := []string{
+		"Components.slideOver(",
+		"Components.severityPill(",
+		"Components.statusPill(",
+		"Components.cveLink(",
+		"Components.icon(",
+		"openSlideoverFor",
+	}
+	for _, s := range required {
+		assert.True(t, strings.Contains(js, s),
+			"findings.js must use foundation helper %q after PR4 #37", s)
+	}
+}
+
+// TestFindingsCSSScaffolding gates the CSS classes the rewritten
+// slide-over interior hard-codes. Lives next to the JS guards so a
+// single failed test makes the missing piece obvious.
+func TestFindingsCSSScaffolding(t *testing.T) {
+	data, err := staticFS.ReadFile("static/css/style.css")
+	require.NoError(t, err)
+	css := string(data)
+
+	classes := []string{
+		".so-pillrow", ".so-title", ".so-asset",
+		".so-actionbar", ".so-action",
+		".so-tabs", ".so-tab", ".tab-active",
+		".so-tabpanel", ".so-section", ".so-section-label",
+		".so-cards", ".so-card", ".so-card-label", ".so-card-value",
+		".so-prose", ".so-list",
+		".so-refs", ".cve-link", ".so-extlink",
+		".so-evidence", ".so-evidence-block",
+		".so-timeline", ".so-empty",
+		".toast-stack", ".toast", ".toast-success", ".toast-error",
+	}
+	for _, c := range classes {
+		assert.True(t, strings.Contains(css, c),
+			"findings CSS class %q missing from style.css", c)
 	}
 }
 

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -2286,3 +2286,310 @@ button.kpi-card:focus-visible {
 .dash-status-dot-active { background: var(--brand); }
 .dash-status-dot-paused { background: var(--status-ack); }
 
+/* === UI v2 PR4 — finding slide-over interior (#37) ===================
+ * The slide-over chrome lives above (.slide-over*). PR4 fills its body
+ * with a rich layout: header pills row + title + asset, action bar, tab
+ * strip, and per-tab content. All classes namespace under .so- so they
+ * never clash with the legacy detail-page styles.
+ * =================================================================== */
+
+.so-pillrow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.so-pillrow .pill {
+  font-size: 11px;
+  padding: 2px 8px;
+}
+.so-id {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--ink-700);
+  border: 1px solid var(--ink-600);
+  border-radius: 4px;
+  padding: 1px 6px;
+  cursor: pointer;
+}
+.so-id:hover { color: var(--text-primary); background: var(--ink-600); }
+.so-title {
+  margin: 10px 0 4px;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--text-primary);
+}
+.so-asset {
+  font-size: 12px;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.so-asset code {
+  font-family: var(--font-mono, monospace);
+  color: var(--text-primary);
+}
+.so-icon-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 2px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
+}
+.so-icon-btn:hover { color: var(--text-primary); background: var(--ink-700); }
+.so-asset-sep { color: var(--ink-600); }
+
+.so-actionbar {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 10px 20px;
+  border-bottom: 1px solid var(--ink-700);
+  flex-shrink: 0;
+  background: var(--ink-900);
+}
+.so-action {
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--ink-600);
+  background: var(--ink-700);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: opacity 0.12s;
+}
+.so-action:hover:not(:disabled) { background: var(--ink-600); color: var(--text-primary); }
+.so-action:disabled { opacity: 0.5; cursor: wait; }
+.so-action-resolved { background: var(--status-resolved-bg); color: var(--status-resolved); border-color: var(--status-resolved-border); }
+.so-action-ack { background: var(--status-ack-bg); color: var(--status-ack); border-color: var(--status-ack-border); }
+.so-action-reopen { background: var(--status-open-bg); color: var(--status-open); border-color: var(--status-open-border); }
+
+.so-tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--ink-700);
+  padding: 0 16px;
+  flex-shrink: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+.so-tab {
+  background: transparent;
+  border: none;
+  padding: 10px 12px;
+  font-size: 13px;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  white-space: nowrap;
+}
+.so-tab:hover { color: var(--text-primary); }
+.so-tab.tab-active {
+  color: var(--brand);
+  border-bottom-color: var(--brand);
+}
+
+.so-tabpanel { padding: 16px 0; }
+.so-tabpanel[hidden] { display: none; }
+.so-section + .so-section { margin-top: 20px; }
+.so-section-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0 0 8px;
+}
+.so-prose {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text-primary);
+  margin: 0;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+.so-prose code {
+  font-family: var(--font-mono, monospace);
+  color: var(--brand);
+  background: rgba(0,229,153,0.08);
+  border-radius: 3px;
+  padding: 1px 4px;
+  font-size: 12px;
+}
+.so-list {
+  margin: 0;
+  padding-left: 20px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-primary);
+}
+.so-list li + li { margin-top: 4px; }
+
+.so-cards {
+  display: grid;
+  grid-template-columns: repeat(var(--so-card-cols, 3), 1fr);
+  gap: 10px;
+}
+.so-card {
+  background: var(--ink-900);
+  border: 1px solid var(--ink-700);
+  border-radius: 6px;
+  padding: 10px 12px;
+}
+.so-card-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+.so-card-value {
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 1.1;
+  color: var(--text-primary);
+}
+.so-card-value-empty { color: var(--text-muted); font-size: 22px; }
+.so-card-caption {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+.so-card-value.sev-critical { color: var(--sev-critical); }
+.so-card-value.sev-high     { color: var(--sev-high); }
+.so-card-value.sev-medium   { color: var(--sev-medium); }
+.so-card-value.sev-low      { color: var(--sev-low); }
+
+.so-refs { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; font-size: 13px; }
+.so-refs li { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.cve-link {
+  font-family: var(--font-mono, monospace);
+  color: var(--brand);
+  text-decoration: none;
+}
+.cve-link:hover { text-decoration: underline; }
+.so-extlink {
+  color: var(--brand);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  word-break: break-all;
+}
+.so-extlink:hover { text-decoration: underline; }
+
+.so-evidence {
+  background: var(--ink-900);
+  border: 1px solid var(--ink-700);
+  border-radius: 6px;
+  padding: 12px;
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+.so-evidence-block + .so-evidence-block { margin-top: 10px; }
+.so-evidence-block-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.so-timeline { list-style: none; margin: 0; padding: 0; }
+.so-timeline li {
+  display: flex;
+  gap: 12px;
+  font-size: 12px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--ink-700);
+}
+.so-timeline li:last-child { border-bottom: none; }
+.so-timeline-when { color: var(--text-muted); width: 80px; flex-shrink: 0; }
+.so-timeline-what { color: var(--text-primary); }
+
+.so-empty {
+  font-size: 13px;
+  color: var(--text-muted);
+  text-align: center;
+  padding: 28px 12px;
+}
+
+.so-skeleton { padding: 4px 0; }
+.so-skel-bar {
+  background: var(--ink-700);
+  border-radius: 4px;
+  margin-bottom: 10px;
+  animation: so-pulse 1.4s ease-in-out infinite;
+}
+.so-skel-bar-1 { height: 14px; width: 33%; }
+.so-skel-bar-2 { height: 12px; width: 66%; }
+.so-skel-bar-3 { height: 12px; width: 100%; }
+.so-skel-bar-4 { height: 96px; width: 100%; }
+@keyframes so-pulse { 0%,100% { opacity: 0.45; } 50% { opacity: 0.85; } }
+
+@media (max-width: 768px) {
+  .so-cards { --so-card-cols: 1; }
+}
+
+/* Toast stack — bottom-right, stacks newest at bottom. The stack mounts
+ * as a body sibling so it floats above slide-overs and modals. */
+.toast-stack {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 60;
+  pointer-events: none;
+}
+.toast {
+  pointer-events: auto;
+  background: var(--ink-700);
+  border: 1px solid var(--ink-600);
+  color: var(--text-primary);
+  padding: 8px 10px 8px 14px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 220px;
+  max-width: 360px;
+  font-size: 13px;
+  box-shadow: 0 6px 18px rgba(0,0,0,0.35);
+  animation: toast-in 0.14s ease-out;
+}
+.toast-success { border-left: 3px solid var(--status-resolved); }
+.toast-error   { border-left: 3px solid var(--sev-critical); }
+.toast-info    { border-left: 3px solid var(--brand); }
+.toast-msg { flex: 1; }
+.toast-close {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  padding: 0 4px;
+}
+.toast-close:hover { color: var(--text-primary); }
+.toast-leaving { opacity: 0; transform: translateX(8px); transition: opacity 0.16s, transform 0.16s; }
+@keyframes toast-in { from { opacity: 0; transform: translateX(8px); } to { opacity: 1; transform: translateX(0); } }
+

--- a/internal/webui/static/js/app.js
+++ b/internal/webui/static/js/app.js
@@ -2,7 +2,10 @@
 const Router = {
   routes: [
     { pattern: /^#?\/?$/, page: 'dashboard', render: () => DashboardPage.render(app) },
-    { pattern: /^#\/findings\/(.+)$/, page: 'findings', render: (m) => FindingsPage.render(app, { id: m[1] }) },
+    // PR4 #37: deep link with id MUST come before the list route. The
+    // capture stops at `?` so #/findings/abc?status=open routes to the
+    // list+slide-over for abc with the query preserved on the listing.
+    { pattern: /^#\/findings\/([^?]+)(\?.*)?$/, page: 'findings', render: (m) => FindingsPage.render(app, Object.assign(parseQueryParams(), { id: decodeURIComponent(m[1]) })) },
     { pattern: /^#\/findings/, page: 'findings', render: () => FindingsPage.render(app, parseQueryParams()) },
     { pattern: /^#\/assets/, page: 'assets', render: () => AssetsPage.render(app, parseQueryParams()) },
     { pattern: /^#\/scans\/(.+)$/, page: 'scans', render: (m) => ScansPage.render(app, { id: m[1] }) },
@@ -25,9 +28,25 @@ const Router = {
     { pattern: /^#\/settings\/defaults/, page: 'settings-defaults', render: () => SettingsDefaultsPage.render(app) },
   ],
 
+  // _lastHash captures the previous hash so the navigate() short-circuit
+  // can detect findings list-vs-slide-over toggles without re-rendering
+  // the list. Set on every navigate() call.
+  _lastHash: '',
+
   navigate() {
     const hash = location.hash || '#/';
     const app = document.getElementById('app');
+
+    // PR4 #37: when transitioning between #/findings and
+    // #/findings/{id} with identical query params, the only thing that
+    // changes is whether the slide-over is open. Re-rendering the list
+    // would flash and lose scroll/selection state, so short-circuit.
+    if (this._isFindingsSlideoverToggle(this._lastHash, hash)) {
+      this._lastHash = hash;
+      this._syncFindingsSlideover(hash);
+      return;
+    }
+    this._lastHash = hash;
 
     // Update active nav link
     document.querySelectorAll('.nav-link').forEach(link => {
@@ -49,6 +68,11 @@ const Router = {
       AgentCard.unmount();
     }
 
+    // Slide-overs from one page should not survive cross-page nav.
+    if (typeof FindingsPage !== 'undefined' && FindingsPage.closeSlideover) {
+      FindingsPage.closeSlideover();
+    }
+
     for (const route of this.routes) {
       const match = hash.match(route.pattern);
       if (match) {
@@ -58,6 +82,39 @@ const Router = {
     }
 
     app.innerHTML = Components.emptyState('Page not found', 'The requested page does not exist.');
+  },
+
+  // _isFindingsSlideoverToggle returns true when prev and cur both live
+  // under #/findings, share the same query string, and differ only by
+  // the trailing /{id} segment (open or close). The path comparison
+  // uses split('?') so query order is preserved verbatim.
+  _isFindingsSlideoverToggle(prev, cur) {
+    if (!prev || !cur) return false;
+    const a = this._parseFindings(prev);
+    const b = this._parseFindings(cur);
+    if (!a || !b) return false;
+    if (a.query !== b.query) return false;
+    return a.id !== b.id;
+  },
+
+  _parseFindings(hash) {
+    const m = hash.match(/^#\/findings(\/[^?]+)?(\?.*)?$/);
+    if (!m) return null;
+    return {
+      id: m[1] ? decodeURIComponent(m[1].slice(1)) : '',
+      query: m[2] || '',
+    };
+  },
+
+  _syncFindingsSlideover(hash) {
+    const parsed = this._parseFindings(hash);
+    if (!parsed) return;
+    if (typeof FindingsPage === 'undefined') return;
+    if (parsed.id) {
+      FindingsPage.openSlideoverFor(parsed.id);
+    } else {
+      FindingsPage.closeSlideover();
+    }
   },
 };
 

--- a/internal/webui/static/js/components.js
+++ b/internal/webui/static/js/components.js
@@ -730,7 +730,57 @@ const Components = {
       <span class="bulk-bar-actions">${btns}</span>
     </div>`;
   },
+
+  // cveLink renders a CVE-id as a link to NVD when the input matches the
+  // canonical "CVE-YYYY-NNNN" shape, escaped text otherwise. The shape
+  // check guards against XSS in case the CVE field is operator-supplied
+  // by an external tool. target=_blank carries rel=noopener noreferrer
+  // because referrer leak via window.opener is the documented risk.
+  cveLink(cve) {
+    if (!cve || !/^CVE-\d{4}-\d{4,7}$/i.test(cve)) return escapeHtml(cve || '');
+    const id = cve.toUpperCase();
+    return `<a class="cve-link" href="https://nvd.nist.gov/vuln/detail/${encodeURIComponent(id)}" target="_blank" rel="noopener noreferrer" aria-label="Open ${id} on NVD (opens in new tab)">${id}</a>`;
+  },
+
+  // toast renders a transient message in a stack at the bottom-right of
+  // the viewport. kind controls the accent color ('success' | 'error' |
+  // 'info'). The stack container is created on demand. Toasts auto-
+  // dismiss after timeoutMs (default 2200ms); set to 0 to keep open until
+  // the user closes via the X button.
+  toast(message, opts) {
+    const o = opts || {};
+    const kind = o.kind || 'info';
+    let stack = document.getElementById('toast-stack');
+    if (!stack) {
+      stack = document.createElement('div');
+      stack.id = 'toast-stack';
+      stack.className = 'toast-stack';
+      stack.setAttribute('role', 'status');
+      stack.setAttribute('aria-live', 'polite');
+      document.body.appendChild(stack);
+    }
+    const el = document.createElement('div');
+    el.className = 'toast toast-' + kind;
+    el.innerHTML = `<span class="toast-msg">${escapeHtml(String(message || ''))}</span>
+      <button type="button" class="toast-close" aria-label="Dismiss">&times;</button>`;
+    stack.appendChild(el);
+    const close = () => {
+      if (!el.parentNode) return;
+      el.classList.add('toast-leaving');
+      setTimeout(() => el.remove(), 180);
+    };
+    el.querySelector('.toast-close').addEventListener('click', close);
+    const timeout = o.timeoutMs == null ? 2200 : o.timeoutMs;
+    if (timeout > 0) setTimeout(close, timeout);
+    return { close };
+  },
 };
+
+// Convenience shortcuts so callers can write Components.toast.error('…')
+// without juggling the kind string.
+Components.toast.success = (msg, opts) => Components.toast(msg, Object.assign({ kind: 'success' }, opts || {}));
+Components.toast.error   = (msg, opts) => Components.toast(msg, Object.assign({ kind: 'error', timeoutMs: 4500 }, opts || {}));
+Components.toast.info    = (msg, opts) => Components.toast(msg, Object.assign({ kind: 'info' }, opts || {}));
 
 // Severity level whitelist for severityPill. Kept as a frozen object
 // so an unknown level can short-circuit to 'info' without spelling out
@@ -754,6 +804,7 @@ const ICONS = Object.freeze({
   alert:          '<path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>',
   copy:           '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>',
   refresh:        '<polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"/>',
+  external:       '<path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>',
 });
 
 function pad2(n) { return String(n).padStart(2, '0'); }

--- a/internal/webui/static/js/pages/findings.js
+++ b/internal/webui/static/js/pages/findings.js
@@ -1,15 +1,31 @@
 // Findings page — grouped-by-host default, toggle to raw per-asset view.
+// PR4 (#37): rows open a slide-over instead of a detail page. The deep
+// link #/findings/{id} renders the list and opens the panel on top.
 const FindingsPage = {
-  async render(app, params) {
-    if (params && params.id) {
-      return this.renderDetail(app, params.id);
-    }
+  // _slide is the live slide-over handle while open, null otherwise.
+  // _lastTrigger is the row element that opened it — focus returns there
+  // on close so keyboard operators don't lose their place.
+  _slide: null,
+  _lastTrigger: null,
+  _abortCtrl: null,
+  _statusToPill: { open: 'open', acknowledged: 'ack', resolved: 'resolved', false_positive: 'fp', ignored: 'ignored' },
 
+  async render(app, params) {
+    // PR4: deep link #/findings/{id} renders the list, then opens the
+    // panel. Legacy ?view=raw&host=…&template_id=… still routes to the
+    // raw list (no slide-over auto-open).
     const view = params?.view || 'grouped';
+    let listPromise;
     if (view === 'grouped') {
-      return this.renderGrouped(app, params);
+      listPromise = this.renderGrouped(app, params);
+    } else {
+      listPromise = this.renderRaw(app, params);
     }
-    return this.renderRaw(app, params);
+    await listPromise;
+    if (params && params.id) {
+      // After the list paints, open the slide-over on top.
+      this.openSlideoverFor(params.id);
+    }
   },
 
   // --- Grouped view (default) ---
@@ -120,10 +136,14 @@ const FindingsPage = {
       `;
     }
 
+    // PR4: row click opens slide-over. Inline event.target check stops
+    // the click from firing when the operator is clicking the inline
+    // status <select>. data-finding-id lets the row stash its id without
+    // re-encoding the string into the onclick attribute.
     const rows = data.findings.map(f => `
-      <tr>
+      <tr class="clickable" data-finding-id="${escapeHtml(f.id)}" onclick="FindingsPage.handleRowClick(event, '${escapeHtml(f.id)}')">
         <td>${Components.severityBadge(f.severity)}</td>
-        <td class="text-truncate clickable" onclick="location.hash='#/findings/${f.id}'">${escapeHtml(f.title)}</td>
+        <td class="text-truncate">${escapeHtml(f.title)}</td>
         <td class="mono text-truncate">${escapeHtml(f.evidence || '')}</td>
         <td class="mono">${escapeHtml(f.source_tool)}</td>
         <td>
@@ -190,7 +210,6 @@ const FindingsPage = {
 
   switchView(view) {
     const params = parseQueryParams();
-    // Reset page when switching views
     const q = ['view=' + view];
     if (params.severity) q.push('severity=' + params.severity);
     const newHash = '#/findings?' + q.join('&');
@@ -244,124 +263,501 @@ const FindingsPage = {
       await API.updateFindingStatus(id, newStatus);
       selectEl.dataset.original = newStatus;
       selectEl.className = 'status-select status-' + newStatus;
+      // Refresh the sidebar findings count after a status flip — open
+      // ↔ non-open transitions are exactly what the badge tracks.
+      if (typeof loadSidebarBadge === 'function') loadSidebarBadge();
     } catch (err) {
       selectEl.value = original;
-      alert('Failed to update status: ' + err.message);
+      Components.toast.error('Failed to update status: ' + err.message);
     }
   },
 
-  async changeStatusFromDetail(id, newStatus) {
+  // --- Slide-over (PR4 #37) ----------------------------------------
+
+  // handleRowClick is the click handler for raw-view <tr>s. It guards
+  // against firing when the operator clicked the inline status <select>
+  // or any other interactive element nested in the row.
+  handleRowClick(evt, id) {
+    const t = evt.target;
+    const tag = t && t.tagName;
+    if (tag === 'SELECT' || tag === 'OPTION' || tag === 'INPUT' ||
+        tag === 'BUTTON' || tag === 'A') return;
+    this._lastTrigger = evt.currentTarget;
+    // Setting hash drives the open via Router's findings transition
+    // detector — keeps Back-button semantics aligned with the panel.
+    location.hash = '#/findings/' + encodeURIComponent(id);
+  },
+
+  // openSlideoverFor is the entry point used by both the row click and
+  // the deep-link route. It mounts the panel with a skeleton, fetches
+  // the finding, and replaces the body. AbortController guards against
+  // a stale render when the operator clicks a different row mid-fetch.
+  async openSlideoverFor(id) {
+    if (this._slide) {
+      // Already open on a different finding: tear down the old panel
+      // before mounting a new one so the focus-return pointer is fresh.
+      this._slide.close('replace');
+      this._slide = null;
+    }
+    if (this._abortCtrl) this._abortCtrl.abort();
+    const ctrl = new AbortController();
+    this._abortCtrl = ctrl;
+
+    const bodyEl = document.createElement('div');
+    bodyEl.className = 'so-content';
+    bodyEl.innerHTML = this._skeletonHtml();
+
+    const trigger = this._lastTrigger;
+    this._slide = Components.slideOver({
+      title: 'Finding',
+      body: bodyEl,
+      onClose: (reason) => {
+        this._slide = null;
+        if (this._abortCtrl) { this._abortCtrl.abort(); this._abortCtrl = null; }
+        // Focus return to the row that opened the panel — keyboard
+        // operators rely on this to keep their place in the list.
+        if (trigger && document.body.contains(trigger)) {
+          try { trigger.focus(); } catch (_) {}
+        }
+        // Strip the /{id} segment from the hash so reopening from
+        // history doesn't immediately re-mount the panel. Skip the
+        // cleanup when 'replace' (we're swapping for another finding).
+        if (reason !== 'replace' && /^#\/findings\/[^?]+/.test(location.hash)) {
+          const params = parseQueryParams();
+          const q = Object.entries(params).filter(([,v]) => v != null && v !== '').map(([k,v]) => k+'='+v).join('&');
+          history.replaceState(null, '', '#/findings' + (q ? '?' + q : ''));
+        }
+      },
+    });
+
+    let data;
     try {
-      await API.updateFindingStatus(id, newStatus);
-      this.renderDetail(document.getElementById('app'), id);
+      data = await API.finding(id);
     } catch (err) {
-      alert('Failed to update status: ' + err.message);
+      if (ctrl.signal.aborted) return;
+      // 404: the finding does not exist (or was deleted). Close the
+      // panel, surface a non-blocking toast, and clean the URL so a
+      // refresh does not loop on the same error.
+      if (err.status === 404) {
+        if (this._slide) this._slide.close('not-found');
+        Components.toast.error('Finding ' + id + ' not found');
+        history.replaceState(null, '', '#/findings');
+      } else {
+        // 5xx or network: leave the panel open and offer a retry.
+        bodyEl.innerHTML = `<div class="so-empty">Failed to load finding.<br>
+          <button class="btn btn-ghost btn-sm" style="margin-top:12px"
+            onclick="FindingsPage.openSlideoverFor('${escapeHtml(id)}')">Retry</button></div>`;
+      }
+      return;
+    }
+    if (ctrl.signal.aborted || !this._slide) return;
+    this._renderSlideoverBody(bodyEl, data.finding, data.asset);
+  },
+
+  _skeletonHtml() {
+    return `<div class="so-skeleton">
+      <div class="so-skel-bar so-skel-bar-1"></div>
+      <div class="so-skel-bar so-skel-bar-2"></div>
+      <div class="so-skel-bar so-skel-bar-3"></div>
+      <div class="so-skel-bar so-skel-bar-4"></div>
+    </div>`;
+  },
+
+  // _renderSlideoverBody builds the full panel interior: header pills +
+  // title + asset, action bar, tab strip, and the four tab panels. The
+  // panel content all comes from the single GET /findings/{id} call —
+  // tab switches do not re-fetch.
+  _renderSlideoverBody(root, f, asset) {
+    root.innerHTML = `
+      ${this._headerHtml(f, asset)}
+      ${this._actionBarHtml(f)}
+      ${this._tabsHtml()}
+      <div class="so-tabpanel" data-tab-panel="overview" role="tabpanel" aria-labelledby="so-tab-overview">${this._overviewHtml(f)}</div>
+      <div class="so-tabpanel" data-tab-panel="evidence" role="tabpanel" aria-labelledby="so-tab-evidence" hidden>${this._evidenceHtml(f)}</div>
+      <div class="so-tabpanel" data-tab-panel="remediation" role="tabpanel" aria-labelledby="so-tab-remediation" hidden>${this._remediationHtml(f)}</div>
+      <div class="so-tabpanel" data-tab-panel="timeline" role="tabpanel" aria-labelledby="so-tab-timeline" hidden>${this._timelineHtml(f)}</div>
+    `;
+    this._wireTabs(root);
+    this._wireActions(root, f);
+    this._wireCopyButtons(root, f, asset);
+    this._wireRemediationCopy(root, f);
+    // Update the panel title for screen readers — the helper builds
+    // .slide-over-title from the title arg of slideOver({title:…}); we
+    // patch it post-mount with the real finding title.
+    if (this._slide && this._slide.root) {
+      const titleEl = this._slide.root.querySelector('.slide-over-title');
+      if (titleEl) titleEl.textContent = f.title || 'Finding';
     }
   },
 
-  async renderDetail(app, id) {
-    app.innerHTML = '<div class="loading">Loading finding...</div>';
+  _headerHtml(f, asset) {
+    const sevPill = Components.severityPill(f.severity);
+    const statusPill = Components.statusPill(this._statusToPill[f.status] || 'open');
+    const toolPill = `<span class="pill" style="background:var(--ink-700);border:1px solid var(--ink-600);color:var(--text-secondary)">${escapeHtml(f.source_tool || 'unknown')}</span>`;
+    const idShort = (f.id || '').slice(0, 12);
+    const assetLine = asset
+      ? `on <code>${escapeHtml(asset.value)}</code>
+         <button type="button" class="so-icon-btn" data-copy-asset aria-label="Copy asset">${Components.icon('copy', 14)}</button>`
+      : `<span class="text-muted">(asset deleted)</span>`;
+    return `
+      <div class="so-pillrow">
+        ${sevPill}
+        ${statusPill}
+        ${toolPill}
+        <span style="flex:1"></span>
+        <button type="button" class="so-id" data-copy-id aria-label="Copy finding ID">${escapeHtml(idShort)}</button>
+      </div>
+      <h2 class="so-title">${escapeHtml(f.title || '(untitled finding)')}</h2>
+      <div class="so-asset">
+        ${assetLine}
+        <span class="so-asset-sep">·</span>
+        <span class="text-muted">last seen ${escapeHtml(Components.timeAgo(f.last_seen))}</span>
+      </div>
+    `;
+  },
 
-    try {
-      const data = await API.finding(id);
-      const f = data.finding;
-      const asset = data.asset;
+  _actionBarHtml(f) {
+    // Visibility matrix per status — see issue #37 P0.4. Map button
+    // class hints to so-action-* modifiers so the colors match status
+    // tokens without restating them in the call site.
+    const matrix = {
+      open:           [['acknowledged','Acknowledge','ack'], ['resolved','Mark resolved','resolved'], ['false_positive','False positive',''], ['ignored','Ignore','']],
+      acknowledged:   [['resolved','Mark resolved','resolved'], ['open','Reopen','reopen'], ['false_positive','False positive','']],
+      resolved:       [['open','Reopen','reopen']],
+      false_positive: [['open','Reopen','reopen']],
+      ignored:        [['open','Reopen','reopen']],
+    };
+    const actions = matrix[f.status] || [];
+    if (!actions.length) return '<div class="so-actionbar" data-actionbar></div>';
+    const btns = actions.map(([s, label, accent]) => {
+      const cls = 'so-action' + (accent ? ' so-action-' + accent : '');
+      return `<button type="button" class="${cls}" data-set-status="${s}">${escapeHtml(label)}</button>`;
+    }).join('');
+    return `<div class="so-actionbar" data-actionbar>${btns}</div>`;
+  },
 
-      const statusActions = this.statusActionsHtml(f);
+  _tabsHtml() {
+    // Comments tab is intentionally absent (#37 Non-goals #4). aria-
+    // selected is updated by _wireTabs on activation.
+    return `<div class="so-tabs" role="tablist" aria-label="Finding sections">
+      <button type="button" class="so-tab tab-active" id="so-tab-overview" role="tab" aria-selected="true" aria-controls="so-panel-overview" data-tab="overview">Overview</button>
+      <button type="button" class="so-tab" id="so-tab-evidence" role="tab" aria-selected="false" aria-controls="so-panel-evidence" data-tab="evidence">Evidence</button>
+      <button type="button" class="so-tab" id="so-tab-remediation" role="tab" aria-selected="false" aria-controls="so-panel-remediation" data-tab="remediation">Remediation</button>
+      <button type="button" class="so-tab" id="so-tab-timeline" role="tab" aria-selected="false" aria-controls="so-panel-timeline" data-tab="timeline">Timeline</button>
+    </div>`;
+  },
 
-      app.innerHTML = `
-        ${Components.backLink('#/findings', 'Back to findings')}
-        <div class="detail-panel">
-          <div class="detail-header">
-            ${Components.severityBadge(f.severity)}
-            <h3>${escapeHtml(f.title)}</h3>
-          </div>
+  _wireTabs(root) {
+    const tabs = root.querySelectorAll('.so-tab');
+    tabs.forEach(tab => {
+      tab.addEventListener('click', () => {
+        const name = tab.getAttribute('data-tab');
+        tabs.forEach(t => {
+          const active = t === tab;
+          t.classList.toggle('tab-active', active);
+          t.setAttribute('aria-selected', active ? 'true' : 'false');
+        });
+        root.querySelectorAll('[data-tab-panel]').forEach(p => {
+          p.hidden = p.getAttribute('data-tab-panel') !== name;
+        });
+      });
+    });
+  },
 
-          ${statusActions}
+  _wireActions(root, f) {
+    const bar = root.querySelector('[data-actionbar]');
+    if (!bar) return;
+    bar.querySelectorAll('[data-set-status]').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const newStatus = btn.getAttribute('data-set-status');
+        bar.querySelectorAll('[data-set-status]').forEach(b => { b.disabled = true; });
+        try {
+          await API.updateFindingStatus(f.id, newStatus);
+          // 1. Mutate the local model and refresh in-place: header pill
+          //    + action bar + the row in the list behind. No re-fetch.
+          f.status = newStatus;
+          this._refreshHeaderStatusPill(root, newStatus);
+          bar.outerHTML = this._actionBarHtml(f);
+          this._wireActions(root, f);
+          this._refreshListRow(f.id, newStatus);
+          if (typeof loadSidebarBadge === 'function') loadSidebarBadge();
+        } catch (err) {
+          Components.toast.error('Failed to update status: ' + err.message);
+          bar.querySelectorAll('[data-set-status]').forEach(b => { b.disabled = false; });
+        }
+      });
+    });
+  },
 
-          <div class="detail-grid">
-            <span class="detail-label">ID</span>
-            <span class="detail-value mono">${f.id}</span>
-            <span class="detail-label">Template</span>
-            <span class="detail-value mono">${escapeHtml(f.template_id)}</span>
-            <span class="detail-label">Tool</span>
-            <span class="detail-value">${escapeHtml(f.source_tool)}</span>
-            <span class="detail-label">Status</span>
-            <span class="detail-value">${Components.statusBadge(f.status)}</span>
-            <span class="detail-label">Confidence</span>
-            <span class="detail-value">${f.confidence}%</span>
-            ${f.cvss ? `<span class="detail-label">CVSS</span><span class="detail-value">${f.cvss}</span>` : ''}
-            ${f.cve ? `<span class="detail-label">CVE</span><span class="detail-value mono">${escapeHtml(f.cve)}</span>` : ''}
-            <span class="detail-label">First seen</span>
-            <span class="detail-value">${Components.formatDate(f.first_seen)}</span>
-            <span class="detail-label">Last seen</span>
-            <span class="detail-value">${Components.formatDate(f.last_seen)}</span>
-            ${f.resolved_at ? `<span class="detail-label">Resolved</span><span class="detail-value">${Components.formatDate(f.resolved_at)}</span>` : ''}
-          </div>
-        </div>
-
-        ${f.description ? `<div class="card" style="margin-bottom:16px">
-          <div class="card-label">Description</div>
-          <p style="margin-top:8px">${escapeHtml(f.description)}</p>
-        </div>` : ''}
-
-        ${asset ? `<div class="card" style="margin-bottom:16px">
-          <div class="card-label">Related Asset</div>
-          <div class="detail-grid" style="margin-top:8px">
-            <span class="detail-label">Value</span>
-            <span class="detail-value mono">${escapeHtml(asset.value)}</span>
-            <span class="detail-label">Type</span>
-            <span class="detail-value">${asset.type}</span>
-          </div>
-        </div>` : ''}
-
-        ${f.remediation ? `<div class="card" style="margin-bottom:16px">
-          <div class="card-label">Remediation</div>
-          <p style="margin-top:8px">${escapeHtml(f.remediation)}</p>
-        </div>` : ''}
-
-        ${f.evidence ? `<div class="card" style="margin-bottom:16px">
-          <div class="card-label">Evidence</div>
-          ${Components.jsonViewer(f.evidence)}
-        </div>` : ''}
-
-        ${f.references && f.references.length > 0 ? `<div class="card" style="margin-bottom:16px">
-          <div class="card-label">References</div>
-          <ul style="margin-top:8px;padding-left:20px">
-            ${f.references.map(r => safeLink(r)).join('')}
-          </ul>
-        </div>` : ''}
-      `;
-    } catch (err) {
-      app.innerHTML = Components.emptyState('Not Found', 'Finding not found.');
+  _refreshHeaderStatusPill(root, status) {
+    const row = root.querySelector('.so-pillrow');
+    if (!row) return;
+    const pillKey = this._statusToPill[status] || 'open';
+    // Status pill is the second .pill in the header row.
+    const pills = row.querySelectorAll('.pill');
+    if (pills.length >= 2) {
+      pills[1].outerHTML = Components.statusPill(pillKey);
     }
   },
 
-  statusActionsHtml(f) {
-    const actions = [];
-    if (f.status === 'open') {
-      actions.push({ label: 'Acknowledge', status: 'acknowledged', cls: 'btn-ghost' });
-      actions.push({ label: 'Resolve', status: 'resolved', cls: 'btn-accent' });
-      actions.push({ label: 'False Positive', status: 'false_positive', cls: 'btn-ghost' });
-      actions.push({ label: 'Ignore', status: 'ignored', cls: 'btn-ghost' });
-    } else if (f.status === 'acknowledged') {
-      actions.push({ label: 'Resolve', status: 'resolved', cls: 'btn-accent' });
-      actions.push({ label: 'Reopen', status: 'open', cls: 'btn-ghost' });
-      actions.push({ label: 'False Positive', status: 'false_positive', cls: 'btn-ghost' });
-    } else if (f.status === 'resolved') {
-      actions.push({ label: 'Reopen', status: 'open', cls: 'btn-ghost' });
-    } else if (f.status === 'false_positive') {
-      actions.push({ label: 'Reopen', status: 'open', cls: 'btn-ghost' });
-    } else if (f.status === 'ignored') {
-      actions.push({ label: 'Reopen', status: 'open', cls: 'btn-ghost' });
+  _refreshListRow(id, newStatus) {
+    // The list lives outside the panel. Find the <tr> by its
+    // data-finding-id and patch the inline <select> + the className
+    // tokens that drive the pill color.
+    const row = document.querySelector(`tr[data-finding-id="${cssAttrEscape(id)}"]`);
+    if (!row) return;
+    const sel = row.querySelector('.status-select');
+    if (sel) {
+      sel.value = newStatus;
+      sel.dataset.original = newStatus;
+      sel.className = 'status-select status-' + newStatus;
+    }
+  },
+
+  _wireCopyButtons(root, f, asset) {
+    const idBtn = root.querySelector('[data-copy-id]');
+    if (idBtn) {
+      idBtn.addEventListener('click', () => {
+        navigator.clipboard.writeText(f.id || '').then(
+          () => Components.toast.success('Finding ID copied'),
+          () => Components.toast.error('Copy failed'),
+        );
+      });
+    }
+    const assetBtn = root.querySelector('[data-copy-asset]');
+    if (assetBtn && asset) {
+      assetBtn.addEventListener('click', () => {
+        navigator.clipboard.writeText(asset.value || '').then(
+          () => Components.toast.success('Asset copied'),
+          () => Components.toast.error('Copy failed'),
+        );
+      });
+    }
+  },
+
+  _wireRemediationCopy(root, f) {
+    const btn = root.querySelector('[data-copy-runbook]');
+    if (!btn) return;
+    btn.addEventListener('click', () => {
+      const blob = '## Remediation\n\n' + (f.remediation || '');
+      navigator.clipboard.writeText(blob).then(
+        () => Components.toast.success('Runbook copied'),
+        () => Components.toast.error('Copy failed'),
+      );
+    });
+  },
+
+  // --- Tab content ------------------------------------------------
+
+  _overviewHtml(f) {
+    // CVSS card. Range → token. Empty / 0 → em-dash.
+    let cvssCard;
+    if (!f.cvss || f.cvss <= 0) {
+      cvssCard = this._cardHtml('CVSS 3.1', '<span class="so-card-value-empty">—</span>', '');
+    } else {
+      const score = f.cvss.toFixed(1);
+      let sev = 'low', label = 'Low';
+      if (f.cvss >= 9.0) { sev = 'critical'; label = 'Critical'; }
+      else if (f.cvss >= 7.0) { sev = 'high'; label = 'High'; }
+      else if (f.cvss >= 4.0) { sev = 'medium'; label = 'Medium'; }
+      cvssCard = this._cardHtml('CVSS 3.1', `<span class="so-card-value sev-${sev}">${score}</span>`, label);
     }
 
-    if (actions.length === 0) return '';
+    // Confidence card.
+    const conf = (f.confidence == null || f.confidence === 0)
+      ? '<span class="so-card-value-empty">—</span>'
+      : `<span class="so-card-value">${Math.round(f.confidence)}%</span>`;
+    const confCard = this._cardHtml('Confidence', conf, '');
 
-    const btns = actions.map(a =>
-      `<button class="btn btn-sm ${a.cls}" onclick="FindingsPage.changeStatusFromDetail('${f.id}', '${a.status}')">${a.label}</button>`
-    ).join('');
+    // EPSS column omitted (model.Finding has no EPSS field — see #37
+    // Non-goals #6). Two cards collapse to a 2-col grid.
+    const cards = `<div class="so-cards" style="--so-card-cols:2">${cvssCard}${confCard}</div>`;
 
-    return `<div class="action-bar">${btns}</div>`;
+    const description = f.description
+      ? `<div class="so-section">
+          <h3 class="so-section-label">Description</h3>
+          <p class="so-prose">${escapeHtml(f.description)}</p>
+        </div>`
+      : '';
+
+    const refs = this._referencesHtml(f);
+
+    // Metadata footer (template + first/last seen) — the wireframe
+    // collapses the legacy detail-grid into a smaller card. Useful for
+    // operators who want the canonical IDs at a glance.
+    const meta = `<div class="so-section">
+      <h3 class="so-section-label">Details</h3>
+      <ul class="so-list" style="list-style:none;padding-left:0">
+        <li><span class="text-muted">Template</span> <code>${escapeHtml(f.template_id || '—')}</code></li>
+        <li><span class="text-muted">First seen</span> ${escapeHtml(Components.formatDate(f.first_seen))}</li>
+        ${f.resolved_at ? `<li><span class="text-muted">Resolved</span> ${escapeHtml(Components.formatDate(f.resolved_at))}</li>` : ''}
+      </ul>
+    </div>`;
+
+    return `<div class="so-section">${cards}</div>${description}${refs}${meta}`;
+  },
+
+  _cardHtml(label, valueHtml, captionText) {
+    return `<div class="so-card">
+      <div class="so-card-label">${escapeHtml(label)}</div>
+      ${valueHtml}
+      ${captionText ? `<div class="so-card-caption">${escapeHtml(captionText)}</div>` : ''}
+    </div>`;
+  },
+
+  _referencesHtml(f) {
+    const items = [];
+    if (f.cve) items.push({ kind: 'cve', value: f.cve });
+    if (Array.isArray(f.references)) {
+      for (const r of f.references) {
+        if (!r) continue;
+        const cveMatch = String(r).match(/CVE-\d{4}-\d{4,7}/i);
+        if (cveMatch && /^CVE-\d{4}-\d{4,7}$/i.test(String(r).trim())) {
+          items.push({ kind: 'cve', value: cveMatch[0] });
+        } else if (/^https?:\/\//i.test(String(r))) {
+          items.push({ kind: 'url', value: String(r) });
+        } else if (cveMatch) {
+          // Mixed string with a CVE id inside — render the CVE link plus
+          // a stripped-text remainder as plain.
+          items.push({ kind: 'cve', value: cveMatch[0] });
+        } else {
+          items.push({ kind: 'text', value: String(r) });
+        }
+      }
+    }
+    if (!items.length) return '';
+    const lis = items.map(it => {
+      if (it.kind === 'cve') return `<li>${Components.cveLink(it.value)}</li>`;
+      if (it.kind === 'url') return `<li><a class="so-extlink" href="${escapeHtml(it.value)}" target="_blank" rel="noopener noreferrer">${escapeHtml(it.value)}${Components.icon('external', 12)}</a></li>`;
+      return `<li><span class="text-muted">${escapeHtml(it.value)}</span></li>`;
+    }).join('');
+    return `<div class="so-section">
+      <h3 class="so-section-label">References</h3>
+      <ul class="so-refs">${lis}</ul>
+    </div>`;
+  },
+
+  _evidenceHtml(f) {
+    const raw = f.evidence;
+    if (!raw) return '<div class="so-empty">No evidence captured.</div>';
+
+    const trimmed = String(raw).trim();
+
+    // 1. JSON shape: try to parse; if it has request/response keys use
+    //    the dual-block format, otherwise pretty-print the object.
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      try {
+        const obj = JSON.parse(trimmed);
+        if (obj && (obj.request || obj.response)) {
+          return this._httpInteractionHtml(obj);
+        }
+        return `<div class="so-section">
+          <h3 class="so-section-label">Evidence</h3>
+          <pre class="so-evidence">${escapeHtml(JSON.stringify(obj, null, 2))}</pre>
+        </div>`;
+      } catch (_) { /* fallthrough */ }
+    }
+
+    // 2. Plain text — preformatted with a header label.
+    return `<div class="so-section">
+      <h3 class="so-section-label">Evidence</h3>
+      <pre class="so-evidence">${escapeHtml(String(raw))}</pre>
+    </div>`;
+  },
+
+  _httpInteractionHtml(obj) {
+    const req = obj.request ? `<div class="so-evidence-block">
+      <div class="so-evidence-block-label">Request</div>
+      <pre class="so-evidence">${escapeHtml(typeof obj.request === 'string' ? obj.request : JSON.stringify(obj.request, null, 2))}</pre>
+    </div>` : '';
+    const resp = obj.response ? `<div class="so-evidence-block">
+      <div class="so-evidence-block-label">Response</div>
+      <pre class="so-evidence">${escapeHtml(typeof obj.response === 'string' ? obj.response : JSON.stringify(obj.response, null, 2))}</pre>
+    </div>` : '';
+    return `<div class="so-section">
+      <h3 class="so-section-label">Evidence</h3>
+      ${req}${resp}
+    </div>`;
+  },
+
+  _remediationHtml(f) {
+    const body = f.remediation;
+    if (!body) return '<div class="so-empty">No remediation steps documented.</div>';
+
+    // Numbered-list parser: if every non-empty line starts with "1." /
+    // "2)" / etc., render as <ol>. Otherwise prose.
+    const lines = String(body).split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+    const allNumbered = lines.length > 1 && lines.every(l => /^\d+[.)]\s+/.test(l));
+
+    let bodyHtml;
+    if (allNumbered) {
+      const items = lines.map(l => l.replace(/^\d+[.)]\s+/, '')).map(l =>
+        `<li>${this._inlineCode(l)}</li>`).join('');
+      bodyHtml = `<ol class="so-list">${items}</ol>`;
+    } else {
+      bodyHtml = `<p class="so-prose">${this._inlineCode(String(body))}</p>`;
+    }
+    return `<div class="so-section">
+      <h3 class="so-section-label">Remediation</h3>
+      ${bodyHtml}
+      <div style="margin-top:12px">
+        <button type="button" class="btn btn-ghost btn-sm" data-copy-runbook>Copy as runbook</button>
+      </div>
+    </div>`;
+  },
+
+  // _inlineCode escapes HTML and then promotes single-backtick spans to
+  // <code> — a deliberate ASCII-only mini parser, NOT markdown. Run on
+  // already-escaped text so the regex never sees raw HTML.
+  _inlineCode(text) {
+    return escapeHtml(text).replace(/`([^`]+)`/g, (_m, g) => `<code>${g}</code>`);
+  },
+
+  _timelineHtml(f) {
+    // Events derive from the model — there is no finding_status_history
+    // table yet (see #37 P2.1). resolved_at is the only status-related
+    // event we can reliably show.
+    const events = [];
+    if (f.created_at) {
+      const scanShort = (f.first_seen_scan_id || f.scan_id || '').slice(0, 8);
+      const scanText = scanShort ? `Detected · scan <code>${escapeHtml(scanShort)}</code>` : 'Detected';
+      events.push({ ts: f.created_at, text: scanText });
+    }
+    if (f.first_seen && f.first_seen !== f.created_at) {
+      events.push({ ts: f.first_seen, text: 'First seen on this asset' });
+    }
+    if (f.last_seen && f.last_seen !== f.first_seen) {
+      events.push({ ts: f.last_seen, text: 'Last seen' });
+    }
+    if (f.resolved_at) {
+      events.push({ ts: f.resolved_at, text: 'Resolved' });
+    }
+    if (!events.length) return '<div class="so-empty">No timeline events.</div>';
+    events.sort((a, b) => new Date(b.ts) - new Date(a.ts));
+    const lis = events.map(e => `<li>
+      <span class="so-timeline-when">${escapeHtml(Components.timeAgo(e.ts))}</span>
+      <span class="so-timeline-what">${e.text}</span>
+    </li>`).join('');
+    return `<div class="so-section">
+      <h3 class="so-section-label">Timeline</h3>
+      <ol class="so-timeline">${lis}</ol>
+    </div>`;
+  },
+
+  // closeSlideover is invoked by app.js when the hash transitions away
+  // from #/findings/{id} (back button, manual edit, etc.). Idempotent.
+  closeSlideover() {
+    if (this._slide) {
+      this._slide.close('hashchange');
+      this._slide = null;
+    }
   },
 };
+
+// cssAttrEscape quotes a value for use inside an attribute selector
+// (`[data-finding-id="…"]`). CSS.escape covers everything; the manual
+// fallback covers the rare browser without it.
+function cssAttrEscape(s) {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') return CSS.escape(s);
+  return String(s).replace(/(["\\])/g, '\\$1');
+}

--- a/internal/webui/static/js/pages/findings.js
+++ b/internal/webui/static/js/pages/findings.js
@@ -56,14 +56,26 @@ const FindingsPage = {
       `;
     }
 
+    // Single-finding groups skip the raw-filtered drill: the row opens
+    // the slide-over directly using finding_ids[0]. Multi-asset groups
+    // still drill — picking which port/asset is meaningful when N>1.
     const rows = data.groups.map(g => {
       const badge = g.affected_assets_count > 1
         ? `<span class="port-badge">${g.affected_assets_count} ports</span>`
         : '';
-      const drillHref = '#/findings?view=raw&host=' + encodeURIComponent(g.host)
-        + '&template_id=' + encodeURIComponent(g.template_id);
+      const single = g.affected_assets_count === 1
+        && Array.isArray(g.finding_ids) && g.finding_ids.length === 1;
+      let onclick;
+      if (single) {
+        onclick = `FindingsPage.handleGroupedRowClick(event, '${escapeHtml(g.finding_ids[0])}')`;
+      } else {
+        const drillHref = '#/findings?view=raw&host=' + encodeURIComponent(g.host)
+          + '&template_id=' + encodeURIComponent(g.template_id);
+        onclick = `location.hash='${drillHref}'`;
+      }
+      const dataAttr = single ? ` data-finding-id="${escapeHtml(g.finding_ids[0])}"` : '';
       return `
-        <tr class="clickable" onclick="location.hash='${drillHref}'">
+        <tr class="clickable"${dataAttr} onclick="${onclick}">
           <td>${Components.severityBadge(g.severity)}</td>
           <td class="text-truncate">${escapeHtml(g.title)} ${badge}</td>
           <td class="mono">${escapeHtml(g.host)}</td>
@@ -285,6 +297,15 @@ const FindingsPage = {
     this._lastTrigger = evt.currentTarget;
     // Setting hash drives the open via Router's findings transition
     // detector — keeps Back-button semantics aligned with the panel.
+    location.hash = '#/findings/' + encodeURIComponent(id);
+  },
+
+  // handleGroupedRowClick is the equivalent for the grouped view when
+  // the group has a single underlying finding. Multi-asset groups keep
+  // the drill-through to the raw-filtered list because picking the
+  // port/asset is the meaningful next step there.
+  handleGroupedRowClick(evt, id) {
+    this._lastTrigger = evt.currentTarget;
     location.hash = '#/findings/' + encodeURIComponent(id);
   },
 


### PR DESCRIPTION
Closes #37.

## Summary

- Click on a finding row now opens a right-anchored slide-over instead of navigating to a full detail page. The list stays visible behind the panel; closing returns focus to the row.
- Slide-over body has four tabs (Overview / Evidence / Remediation / Timeline) populated from a single `GET /findings/{id}` — switching tabs does not re-fetch.
- Status actions (Acknowledge / Mark resolved / False positive / Ignore / Reopen) update header pill, list row, and sidebar count in-place. Slide-over stays open after a status change.
- Deep link `#/findings/{id}` renders the list and opens the panel on top. Back button closes the panel without re-rendering. `history.replaceState` strips `/{id}` on close so refreshes don't loop.
- CVEs in the `cve` field or in `references` auto-link to NVD via a new `Components.cveLink()` helper. URLs render as external links with `rel=noopener noreferrer`.
- New `Components.toast()` helper for non-blocking feedback (copy confirmations, status update errors).

## Files

- `internal/webui/static/js/pages/findings.js` — rewritten slide-over machinery; legacy `renderDetail` / `statusActionsHtml` / `changeStatusFromDetail` removed.
- `internal/webui/static/js/components.js` — `cveLink`, `toast`, `external` icon.
- `internal/webui/static/js/app.js` — router detects `#/findings` ↔ `#/findings/{id}` toggles and short-circuits (no list re-render).
- `internal/webui/static/css/style.css` — `.so-*` interior layout + `.toast-*` stack.
- `internal/webui/foundation_assets_test.go` — guards for legacy artifact removal, foundation helper usage, and CSS scaffolding.

## Out of scope (per issue Non-goals)

- Filter chips / bulk actions / sev-pill tabs (PR5 #38)
- Comments tab, Assignment, EPSS data, Jira integration (no backend yet)
- Markdown rendering in remediation (escapes HTML, supports backticks + numbered lists only)
- HTTP evidence syntax highlighting (P1, deferred)
- Status-history backed Timeline (P2 — needs new table)

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -race` (all packages green; webui suite covers new foundation guards)
- [x] `go vet ./...`
- [x] `node --check` on each touched JS file
- [ ] Manual smoke: row click opens panel, Esc closes and returns focus, deep link `#/findings/{id}` works, status change updates list+sidebar, CVE link opens NVD in new tab
- [ ] Manual mobile (375px): panel takes full width, tabs scroll horizontally
