### PR TITLE
webui: ui v2 filter chips persistentes + bulk actions (PR5 #38)

### DIFF
--- a/internal/webui/findings_filter_test.go
+++ b/internal/webui/findings_filter_test.go
@@ -1,0 +1,66 @@
+package webui
+
+// PR5 #38 — filter chip surface for the findings list. The new chips
+// derive from the same query params the legacy <select> dropdowns
+// targeted, so a regression that drops one of them on the server side
+// would make the chip silently ineffective. These tests exercise each
+// supported filter through /api/v1/findings and confirm the handler is
+// permissive about unknown enum values (returns 200 with zero rows
+// rather than 400, matching the chip UX expectation).
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindingsListAcceptsAllFilterParams(t *testing.T) {
+	h, s := newTestHandler(t)
+	seedTestData(t, s)
+
+	cases := []struct {
+		name string
+		q    string
+	}{
+		{"severity", "/api/v1/findings?severity=critical"},
+		{"status", "/api/v1/findings?status=open"},
+		{"host", "/api/v1/findings?host=blog.example.com"},
+		{"tool", "/api/v1/findings?tool=nuclei"},
+		{"template_id", "/api/v1/findings?template_id=wordpress-xmlrpc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.q, nil)
+			w := httptest.NewRecorder()
+			h.handleFindings(w, req)
+			assert.Equal(t, http.StatusOK, w.Code, "unexpected status for %s", tc.q)
+
+			var resp findingsResponse
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			assert.NotNil(t, resp.Findings)
+		})
+	}
+}
+
+func TestFindingsListInvalidEnumIsPermissive(t *testing.T) {
+	h, s := newTestHandler(t)
+	seedTestData(t, s)
+
+	// "banana" is not a valid severity enum value. The handler casts
+	// the raw string into model.Severity and lets the storage layer
+	// match nothing — that's the contract the chip UI relies on (no
+	// 400 surfacing while typing into the chip submenu).
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/findings?severity=banana", nil)
+	w := httptest.NewRecorder()
+	h.handleFindings(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp findingsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 0, len(resp.Findings))
+	assert.Equal(t, 0, resp.Total)
+}

--- a/internal/webui/foundation_assets_test.go
+++ b/internal/webui/foundation_assets_test.go
@@ -244,3 +244,121 @@ func TestDashboardCSSScaffolding(t *testing.T) {
 			"dashboard CSS class %q missing from style.css", c)
 	}
 }
+
+// PR5 #38 — filter chips persistentes + bulk actions. The findings,
+// targets, and scans list pages migrate to the chip + tab vocabulary
+// (and bulk-bar on findings/targets). These guards catch a partial
+// migration: legacy <select id="filter-..."> dropdowns or the legacy
+// inline status-select must be gone, and the foundation helpers (PR1
+// filterChip, bulkBar, severityPill, statusPill) must be wired in.
+
+func TestFindingsLegacyFiltersRemoved(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/pages/findings.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	legacy := []string{
+		"groupedFiltersHtml",
+		"rawFiltersHtml",
+		"id=\"filter-severity\"",
+		"id=\"filter-status\"",
+		"id=\"filter-host\"",
+		"class=\"status-select",
+		"changeStatus(",
+	}
+	for _, s := range legacy {
+		assert.False(t, strings.Contains(js, s),
+			"legacy filter artifact %q must not appear in findings.js after PR5 #38", s)
+	}
+}
+
+func TestFindingsUsesChipsAndBulkBar(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/pages/findings.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	required := []string{
+		"Components.filterChip(",
+		"Components.bulkBar(",
+		"Components.severityPill(",
+		"Components.statusPill(",
+		"Components.confirmDialog(",
+		"surfbot_findings_filters",
+		"_selectedIds",
+		"bulkApplyStatus",
+		"updateFindingStatus",
+	}
+	for _, s := range required {
+		assert.True(t, strings.Contains(js, s),
+			"findings.js must reference %q after PR5 #38", s)
+	}
+}
+
+func TestTargetsUsesChipsAndBulkBar(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/pages/targets.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	required := []string{
+		"Components.bulkBar(",
+		"Components.confirmDialog(",
+		"_selectedIds",
+		"surfbot_targets_filters",
+		"bulkRunScan",
+		"bulkDelete",
+		"tgt-checkbox",
+	}
+	for _, s := range required {
+		assert.True(t, strings.Contains(js, s),
+			"targets.js must reference %q after PR5 #38", s)
+	}
+}
+
+func TestScansUsesChipsNoBulkBar(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/pages/scans.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	required := []string{
+		"Components.filterChip(",
+		"surfbot_scans_filters",
+		"_chipStripHtml",
+		"_statusTabsHtml",
+	}
+	for _, s := range required {
+		assert.True(t, strings.Contains(js, s),
+			"scans.js must reference %q after PR5 #38", s)
+	}
+
+	// Scans explicitly does NOT add the floating bulk-bar (P0/non-goal #1).
+	// The page may still inherit components.js helper definitions, but the
+	// page module must not invoke Components.bulkBar(.
+	assert.False(t, strings.Contains(js, "Components.bulkBar("),
+		"scans.js must NOT mount Components.bulkBar after PR5 #38 (bulk explicitly out of scope)")
+}
+
+// TestPR5CSSScaffolding gates the CSS classes the new layout hard-codes:
+// severity tabs, filter strip, filter menu (popup + submenu), save-view
+// pill, and the table checkbox column.
+func TestPR5CSSScaffolding(t *testing.T) {
+	data, err := staticFS.ReadFile("static/css/style.css")
+	require.NoError(t, err)
+	css := string(data)
+
+	classes := []string{
+		".sev-tabs", ".sev-tab", ".sev-tab-active",
+		".sev-tab-critical", ".sev-tab-high", ".sev-tab-medium",
+		".sev-tab-low", ".sev-tab-info",
+		".filter-strip", ".filter-strip-chips", ".filter-add-btn",
+		".filter-menu", ".filter-menu-item", ".filter-menu-divider",
+		".filter-menu-search", ".filter-menu-list",
+		".save-view-pill",
+		".fnd-cb-col", ".fnd-checkbox",
+		".fnd-row-selected",
+		".tgt-checkbox", ".tgt-row-selected",
+	}
+	for _, c := range classes {
+		assert.True(t, strings.Contains(css, c),
+			"PR5 CSS class %q missing from style.css", c)
+	}
+}

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -2593,3 +2593,208 @@ button.kpi-card:focus-visible {
 .toast-leaving { opacity: 0; transform: translateX(8px); transition: opacity 0.16s, transform 0.16s; }
 @keyframes toast-in { from { opacity: 0; transform: translateX(8px); } to { opacity: 1; transform: translateX(0); } }
 
+/* === UI v2 PR5 (#38) — chips persistentes + bulk actions ============
+ * Severity tabs, filter strip, filter menu (popup + submenu), save-view
+ * pill, table checkbox column, and the "selected row" highlight.
+ * The .filter-chip / .bulk-bar foundations come from PR1; PR5 adds the
+ * containers around them and the new affordances unique to this layout.
+ * =================================================================== */
+
+/* --- Severity tabs ------------------------------------------------- */
+.sev-tabs {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin: 0 0 12px;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+.sev-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 9999px;
+  background: var(--ink-800);
+  border: 1px solid var(--ink-600);
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.sev-tab:hover { color: var(--text-primary); background: var(--ink-700); }
+.sev-tab-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+.sev-tab-count {
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-left: 2px;
+}
+.sev-tab-active .sev-tab-count { color: inherit; }
+.sev-tab-critical { color: var(--sev-critical); }
+.sev-tab-high     { color: var(--sev-high); }
+.sev-tab-medium   { color: var(--sev-medium); }
+.sev-tab-low      { color: var(--sev-low); }
+.sev-tab-info     { color: var(--sev-info); }
+.sev-tab-active {
+  background: rgba(0,229,153,0.10);
+  border-color: rgba(0,229,153,0.4);
+  color: var(--brand);
+}
+.sev-tab-active.sev-tab-critical { background: var(--sev-critical-bg); border-color: rgba(248,81,73,0.4); color: var(--sev-critical); }
+.sev-tab-active.sev-tab-high     { background: var(--sev-high-bg);     border-color: rgba(219,109,40,0.4); color: var(--sev-high); }
+.sev-tab-active.sev-tab-medium   { background: var(--sev-medium-bg);   border-color: rgba(210,153,34,0.4); color: var(--sev-medium); }
+.sev-tab-active.sev-tab-low      { background: var(--sev-low-bg);      border-color: rgba(88,166,255,0.4); color: var(--sev-low); }
+.sev-tab-active.sev-tab-info     { background: var(--sev-info-bg);     border-color: rgba(139,148,158,0.4); color: var(--sev-info); }
+
+/* --- Filter strip (chips + add + save-view) ----------------------- */
+.filter-strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 0 0 12px;
+  padding: 8px 0;
+  border-top: 1px solid var(--ink-700);
+}
+.filter-strip-chips {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.filter-strip-chips:empty + .filter-add-btn { margin-left: 0; }
+.filter-strip-spacer { flex: 1; }
+.filter-add-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 9999px;
+  background: transparent;
+  border: 1px dashed var(--ink-600);
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+}
+.filter-add-btn:hover { color: var(--text-primary); border-color: var(--brand); }
+
+.save-view-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 9999px;
+  background: var(--ink-700);
+  border: 1px solid var(--ink-600);
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  line-height: 1.4;
+}
+.save-view-pill.empty { color: var(--text-muted); cursor: default; }
+.save-view-pill.saved { color: var(--brand); border-color: rgba(0,229,153,0.4); }
+.save-view-pill:hover.saved { background: rgba(0,229,153,0.08); }
+
+/* --- Filter menu / submenu (popup) -------------------------------- */
+.filter-menu {
+  background: var(--ink-800);
+  border: 1px solid var(--ink-600);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+  padding: 4px;
+  min-width: 180px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+.filter-submenu { min-width: 220px; }
+.filter-menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  padding: 6px 10px;
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+}
+.filter-menu-item:hover { background: var(--ink-700); }
+.filter-menu-divider { height: 1px; margin: 4px 0; background: var(--ink-700); }
+.filter-menu-reset { color: var(--text-muted); }
+.filter-menu-reset:hover { color: var(--text-primary); }
+.filter-menu-empty {
+  padding: 10px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.filter-menu-search {
+  display: block;
+  width: calc(100% - 8px);
+  margin: 4px;
+  padding: 6px 8px;
+  background: var(--ink-900);
+  border: 1px solid var(--ink-600);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 13px;
+}
+.filter-menu-list { max-height: 220px; overflow-y: auto; }
+.filter-menu-apply {
+  margin-top: 4px;
+  background: rgba(0,229,153,0.10);
+  color: var(--brand);
+  text-align: center;
+}
+
+/* --- Findings table — checkbox column + selected row highlight --- */
+.fnd-cb-col {
+  width: 32px;
+  padding-left: 8px !important;
+  padding-right: 4px !important;
+}
+.fnd-checkbox, #findings-select-all,
+.tgt-checkbox, #targets-select-all {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: var(--brand);
+}
+.fnd-row-selected { background: rgba(0,229,153,0.06); }
+.fnd-row-selected:hover { background: rgba(0,229,153,0.14); }
+.tgt-row-selected { background: rgba(0,229,153,0.06); }
+.tgt-row-selected:hover { background: rgba(0,229,153,0.14); }
+
+/* --- Pagination (light) ------------------------------------------- */
+.pagination {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  align-items: center;
+  margin-top: 16px;
+}
+.pagination .text-muted { padding: 0 8px; font-size: 12px; }
+
+/* --- Mobile / small viewports ------------------------------------- */
+@media (max-width: 768px) {
+  .sev-tabs,
+  .filter-strip-chips {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+  .fnd-cb-col { width: 24px; padding-left: 4px !important; }
+  .bulk-bar {
+    overflow-x: auto;
+    max-width: calc(100% - 16px);
+  }
+}

--- a/internal/webui/static/js/pages/findings.js
+++ b/internal/webui/static/js/pages/findings.js
@@ -1,322 +1,745 @@
-// Findings page — grouped-by-host default, toggle to raw per-asset view.
-// PR4 (#37): rows open a slide-over instead of a detail page. The deep
-// link #/findings/{id} renders the list and opens the panel on top.
+// Findings page — UI v2 (PR5 #38).
+//
+// Layout above the list (raw view):
+//   1. Severity tabs (pills, single-select including "All").
+//   2. Filter chip strip — every active non-severity filter is a chip with
+//      a ✕ button. "+ Filter" opens a popup menu to add one. "Save view"
+//      is a status pill (decorative + Reset).
+//   3. Bulk-bar (Components.bulkBar) — visible when selectedIds.size > 0.
+//   4. Table with a leading checkbox column.
+//
+// Filters auto-persist to localStorage (key `surfbot_findings_filters`).
+// URL hash params win over storage so deep links from dashboard chips
+// stay deterministic.
+//
+// Slide-over (PR4 #37) is preserved verbatim — row click still opens the
+// detail panel; checkbox stops propagation so it doesn't trigger.
 const FindingsPage = {
-  // _slide is the live slide-over handle while open, null otherwise.
-  // _lastTrigger is the row element that opened it — focus returns there
-  // on close so keyboard operators don't lose their place.
+  STORAGE_KEY: 'surfbot_findings_filters',
+  STORAGE_VERSION: 1,
+
+  // Selection state. Persists across pagination but resets on filter change.
+  // Module-level Set so #_renderList() can read/write across re-renders.
+  _selectedIds: new Set(),
+
+  // Slide-over state (PR4).
   _slide: null,
   _lastTrigger: null,
   _abortCtrl: null,
   _statusToPill: { open: 'open', acknowledged: 'ack', resolved: 'resolved', false_positive: 'fp', ignored: 'ignored' },
 
+  // Active "+ Filter" menu element (so we close on outside click before
+  // mounting a new one).
+  _filterMenu: null,
+
+  // Cache of /overview severity counts for the tab labels. Refreshed
+  // whenever the list re-renders; falls back to 0 on fetch failure.
+  _sevCounts: null,
+
+  // Targets & list data — kept on the page so submenu/bulk handlers
+  // can reach the most recent fetch without threading them through every
+  // helper.
+  _lastFindings: [],
+  _lastTargets: [],
+
   async render(app, params) {
-    // PR4: deep link #/findings/{id} renders the list, then opens the
-    // panel. Legacy ?view=raw&host=…&template_id=… still routes to the
-    // raw list (no slide-over auto-open).
-    const view = params?.view || 'grouped';
-    let listPromise;
-    if (view === 'grouped') {
-      listPromise = this.renderGrouped(app, params);
-    } else {
-      listPromise = this.renderRaw(app, params);
-    }
-    await listPromise;
+    // PR5: list always uses the "raw" data shape — chips and bulk
+    // operations need per-finding rows. The legacy grouped view is
+    // removed in favor of the new layout. Deep link #/findings/{id}
+    // still renders the list and opens the panel on top.
+    const merged = this._mergeFiltersWithStorage(params);
+    await this._renderList(app, merged);
     if (params && params.id) {
-      // After the list paints, open the slide-over on top.
       this.openSlideoverFor(params.id);
     }
   },
 
-  // --- Grouped view (default) ---
+  // Merge URL params with localStorage. URL wins so deep links
+  // (`#/findings?status=open` from dashboard chips) override prior state.
+  // When the URL has no filter params at all, restore from storage and
+  // rewrite the hash so refreshes are stable.
+  _mergeFiltersWithStorage(params) {
+    const p = Object.assign({}, params || {});
+    const filterKeys = ['severity', 'status', 'host', 'tool', 'target_id', 'template_id'];
+    const hasURLFilter = filterKeys.some(k => p[k]);
+    if (hasURLFilter) return p;
 
-  async renderGrouped(app, params) {
+    const stored = this._loadStored();
+    if (!stored) return p;
+    let restored = false;
+    for (const k of filterKeys) {
+      if (stored[k]) { p[k] = stored[k]; restored = true; }
+    }
+    if (restored) {
+      const q = filterKeys.filter(k => p[k]).map(k => k + '=' + encodeURIComponent(p[k]));
+      if (p.page) q.push('page=' + p.page);
+      const newHash = '#/findings' + (q.length ? '?' + q.join('&') : '');
+      if (location.hash !== newHash) {
+        history.replaceState(null, '', newHash);
+      }
+    }
+    return p;
+  },
+
+  _loadStored() {
+    try {
+      const raw = localStorage.getItem(this.STORAGE_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (!parsed || parsed.version !== this.STORAGE_VERSION) return null;
+      return parsed.filters || {};
+    } catch (_) { return null; }
+  },
+
+  _saveStored(filters) {
+    try {
+      localStorage.setItem(this.STORAGE_KEY, JSON.stringify({
+        version: this.STORAGE_VERSION,
+        filters: filters,
+        savedAt: new Date().toISOString(),
+      }));
+    } catch (_) { /* quota / private mode — silently ignore */ }
+  },
+
+  _clearStored() {
+    try { localStorage.removeItem(this.STORAGE_KEY); } catch (_) {}
+  },
+
+  // _persistFromParams writes the canonical filter set to storage. Called
+  // after every filter mutation so a refresh reapplies the last state.
+  _persistFromParams(params) {
+    const filterKeys = ['severity', 'status', 'host', 'tool', 'target_id', 'template_id'];
+    const filters = {};
+    for (const k of filterKeys) if (params[k]) filters[k] = params[k];
+    this._saveStored(filters);
+  },
+
+  // --- List render ------------------------------------------------
+
+  async _renderList(app, params) {
     app.innerHTML = '<div class="loading">Loading findings...</div>';
     try {
-      const data = await API.findingsGrouped({
-        severity: params?.severity,
-        tool: params?.tool,
-        host: params?.host,
-        sort: params?.sort || 'last_seen',
-        page: params?.page || 1,
-        limit: 50,
-      });
-      app.innerHTML = this.groupedTemplate(data, params);
+      const [data, overview, targetsResp] = await Promise.all([
+        API.findings({
+          severity: params.severity,
+          tool: params.tool,
+          status: params.status,
+          target_id: params.target_id,
+          host: params.host,
+          template_id: params.template_id,
+          page: params.page || 1,
+          limit: 50,
+        }),
+        API.overview().catch(() => null),
+        API.targets().catch(() => ({ targets: [] })),
+      ]);
+      this._sevCounts = (overview && overview.findings_by_severity) || {};
+      this._lastFindings = data.findings || [];
+      this._lastTargets = (targetsResp && targetsResp.targets) || [];
+      app.innerHTML = this._listTemplate(data, params);
+      this._wireListInteractions(app, params);
     } catch (err) {
       app.innerHTML = Components.emptyState('Error', 'Failed to load findings: ' + err.message);
     }
   },
 
-  groupedTemplate(data, params) {
-    if (data.groups.length === 0 && !params?.severity && !params?.host) {
+  _listTemplate(data, params) {
+    if (data.findings.length === 0 && !this._anyFilter(params)) {
       return `
         <div class="page-header"><h2>Findings</h2></div>
-        ${this.viewToggle('grouped')}
         ${Components.emptyState('No findings', 'No vulnerabilities detected. Run a scan to discover findings.')}
       `;
     }
 
-    // Single-finding groups skip the raw-filtered drill: the row opens
-    // the slide-over directly using finding_ids[0]. Multi-asset groups
-    // still drill — picking which port/asset is meaningful when N>1.
-    const rows = data.groups.map(g => {
-      const badge = g.affected_assets_count > 1
-        ? `<span class="port-badge">${g.affected_assets_count} ports</span>`
-        : '';
-      const single = g.affected_assets_count === 1
-        && Array.isArray(g.finding_ids) && g.finding_ids.length === 1;
-      let onclick;
-      if (single) {
-        onclick = `FindingsPage.handleGroupedRowClick(event, '${escapeHtml(g.finding_ids[0])}')`;
-      } else {
-        const drillHref = '#/findings?view=raw&host=' + encodeURIComponent(g.host)
-          + '&template_id=' + encodeURIComponent(g.template_id);
-        onclick = `location.hash='${drillHref}'`;
-      }
-      const dataAttr = single ? ` data-finding-id="${escapeHtml(g.finding_ids[0])}"` : '';
+    const totalPages = Math.ceil(data.total / data.limit);
+    const page = data.page;
+
+    return `
+      <div class="page-header">
+        <h2>Findings</h2>
+        <p>${data.total} finding${data.total !== 1 ? 's' : ''}${params.severity ? ' (' + params.severity + ')' : ''}</p>
+      </div>
+      ${this._severityTabsHtml(params)}
+      ${this._chipStripHtml(params)}
+      <div data-bulk-slot>${Components.bulkBar({ count: this._selectedIds.size, actions: this._bulkActionDescriptors() })}</div>
+      ${this._tableHtml(data.findings)}
+      ${totalPages > 1 ? this._paginationHtml(page, totalPages, params) : ''}
+    `;
+  },
+
+  _anyFilter(params) {
+    return !!(params.severity || params.status || params.host || params.tool || params.target_id || params.template_id);
+  },
+
+  _severityTabsHtml(params) {
+    const counts = this._sevCounts || {};
+    const total = Object.values(counts).reduce((a, b) => a + (b || 0), 0);
+    const levels = [
+      { key: '',         label: 'All',  count: total },
+      { key: 'critical', label: 'Crit', count: counts.critical || 0 },
+      { key: 'high',     label: 'High', count: counts.high || 0 },
+      { key: 'medium',   label: 'Med',  count: counts.medium || 0 },
+      { key: 'low',      label: 'Low',  count: counts.low || 0 },
+      { key: 'info',     label: 'Info', count: counts.info || 0 },
+    ];
+    const active = params.severity || '';
+    const tabs = levels.map(l => {
+      const isActive = (l.key === active);
+      const cls = 'sev-tab' + (l.key ? ' sev-tab-' + l.key : ' sev-tab-all') + (isActive ? ' sev-tab-active' : '');
+      return `<button type="button" class="${cls}" role="tab" aria-selected="${isActive}" data-sev="${escapeHtml(l.key)}">
+        ${l.key ? '<span class="sev-tab-dot"></span>' : ''}${escapeHtml(l.label)}<span class="sev-tab-count">${l.count}</span>
+      </button>`;
+    }).join('');
+    return `<div class="sev-tabs" role="tablist" aria-label="Filter by severity">${tabs}</div>`;
+  },
+
+  _chipStripHtml(params) {
+    const chips = [];
+    const labels = {
+      status: { Open: 'open', Acknowledged: 'acknowledged', Resolved: 'resolved', 'False positive': 'false_positive', Ignored: 'ignored' },
+    };
+    if (params.status) chips.push({ key: 'status', label: 'Status: ' + this._humanStatus(params.status) });
+    if (params.target_id) {
+      const t = this._lastTargets.find(t => t.id === params.target_id);
+      chips.push({ key: 'target_id', label: 'Target: ' + (t ? t.value : params.target_id) });
+    }
+    if (params.tool) chips.push({ key: 'tool', label: 'Tool: ' + params.tool });
+    if (params.host) chips.push({ key: 'host', label: 'Host: ' + params.host });
+    if (params.template_id) chips.push({ key: 'template_id', label: 'Template: ' + params.template_id });
+
+    const chipMounts = chips.map((c, i) =>
+      `<span class="filter-chip-mount" data-chip-idx="${i}" data-chip-key="${c.key}" data-chip-label="${escapeHtml(c.label)}"></span>`
+    ).join('');
+
+    const saveLabel = chips.length || params.severity ? 'View saved' : 'Save view';
+    const saveCls = 'save-view-pill' + (chips.length || params.severity ? ' saved' : ' empty');
+    const checkIcon = chips.length || params.severity ? Components.icon('check', 14) : '';
+    void labels;
+
+    return `<div class="filter-strip" role="group" aria-label="Active filters">
+      <div class="filter-strip-chips" data-chip-strip>${chipMounts}</div>
+      <button type="button" class="filter-add-btn" data-add-filter>
+        ${Components.icon('plus', 14)}<span>Filter</span>
+      </button>
+      <span class="filter-strip-spacer"></span>
+      <button type="button" class="${saveCls}" data-save-view>${checkIcon}<span>${saveLabel}</span></button>
+    </div>`;
+  },
+
+  _tableHtml(findings) {
+    if (!findings || findings.length === 0) {
+      return `<div class="table-container"><table>
+        <thead><tr>
+          <th class="fnd-cb-col"><input type="checkbox" disabled aria-label="Select all (no findings)" /></th>
+          <th>Severity</th><th>Title</th><th>Asset</th><th>Tool</th><th>Status</th><th>Last Seen</th>
+        </tr></thead>
+        <tbody><tr><td colspan="7" class="empty-state">No findings match the current filters.</td></tr></tbody>
+      </table></div>`;
+    }
+
+    const rows = findings.map(f => {
+      const sel = this._selectedIds.has(f.id);
+      const selCls = sel ? ' fnd-row-selected' : '';
       return `
-        <tr class="clickable"${dataAttr} onclick="${onclick}">
-          <td>${Components.severityBadge(g.severity)}</td>
-          <td class="text-truncate">${escapeHtml(g.title)} ${badge}</td>
-          <td class="mono">${escapeHtml(g.host)}</td>
-          <td class="mono">${escapeHtml(g.source_tool)}</td>
-          <td class="mono text-muted">${Components.timeAgo(g.last_seen)}</td>
+        <tr class="fnd-row clickable${selCls}" data-finding-id="${escapeHtml(f.id)}" onclick="FindingsPage.handleRowClick(event, '${escapeHtml(f.id)}')">
+          <td class="fnd-cb-col" onclick="event.stopPropagation()">
+            <input type="checkbox" class="fnd-checkbox" value="${escapeHtml(f.id)}" ${sel ? 'checked' : ''}
+              aria-label="Select finding ${escapeHtml(f.title || f.id)}"
+              onclick="event.stopPropagation(); FindingsPage.onCheckboxChange(this)" />
+          </td>
+          <td>${Components.severityPill(f.severity)}</td>
+          <td class="text-truncate">${escapeHtml(f.title)}</td>
+          <td class="mono text-truncate">${escapeHtml(f.asset_value || f.evidence || '')}</td>
+          <td class="mono">${escapeHtml(f.source_tool)}</td>
+          <td data-row-status>${Components.statusPill(this._statusToPill[f.status] || 'open')}</td>
+          <td class="mono text-muted">${Components.timeAgo(f.last_seen)}</td>
         </tr>
       `;
     }).join('');
 
-    const totalPages = Math.ceil(data.total / data.limit);
-    const page = data.page;
-
-    return `
-      <div class="page-header">
-        <h2>Findings</h2>
-        <p>${data.total} unique finding${data.total !== 1 ? 's' : ''}${params?.severity ? ' (' + params.severity + ')' : ''}</p>
-      </div>
-      ${this.viewToggle('grouped')}
-      ${this.groupedFiltersHtml(params)}
-      ${Components.table(['Severity', 'Title', 'Host', 'Tool', 'Last Seen'], [rows])}
-      ${totalPages > 1 ? this.paginationHtml(page, totalPages, params) : ''}
-    `;
+    return `<div class="table-container"><table>
+      <thead><tr>
+        <th class="fnd-cb-col">
+          <input type="checkbox" id="findings-select-all" aria-label="Select all visible findings" />
+        </th>
+        <th scope="col">Severity</th>
+        <th scope="col">Title</th>
+        <th scope="col">Asset</th>
+        <th scope="col">Tool</th>
+        <th scope="col">Status</th>
+        <th scope="col">Last Seen</th>
+      </tr></thead>
+      <tbody>${rows}</tbody>
+    </table></div>`;
   },
 
-  groupedFiltersHtml(params) {
-    const sev = params?.severity || '';
-    const host = params?.host || '';
-    return `<div class="filters">
-      <select class="filter-select" id="filter-severity" onchange="FindingsPage.applyFilters()">
-        <option value="">All severities</option>
-        <option value="critical" ${sev==='critical'?'selected':''}>Critical</option>
-        <option value="high" ${sev==='high'?'selected':''}>High</option>
-        <option value="medium" ${sev==='medium'?'selected':''}>Medium</option>
-        <option value="low" ${sev==='low'?'selected':''}>Low</option>
-        <option value="info" ${sev==='info'?'selected':''}>Info</option>
-      </select>
-      <input class="filter-input" id="filter-host" placeholder="Filter by host..." value="${escapeHtml(host)}"
-        onkeydown="if(event.key==='Enter')FindingsPage.applyFilters()" />
-    </div>`;
-  },
-
-  // --- Raw view (per-asset findings) ---
-
-  async renderRaw(app, params) {
-    app.innerHTML = '<div class="loading">Loading findings...</div>';
-    try {
-      const data = await API.findings({
-        severity: params?.severity,
-        tool: params?.tool,
-        status: params?.status,
-        target_id: params?.target_id,
-        scan_id: params?.scan_id,
-        host: params?.host,
-        template_id: params?.template_id,
-        page: params?.page || 1,
-        limit: 50,
-      });
-      app.innerHTML = this.rawTemplate(data, params);
-    } catch (err) {
-      app.innerHTML = Components.emptyState('Error', 'Failed to load findings: ' + err.message);
-    }
-  },
-
-  rawTemplate(data, params) {
-    if (data.findings.length === 0 && !params?.severity && !params?.status) {
-      return `
-        <div class="page-header"><h2>Findings</h2></div>
-        ${this.viewToggle('raw')}
-        ${Components.emptyState('No findings', 'No vulnerabilities detected. Run a scan to discover findings.')}
-      `;
-    }
-
-    // PR4: row click opens slide-over. Inline event.target check stops
-    // the click from firing when the operator is clicking the inline
-    // status <select>. data-finding-id lets the row stash its id without
-    // re-encoding the string into the onclick attribute.
-    const rows = data.findings.map(f => `
-      <tr class="clickable" data-finding-id="${escapeHtml(f.id)}" onclick="FindingsPage.handleRowClick(event, '${escapeHtml(f.id)}')">
-        <td>${Components.severityBadge(f.severity)}</td>
-        <td class="text-truncate">${escapeHtml(f.title)}</td>
-        <td class="mono text-truncate">${escapeHtml(f.evidence || '')}</td>
-        <td class="mono">${escapeHtml(f.source_tool)}</td>
-        <td>
-          <select class="status-select status-${f.status}" onchange="FindingsPage.changeStatus('${f.id}', this.value, this)" data-original="${f.status}">
-            <option value="open" ${f.status==='open'?'selected':''}>open</option>
-            <option value="acknowledged" ${f.status==='acknowledged'?'selected':''}>acknowledged</option>
-            <option value="resolved" ${f.status==='resolved'?'selected':''}>resolved</option>
-            <option value="false_positive" ${f.status==='false_positive'?'selected':''}>false positive</option>
-            <option value="ignored" ${f.status==='ignored'?'selected':''}>ignored</option>
-          </select>
-        </td>
-        <td class="mono text-muted">${Components.timeAgo(f.last_seen)}</td>
-      </tr>
-    `).join('');
-
-    const totalPages = Math.ceil(data.total / data.limit);
-    const page = data.page;
-
-    return `
-      <div class="page-header">
-        <h2>Findings</h2>
-        <p>${data.total} finding${data.total !== 1 ? 's' : ''}${params?.severity ? ' (' + params.severity + ')' : ''}</p>
-      </div>
-      ${this.viewToggle('raw')}
-      ${this.rawFiltersHtml(params)}
-      ${Components.table(['Severity', 'Title', 'Asset', 'Tool', 'Status', 'Last Seen'], [rows])}
-      ${totalPages > 1 ? this.paginationHtml(page, totalPages, params) : ''}
-    `;
-  },
-
-  rawFiltersHtml(params) {
-    const sev = params?.severity || '';
-    const status = params?.status || '';
-    return `<div class="filters">
-      <select class="filter-select" id="filter-severity" onchange="FindingsPage.applyFilters()">
-        <option value="">All severities</option>
-        <option value="critical" ${sev==='critical'?'selected':''}>Critical</option>
-        <option value="high" ${sev==='high'?'selected':''}>High</option>
-        <option value="medium" ${sev==='medium'?'selected':''}>Medium</option>
-        <option value="low" ${sev==='low'?'selected':''}>Low</option>
-        <option value="info" ${sev==='info'?'selected':''}>Info</option>
-      </select>
-      <select class="filter-select" id="filter-status" onchange="FindingsPage.applyFilters()">
-        <option value="">All statuses</option>
-        <option value="open" ${status==='open'?'selected':''}>Open</option>
-        <option value="acknowledged" ${status==='acknowledged'?'selected':''}>Acknowledged</option>
-        <option value="resolved" ${status==='resolved'?'selected':''}>Resolved</option>
-        <option value="false_positive" ${status==='false_positive'?'selected':''}>False Positive</option>
-        <option value="ignored" ${status==='ignored'?'selected':''}>Ignored</option>
-      </select>
-    </div>`;
-  },
-
-  // --- View toggle ---
-
-  viewToggle(active) {
-    const groupedCls = active === 'grouped' ? 'btn-accent' : 'btn-ghost';
-    const rawCls = active === 'raw' ? 'btn-accent' : 'btn-ghost';
-    return `<div class="view-toggle" style="margin-bottom:12px;display:flex;gap:8px">
-      <button class="btn btn-sm ${groupedCls}" onclick="FindingsPage.switchView('grouped')">Group by host</button>
-      <button class="btn btn-sm ${rawCls}" onclick="FindingsPage.switchView('raw')">Show all</button>
-    </div>`;
-  },
-
-  switchView(view) {
-    const params = parseQueryParams();
-    const q = ['view=' + view];
-    if (params.severity) q.push('severity=' + params.severity);
-    const newHash = '#/findings?' + q.join('&');
-    if (location.hash === newHash) {
-      Router.navigate();
-    } else {
-      location.hash = newHash;
-    }
-  },
-
-  // --- Shared helpers ---
-
-  applyFilters() {
-    const severity = document.getElementById('filter-severity')?.value || '';
-    const status = document.getElementById('filter-status')?.value || '';
-    const host = document.getElementById('filter-host')?.value || '';
-    const params = parseQueryParams();
-    const view = params.view || 'grouped';
-    const q = ['view=' + view];
-    if (severity) q.push('severity=' + severity);
-    if (status) q.push('status=' + status);
-    if (host) q.push('host=' + host);
-    location.hash = '#/findings?' + q.join('&');
-  },
-
-  paginationHtml(page, totalPages, params) {
-    let html = '<div style="display:flex;gap:8px;justify-content:center;margin-top:16px">';
+  _paginationHtml(page, totalPages, params) {
+    let html = '<div class="pagination">';
     if (page > 1) {
-      html += `<button class="refresh-btn" onclick="FindingsPage.goToPage(${page-1})">Prev</button>`;
+      html += `<button class="btn btn-ghost btn-sm" onclick="FindingsPage.goToPage(${page-1})">Prev</button>`;
     }
-    html += `<span class="text-muted" style="padding:4px 8px">Page ${page} of ${totalPages}</span>`;
+    html += `<span class="text-muted">Page ${page} of ${totalPages}</span>`;
     if (page < totalPages) {
-      html += `<button class="refresh-btn" onclick="FindingsPage.goToPage(${page+1})">Next</button>`;
+      html += `<button class="btn btn-ghost btn-sm" onclick="FindingsPage.goToPage(${page+1})">Next</button>`;
     }
     html += '</div>';
     return html;
   },
 
-  goToPage(page) {
-    const hash = location.hash;
-    const base = hash.split('?')[0];
-    const params = parseQueryParams();
-    params.page = page;
-    const q = Object.entries(params).filter(([,v]) => v).map(([k,v]) => k+'='+v).join('&');
-    location.hash = base + (q ? '?' + q : '');
+  // --- Wiring ----------------------------------------------------
+
+  _wireListInteractions(app, params) {
+    // Severity tabs.
+    app.querySelectorAll('[data-sev]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const sev = btn.getAttribute('data-sev') || '';
+        this._mutateFilter({ severity: sev || null });
+      });
+    });
+
+    // Render filter chips into their mount slots so onRemove handlers
+    // are wired without delegation.
+    app.querySelectorAll('.filter-chip-mount').forEach(slot => {
+      const key = slot.getAttribute('data-chip-key');
+      const label = slot.getAttribute('data-chip-label');
+      const chip = Components.filterChip(label, () => this._mutateFilter({ [key]: null }));
+      slot.replaceWith(chip);
+    });
+
+    // "+ Filter" menu.
+    const addBtn = app.querySelector('[data-add-filter]');
+    if (addBtn) addBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this._openFilterMenu(addBtn, params);
+    });
+
+    // Save-view pill: opens menu with Reset filters when filters are
+    // active, decorative-only when the list is unfiltered.
+    const saveBtn = app.querySelector('[data-save-view]');
+    if (saveBtn && !saveBtn.classList.contains('empty')) {
+      saveBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this._openSaveMenu(saveBtn);
+      });
+    }
+
+    // Header select-all checkbox.
+    const selAll = app.querySelector('#findings-select-all');
+    if (selAll) {
+      this._syncSelectAllState(selAll);
+      selAll.addEventListener('click', () => this.toggleAll(selAll.checked));
+    }
+
+    // Bulk-bar action buttons (read descriptors from this._bulkActionDescriptors).
+    this._wireBulkBarActions(app);
   },
 
-  async changeStatus(id, newStatus, selectEl) {
-    const original = selectEl.dataset.original;
-    try {
-      await API.updateFindingStatus(id, newStatus);
-      selectEl.dataset.original = newStatus;
-      selectEl.className = 'status-select status-' + newStatus;
-      // Refresh the sidebar findings count after a status flip — open
-      // ↔ non-open transitions are exactly what the badge tracks.
-      if (typeof loadSidebarBadge === 'function') loadSidebarBadge();
-    } catch (err) {
-      selectEl.value = original;
-      Components.toast.error('Failed to update status: ' + err.message);
+  _wireBulkBarActions(app) {
+    const bar = app.querySelector('[data-bulk-slot] .bulk-bar');
+    if (!bar) return;
+    const descriptors = this._bulkActionDescriptors();
+    bar.querySelectorAll('[data-bulk-action]').forEach(btn => {
+      const i = parseInt(btn.getAttribute('data-bulk-action'), 10);
+      const a = descriptors[i];
+      if (!a || typeof a.onClick !== 'function') return;
+      btn.addEventListener('click', () => a.onClick());
+    });
+  },
+
+  _bulkActionDescriptors() {
+    return [
+      { label: 'Acknowledge',    onClick: () => this.bulkApplyStatus('acknowledged') },
+      { label: 'Resolve',        onClick: () => this.bulkApplyStatus('resolved') },
+      { label: 'False positive', onClick: () => this.bulkApplyStatus('false_positive') },
+      { label: 'Ignore',         onClick: () => this.bulkApplyStatus('ignored') },
+      { label: 'Clear',          onClick: () => this.clearSelection() },
+    ];
+  },
+
+  // --- Filter mutation ---
+
+  // _mutateFilter is the single entry point for any chip add/remove or
+  // tab change. Patches the current params, persists, resets selection
+  // (filter change invalidates which IDs were "visible"), and rewrites
+  // the hash so the back button rewinds to the previous state.
+  _mutateFilter(patch) {
+    this.clearSelection({ rerender: false });
+    const params = parseQueryParams();
+    delete params.id; // never carry slide-over id forward
+    delete params.view; // legacy grouped view dropped
+    Object.assign(params, patch);
+    // Drop nulled-out keys so empty values don't pollute the hash.
+    Object.keys(params).forEach(k => { if (params[k] == null || params[k] === '') delete params[k]; });
+    delete params.page; // filter change always resets pagination
+    this._persistFromParams(params);
+    const q = Object.entries(params).map(([k, v]) => k + '=' + encodeURIComponent(v)).join('&');
+    location.hash = '#/findings' + (q ? '?' + q : '');
+  },
+
+  // --- "+ Filter" menu --------------------------------------------
+
+  _openFilterMenu(anchor, params) {
+    this._closeFilterMenu();
+    const menu = document.createElement('div');
+    menu.className = 'filter-menu';
+    menu.setAttribute('role', 'menu');
+
+    const items = [];
+    if (!params.status)      items.push({ key: 'status',      label: 'Status' });
+    if (!params.target_id)   items.push({ key: 'target_id',   label: 'Target' });
+    if (!params.tool)        items.push({ key: 'tool',        label: 'Tool' });
+    if (!params.host)        items.push({ key: 'host',        label: 'Host' });
+    if (!params.template_id) items.push({ key: 'template_id', label: 'Template' });
+    items.push({ key: '__reset__', label: 'Reset filters', divider: true });
+
+    menu.innerHTML = items.map(it => {
+      if (it.divider) return `<div class="filter-menu-divider"></div>
+        <button type="button" class="filter-menu-item filter-menu-reset" data-mi-key="${it.key}" role="menuitem">${escapeHtml(it.label)}</button>`;
+      return `<button type="button" class="filter-menu-item" data-mi-key="${it.key}" role="menuitem">${escapeHtml(it.label)}</button>`;
+    }).join('');
+
+    document.body.appendChild(menu);
+    this._positionMenu(menu, anchor);
+    this._filterMenu = menu;
+
+    menu.querySelectorAll('[data-mi-key]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const k = btn.getAttribute('data-mi-key');
+        if (k === '__reset__') {
+          this._closeFilterMenu();
+          this.resetAllFilters();
+          return;
+        }
+        this._closeFilterMenu();
+        this._openFilterSubmenu(anchor, k);
+      });
+    });
+
+    setTimeout(() => {
+      document.addEventListener('click', this._onMenuOutside);
+      document.addEventListener('keydown', this._onMenuKey);
+    }, 0);
+  },
+
+  _openFilterSubmenu(anchor, key) {
+    this._closeFilterMenu();
+    const menu = document.createElement('div');
+    menu.className = 'filter-menu filter-submenu';
+    menu.setAttribute('role', 'menu');
+
+    if (key === 'status') {
+      const opts = [
+        ['open', 'Open'], ['acknowledged', 'Acknowledged'],
+        ['resolved', 'Resolved'], ['false_positive', 'False positive'], ['ignored', 'Ignored'],
+      ];
+      menu.innerHTML = opts.map(([v, l]) =>
+        `<button type="button" class="filter-menu-item" data-mi-pick="${v}" role="menuitem">${escapeHtml(l)}</button>`
+      ).join('');
+    } else if (key === 'target_id') {
+      const targets = this._lastTargets || [];
+      menu.innerHTML = `<input type="text" class="filter-menu-search" placeholder="Search targets…" aria-label="Search targets" />
+        <div class="filter-menu-list" data-target-list>
+          ${targets.map(t => `<button type="button" class="filter-menu-item" data-mi-pick="${escapeHtml(t.id)}" data-mi-text="${escapeHtml(t.value)}" role="menuitem">${escapeHtml(t.value)}</button>`).join('')}
+        </div>`;
+    } else if (key === 'tool') {
+      const tools = Array.from(new Set((this._lastFindings || []).map(f => f.source_tool).filter(Boolean))).sort();
+      if (!tools.length) {
+        menu.innerHTML = `<div class="filter-menu-empty">No tools in current view.</div>`;
+      } else {
+        menu.innerHTML = tools.map(t =>
+          `<button type="button" class="filter-menu-item" data-mi-pick="${escapeHtml(t)}" role="menuitem">${escapeHtml(t)}</button>`
+        ).join('');
+      }
+    } else if (key === 'host') {
+      menu.innerHTML = `<input type="text" class="filter-menu-search" placeholder="Host (e.g. api.example.com)" aria-label="Filter by host" />
+        <button type="button" class="filter-menu-item filter-menu-apply" role="menuitem">Apply</button>`;
+    } else if (key === 'template_id') {
+      const tmpls = Array.from(new Set((this._lastFindings || []).map(f => f.template_id).filter(Boolean))).sort();
+      if (!tmpls.length) {
+        menu.innerHTML = `<div class="filter-menu-empty">No template IDs in current view.</div>`;
+      } else {
+        menu.innerHTML = tmpls.map(t =>
+          `<button type="button" class="filter-menu-item" data-mi-pick="${escapeHtml(t)}" role="menuitem">${escapeHtml(t)}</button>`
+        ).join('');
+      }
+    }
+
+    document.body.appendChild(menu);
+    this._positionMenu(menu, anchor);
+    this._filterMenu = menu;
+
+    menu.querySelectorAll('[data-mi-pick]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        this._closeFilterMenu();
+        this._mutateFilter({ [key]: btn.getAttribute('data-mi-pick') });
+      });
+    });
+
+    // Host text input: enter / Apply applies the value.
+    const search = menu.querySelector('.filter-menu-search');
+    if (search) {
+      search.focus();
+      if (key === 'host') {
+        const apply = () => {
+          const v = search.value.trim();
+          if (!v) return;
+          this._closeFilterMenu();
+          this._mutateFilter({ host: v });
+        };
+        search.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); apply(); } });
+        const applyBtn = menu.querySelector('.filter-menu-apply');
+        if (applyBtn) applyBtn.addEventListener('click', apply);
+      } else if (key === 'target_id') {
+        // Live filter the target list as the user types.
+        search.addEventListener('input', () => {
+          const q = search.value.toLowerCase();
+          menu.querySelectorAll('[data-mi-pick]').forEach(btn => {
+            const txt = (btn.getAttribute('data-mi-text') || '').toLowerCase();
+            btn.style.display = (!q || txt.includes(q)) ? '' : 'none';
+          });
+        });
+      }
+    }
+
+    setTimeout(() => {
+      document.addEventListener('click', this._onMenuOutside);
+      document.addEventListener('keydown', this._onMenuKey);
+    }, 0);
+  },
+
+  _onMenuOutside: (e) => {
+    const menu = FindingsPage._filterMenu;
+    if (!menu) return;
+    if (menu.contains(e.target)) return;
+    FindingsPage._closeFilterMenu();
+  },
+
+  _onMenuKey: (e) => {
+    if (e.key === 'Escape') FindingsPage._closeFilterMenu();
+  },
+
+  _closeFilterMenu() {
+    if (this._filterMenu) {
+      this._filterMenu.remove();
+      this._filterMenu = null;
+    }
+    document.removeEventListener('click', this._onMenuOutside);
+    document.removeEventListener('keydown', this._onMenuKey);
+  },
+
+  _positionMenu(menu, anchor) {
+    const r = anchor.getBoundingClientRect();
+    menu.style.position = 'fixed';
+    menu.style.top = (r.bottom + 4) + 'px';
+    menu.style.left = r.left + 'px';
+    menu.style.zIndex = 100;
+  },
+
+  // --- Save-view menu ---------------------------------------------
+
+  _openSaveMenu(anchor) {
+    this._closeFilterMenu();
+    const menu = document.createElement('div');
+    menu.className = 'filter-menu';
+    menu.setAttribute('role', 'menu');
+    menu.innerHTML = `<button type="button" class="filter-menu-item filter-menu-reset" role="menuitem" data-mi-reset>Reset filters</button>`;
+    document.body.appendChild(menu);
+    this._positionMenu(menu, anchor);
+    this._filterMenu = menu;
+    menu.querySelector('[data-mi-reset]').addEventListener('click', () => {
+      this._closeFilterMenu();
+      this.resetAllFilters();
+    });
+    setTimeout(() => {
+      document.addEventListener('click', this._onMenuOutside);
+      document.addEventListener('keydown', this._onMenuKey);
+    }, 0);
+  },
+
+  resetAllFilters() {
+    this._clearStored();
+    this.clearSelection({ rerender: false });
+    location.hash = '#/findings';
+  },
+
+  // --- Bulk select ------------------------------------------------
+
+  // onCheckboxChange — called from the per-row checkbox onclick. Reads
+  // .checked off the input directly so we don't have to hunt up the
+  // value via dataset on every render.
+  onCheckboxChange(input) {
+    const id = input.value;
+    if (input.checked) this._selectedIds.add(id);
+    else this._selectedIds.delete(id);
+    this._refreshBulkBar();
+    this._refreshRowHighlight(id, input.checked);
+    const selAll = document.getElementById('findings-select-all');
+    if (selAll) this._syncSelectAllState(selAll);
+  },
+
+  toggleAll(checked) {
+    document.querySelectorAll('.fnd-checkbox').forEach(cb => {
+      cb.checked = checked;
+      const id = cb.value;
+      if (checked) this._selectedIds.add(id);
+      else this._selectedIds.delete(id);
+      this._refreshRowHighlight(id, checked);
+    });
+    this._refreshBulkBar();
+  },
+
+  clearSelection(opts) {
+    this._selectedIds.clear();
+    if (!opts || opts.rerender !== false) {
+      document.querySelectorAll('.fnd-checkbox').forEach(cb => { cb.checked = false; });
+      document.querySelectorAll('.fnd-row').forEach(r => r.classList.remove('fnd-row-selected'));
+      this._refreshBulkBar();
+      const selAll = document.getElementById('findings-select-all');
+      if (selAll) this._syncSelectAllState(selAll);
     }
   },
 
-  // --- Slide-over (PR4 #37) ----------------------------------------
+  _refreshRowHighlight(id, selected) {
+    const row = document.querySelector(`tr.fnd-row[data-finding-id="${cssAttrEscape(id)}"]`);
+    if (row) row.classList.toggle('fnd-row-selected', selected);
+  },
+
+  _syncSelectAllState(el) {
+    const visible = Array.from(document.querySelectorAll('.fnd-checkbox'));
+    if (visible.length === 0) {
+      el.checked = false;
+      el.indeterminate = false;
+      return;
+    }
+    const checkedCount = visible.filter(cb => cb.checked).length;
+    if (checkedCount === 0) { el.checked = false; el.indeterminate = false; }
+    else if (checkedCount === visible.length) { el.checked = true; el.indeterminate = false; }
+    else { el.checked = false; el.indeterminate = true; }
+  },
+
+  _refreshBulkBar() {
+    const slot = document.querySelector('[data-bulk-slot]');
+    if (!slot) return;
+    slot.innerHTML = Components.bulkBar({
+      count: this._selectedIds.size,
+      actions: this._bulkActionDescriptors(),
+    });
+    this._wireBulkBarActions(document);
+  },
+
+  // --- Bulk apply -------------------------------------------------
+
+  async bulkApplyStatus(newStatus) {
+    const ids = Array.from(this._selectedIds);
+    const total = ids.length;
+    if (total === 0) return;
+
+    // Resolve / FP confirm modals — both are "completed" terminal states
+    // and harder to undo than ack/ignore. Compute severity breakdown from
+    // the rows the user can see (good enough — selectedIds always come
+    // from the current page).
+    if (newStatus === 'resolved' || newStatus === 'false_positive') {
+      const breakdown = this._severityBreakdown(ids);
+      const ok = await Components.confirmDialog({
+        title: newStatus === 'resolved' ? 'Mark as resolved?' : 'Mark as false positive?',
+        message: this._buildBulkConfirmMessage(total, newStatus, breakdown),
+        confirmLabel: 'Confirm',
+      });
+      if (!ok) return;
+    }
+
+    const results = await Promise.allSettled(
+      ids.map(id => API.updateFindingStatus(id, newStatus))
+    );
+    const failed = [];
+    results.forEach((r, i) => { if (r.status === 'rejected') failed.push(ids[i]); });
+
+    if (failed.length === 0) {
+      Components.toast.success(`${total} finding${total !== 1 ? 's' : ''} updated to ${this._humanStatus(newStatus)}`);
+      ids.forEach(id => this._updateRowStatus(id, newStatus));
+      this._selectedIds.clear();
+      this._refreshBulkBar();
+      const selAll = document.getElementById('findings-select-all');
+      if (selAll) this._syncSelectAllState(selAll);
+      if (typeof loadSidebarBadge === 'function') loadSidebarBadge();
+    } else {
+      Components.toast.error(`${failed.length}/${total} failed to update. Selection retained for retry.`);
+      // Successful ones still patch the row UI; retain failures only.
+      ids.forEach(id => {
+        if (!failed.includes(id)) this._updateRowStatus(id, newStatus);
+      });
+      this._selectedIds = new Set(failed);
+      // Rebuild the visible checked state to match the new selection set.
+      document.querySelectorAll('.fnd-checkbox').forEach(cb => {
+        const sel = this._selectedIds.has(cb.value);
+        cb.checked = sel;
+        this._refreshRowHighlight(cb.value, sel);
+      });
+      this._refreshBulkBar();
+      if (typeof loadSidebarBadge === 'function') loadSidebarBadge();
+    }
+  },
+
+  _severityBreakdown(ids) {
+    const counts = {};
+    ids.forEach(id => {
+      const f = (this._lastFindings || []).find(x => x.id === id);
+      if (!f) return;
+      counts[f.severity] = (counts[f.severity] || 0) + 1;
+    });
+    return counts;
+  },
+
+  _buildBulkConfirmMessage(total, status, breakdown) {
+    const order = ['critical', 'high', 'medium', 'low', 'info'];
+    const parts = order.filter(s => breakdown[s] > 0).map(s => `${breakdown[s]} ${s}`);
+    const suffix = parts.length ? ` This affects: ${parts.join(', ')}.` : '';
+    const verb = status === 'resolved' ? 'resolved' : 'false positive';
+    return `Mark ${total} finding${total !== 1 ? 's' : ''} as ${verb}?${suffix}`;
+  },
+
+  _updateRowStatus(id, newStatus) {
+    const row = document.querySelector(`tr.fnd-row[data-finding-id="${cssAttrEscape(id)}"]`);
+    if (!row) return;
+    const cell = row.querySelector('[data-row-status]');
+    if (cell) cell.innerHTML = Components.statusPill(this._statusToPill[newStatus] || 'open');
+    // Mirror to the in-memory cache so a follow-up bulk action sees the
+    // current status without a re-fetch.
+    const f = (this._lastFindings || []).find(x => x.id === id);
+    if (f) f.status = newStatus;
+  },
+
+  _humanStatus(s) {
+    return ({
+      open: 'Open', acknowledged: 'Acknowledged', resolved: 'Resolved',
+      false_positive: 'False positive', ignored: 'Ignored',
+    })[s] || s;
+  },
+
+  // --- Pagination -------------------------------------------------
+
+  goToPage(page) {
+    const params = parseQueryParams();
+    params.page = page;
+    delete params.id;
+    const q = Object.entries(params).filter(([, v]) => v != null && v !== '').map(([k, v]) => k + '=' + encodeURIComponent(v)).join('&');
+    location.hash = '#/findings' + (q ? '?' + q : '');
+  },
+
+  // --- Slide-over (PR4 #37) — preserved verbatim ------------------
 
   // handleRowClick is the click handler for raw-view <tr>s. It guards
-  // against firing when the operator clicked the inline status <select>
-  // or any other interactive element nested in the row.
+  // against firing when the operator clicked the inline checkbox or any
+  // other interactive element nested in the row.
   handleRowClick(evt, id) {
     const t = evt.target;
-    const tag = t && t.tagName;
-    if (tag === 'SELECT' || tag === 'OPTION' || tag === 'INPUT' ||
-        tag === 'BUTTON' || tag === 'A') return;
-    this._lastTrigger = evt.currentTarget;
-    // Setting hash drives the open via Router's findings transition
-    // detector — keeps Back-button semantics aligned with the panel.
-    location.hash = '#/findings/' + encodeURIComponent(id);
-  },
-
-  // handleGroupedRowClick is the equivalent for the grouped view when
-  // the group has a single underlying finding. Multi-asset groups keep
-  // the drill-through to the raw-filtered list because picking the
-  // port/asset is the meaningful next step there.
-  handleGroupedRowClick(evt, id) {
+    if (t && t.closest && t.closest('input, button, a, .fnd-cb-col')) return;
     this._lastTrigger = evt.currentTarget;
     location.hash = '#/findings/' + encodeURIComponent(id);
   },
 
-  // openSlideoverFor is the entry point used by both the row click and
-  // the deep-link route. It mounts the panel with a skeleton, fetches
-  // the finding, and replaces the body. AbortController guards against
-  // a stale render when the operator clicks a different row mid-fetch.
   async openSlideoverFor(id) {
     if (this._slide) {
-      // Already open on a different finding: tear down the old panel
-      // before mounting a new one so the focus-return pointer is fresh.
       this._slide.close('replace');
       this._slide = null;
     }
@@ -335,17 +758,12 @@ const FindingsPage = {
       onClose: (reason) => {
         this._slide = null;
         if (this._abortCtrl) { this._abortCtrl.abort(); this._abortCtrl = null; }
-        // Focus return to the row that opened the panel — keyboard
-        // operators rely on this to keep their place in the list.
         if (trigger && document.body.contains(trigger)) {
           try { trigger.focus(); } catch (_) {}
         }
-        // Strip the /{id} segment from the hash so reopening from
-        // history doesn't immediately re-mount the panel. Skip the
-        // cleanup when 'replace' (we're swapping for another finding).
         if (reason !== 'replace' && /^#\/findings\/[^?]+/.test(location.hash)) {
           const params = parseQueryParams();
-          const q = Object.entries(params).filter(([,v]) => v != null && v !== '').map(([k,v]) => k+'='+v).join('&');
+          const q = Object.entries(params).filter(([,v]) => v != null && v !== '').map(([k,v]) => k+'='+encodeURIComponent(v)).join('&');
           history.replaceState(null, '', '#/findings' + (q ? '?' + q : ''));
         }
       },
@@ -356,15 +774,11 @@ const FindingsPage = {
       data = await API.finding(id);
     } catch (err) {
       if (ctrl.signal.aborted) return;
-      // 404: the finding does not exist (or was deleted). Close the
-      // panel, surface a non-blocking toast, and clean the URL so a
-      // refresh does not loop on the same error.
       if (err.status === 404) {
         if (this._slide) this._slide.close('not-found');
         Components.toast.error('Finding ' + id + ' not found');
         history.replaceState(null, '', '#/findings');
       } else {
-        // 5xx or network: leave the panel open and offer a retry.
         bodyEl.innerHTML = `<div class="so-empty">Failed to load finding.<br>
           <button class="btn btn-ghost btn-sm" style="margin-top:12px"
             onclick="FindingsPage.openSlideoverFor('${escapeHtml(id)}')">Retry</button></div>`;
@@ -384,10 +798,6 @@ const FindingsPage = {
     </div>`;
   },
 
-  // _renderSlideoverBody builds the full panel interior: header pills +
-  // title + asset, action bar, tab strip, and the four tab panels. The
-  // panel content all comes from the single GET /findings/{id} call —
-  // tab switches do not re-fetch.
   _renderSlideoverBody(root, f, asset) {
     root.innerHTML = `
       ${this._headerHtml(f, asset)}
@@ -402,9 +812,6 @@ const FindingsPage = {
     this._wireActions(root, f);
     this._wireCopyButtons(root, f, asset);
     this._wireRemediationCopy(root, f);
-    // Update the panel title for screen readers — the helper builds
-    // .slide-over-title from the title arg of slideOver({title:…}); we
-    // patch it post-mount with the real finding title.
     if (this._slide && this._slide.root) {
       const titleEl = this._slide.root.querySelector('.slide-over-title');
       if (titleEl) titleEl.textContent = f.title || 'Finding';
@@ -438,9 +845,6 @@ const FindingsPage = {
   },
 
   _actionBarHtml(f) {
-    // Visibility matrix per status — see issue #37 P0.4. Map button
-    // class hints to so-action-* modifiers so the colors match status
-    // tokens without restating them in the call site.
     const matrix = {
       open:           [['acknowledged','Acknowledge','ack'], ['resolved','Mark resolved','resolved'], ['false_positive','False positive',''], ['ignored','Ignore','']],
       acknowledged:   [['resolved','Mark resolved','resolved'], ['open','Reopen','reopen'], ['false_positive','False positive','']],
@@ -458,8 +862,6 @@ const FindingsPage = {
   },
 
   _tabsHtml() {
-    // Comments tab is intentionally absent (#37 Non-goals #4). aria-
-    // selected is updated by _wireTabs on activation.
     return `<div class="so-tabs" role="tablist" aria-label="Finding sections">
       <button type="button" class="so-tab tab-active" id="so-tab-overview" role="tab" aria-selected="true" aria-controls="so-panel-overview" data-tab="overview">Overview</button>
       <button type="button" class="so-tab" id="so-tab-evidence" role="tab" aria-selected="false" aria-controls="so-panel-evidence" data-tab="evidence">Evidence</button>
@@ -494,13 +896,11 @@ const FindingsPage = {
         bar.querySelectorAll('[data-set-status]').forEach(b => { b.disabled = true; });
         try {
           await API.updateFindingStatus(f.id, newStatus);
-          // 1. Mutate the local model and refresh in-place: header pill
-          //    + action bar + the row in the list behind. No re-fetch.
           f.status = newStatus;
           this._refreshHeaderStatusPill(root, newStatus);
           bar.outerHTML = this._actionBarHtml(f);
           this._wireActions(root, f);
-          this._refreshListRow(f.id, newStatus);
+          this._updateRowStatus(f.id, newStatus);
           if (typeof loadSidebarBadge === 'function') loadSidebarBadge();
         } catch (err) {
           Components.toast.error('Failed to update status: ' + err.message);
@@ -514,24 +914,9 @@ const FindingsPage = {
     const row = root.querySelector('.so-pillrow');
     if (!row) return;
     const pillKey = this._statusToPill[status] || 'open';
-    // Status pill is the second .pill in the header row.
     const pills = row.querySelectorAll('.pill');
     if (pills.length >= 2) {
       pills[1].outerHTML = Components.statusPill(pillKey);
-    }
-  },
-
-  _refreshListRow(id, newStatus) {
-    // The list lives outside the panel. Find the <tr> by its
-    // data-finding-id and patch the inline <select> + the className
-    // tokens that drive the pill color.
-    const row = document.querySelector(`tr[data-finding-id="${cssAttrEscape(id)}"]`);
-    if (!row) return;
-    const sel = row.querySelector('.status-select');
-    if (sel) {
-      sel.value = newStatus;
-      sel.dataset.original = newStatus;
-      sel.className = 'status-select status-' + newStatus;
     }
   },
 
@@ -568,10 +953,9 @@ const FindingsPage = {
     });
   },
 
-  // --- Tab content ------------------------------------------------
+  // --- Tab content (PR4) ------------------------------------------
 
   _overviewHtml(f) {
-    // CVSS card. Range → token. Empty / 0 → em-dash.
     let cvssCard;
     if (!f.cvss || f.cvss <= 0) {
       cvssCard = this._cardHtml('CVSS 3.1', '<span class="so-card-value-empty">—</span>', '');
@@ -583,15 +967,10 @@ const FindingsPage = {
       else if (f.cvss >= 4.0) { sev = 'medium'; label = 'Medium'; }
       cvssCard = this._cardHtml('CVSS 3.1', `<span class="so-card-value sev-${sev}">${score}</span>`, label);
     }
-
-    // Confidence card.
     const conf = (f.confidence == null || f.confidence === 0)
       ? '<span class="so-card-value-empty">—</span>'
       : `<span class="so-card-value">${Math.round(f.confidence)}%</span>`;
     const confCard = this._cardHtml('Confidence', conf, '');
-
-    // EPSS column omitted (model.Finding has no EPSS field — see #37
-    // Non-goals #6). Two cards collapse to a 2-col grid.
     const cards = `<div class="so-cards" style="--so-card-cols:2">${cvssCard}${confCard}</div>`;
 
     const description = f.description
@@ -603,9 +982,6 @@ const FindingsPage = {
 
     const refs = this._referencesHtml(f);
 
-    // Metadata footer (template + first/last seen) — the wireframe
-    // collapses the legacy detail-grid into a smaller card. Useful for
-    // operators who want the canonical IDs at a glance.
     const meta = `<div class="so-section">
       <h3 class="so-section-label">Details</h3>
       <ul class="so-list" style="list-style:none;padding-left:0">
@@ -638,8 +1014,6 @@ const FindingsPage = {
         } else if (/^https?:\/\//i.test(String(r))) {
           items.push({ kind: 'url', value: String(r) });
         } else if (cveMatch) {
-          // Mixed string with a CVE id inside — render the CVE link plus
-          // a stripped-text remainder as plain.
           items.push({ kind: 'cve', value: cveMatch[0] });
         } else {
           items.push({ kind: 'text', value: String(r) });
@@ -661,11 +1035,7 @@ const FindingsPage = {
   _evidenceHtml(f) {
     const raw = f.evidence;
     if (!raw) return '<div class="so-empty">No evidence captured.</div>';
-
     const trimmed = String(raw).trim();
-
-    // 1. JSON shape: try to parse; if it has request/response keys use
-    //    the dual-block format, otherwise pretty-print the object.
     if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
       try {
         const obj = JSON.parse(trimmed);
@@ -678,8 +1048,6 @@ const FindingsPage = {
         </div>`;
       } catch (_) { /* fallthrough */ }
     }
-
-    // 2. Plain text — preformatted with a header label.
     return `<div class="so-section">
       <h3 class="so-section-label">Evidence</h3>
       <pre class="so-evidence">${escapeHtml(String(raw))}</pre>
@@ -704,12 +1072,8 @@ const FindingsPage = {
   _remediationHtml(f) {
     const body = f.remediation;
     if (!body) return '<div class="so-empty">No remediation steps documented.</div>';
-
-    // Numbered-list parser: if every non-empty line starts with "1." /
-    // "2)" / etc., render as <ol>. Otherwise prose.
     const lines = String(body).split(/\r?\n/).map(s => s.trim()).filter(Boolean);
     const allNumbered = lines.length > 1 && lines.every(l => /^\d+[.)]\s+/.test(l));
-
     let bodyHtml;
     if (allNumbered) {
       const items = lines.map(l => l.replace(/^\d+[.)]\s+/, '')).map(l =>
@@ -727,17 +1091,11 @@ const FindingsPage = {
     </div>`;
   },
 
-  // _inlineCode escapes HTML and then promotes single-backtick spans to
-  // <code> — a deliberate ASCII-only mini parser, NOT markdown. Run on
-  // already-escaped text so the regex never sees raw HTML.
   _inlineCode(text) {
     return escapeHtml(text).replace(/`([^`]+)`/g, (_m, g) => `<code>${g}</code>`);
   },
 
   _timelineHtml(f) {
-    // Events derive from the model — there is no finding_status_history
-    // table yet (see #37 P2.1). resolved_at is the only status-related
-    // event we can reliably show.
     const events = [];
     if (f.created_at) {
       const scanShort = (f.first_seen_scan_id || f.scan_id || '').slice(0, 8);
@@ -765,8 +1123,6 @@ const FindingsPage = {
     </div>`;
   },
 
-  // closeSlideover is invoked by app.js when the hash transitions away
-  // from #/findings/{id} (back button, manual edit, etc.). Idempotent.
   closeSlideover() {
     if (this._slide) {
       this._slide.close('hashchange');

--- a/internal/webui/static/js/pages/scans.js
+++ b/internal/webui/static/js/pages/scans.js
@@ -2,6 +2,17 @@
 const ScansPage = {
   pollTimer: null,
 
+  // PR5 (#38): scans list adds status tabs + filter chips (target /
+  // template / range). Bulk actions are explicitly out of scope; the
+  // backend doesn't yet accept template_id or range params either, so
+  // those filters are applied client-side over the fetched page.
+  STORAGE_KEY: 'surfbot_scans_filters',
+  STORAGE_VERSION: 1,
+  _filterMenu: null,
+  _filters: { status: '', target_id: '', template_id: '', range: '' },
+  _allScans: [],
+  _allTargets: [],
+
   async render(app, params) {
     if (params && params.id) {
       return this.renderDetail(app, params.id);
@@ -10,11 +21,20 @@ const ScansPage = {
     app.innerHTML = '<div class="loading">Loading scans...</div>';
 
     try {
+      this._restoreFilters();
+      // Apply URL params on top of stored — deep links win.
+      if (params) {
+        ['status', 'target_id', 'template_id', 'range'].forEach(k => {
+          if (params[k]) this._filters[k] = params[k];
+        });
+      }
       const [scansData, statusData, targetsData] = await Promise.all([
-        API.scans({ limit: 50 }),
+        API.scans(this._backendParamsForScans()),
         API.scanStatus(),
         API.targets(),
       ]);
+      this._allScans = scansData.scans || [];
+      this._allTargets = (targetsData && targetsData.targets) || [];
       app.innerHTML = this.template(scansData, statusData, targetsData);
       this.bindEvents(app, targetsData);
 
@@ -24,6 +44,63 @@ const ScansPage = {
       }
     } catch (err) {
       app.innerHTML = Components.emptyState('Error', 'Failed to load scans: ' + err.message);
+    }
+  },
+
+  // _backendParamsForScans returns only the params the /scans endpoint
+  // actually accepts. template_id and range are filtered client-side
+  // (P0.7 backend gap noted in #38).
+  _backendParamsForScans() {
+    const p = { limit: 50 };
+    if (this._filters.target_id) p.target_id = this._filters.target_id;
+    return p;
+  },
+
+  _restoreFilters() {
+    try {
+      const raw = localStorage.getItem(this.STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (!parsed || parsed.version !== this.STORAGE_VERSION) return;
+      Object.assign(this._filters, parsed.filters || {});
+    } catch (_) {}
+  },
+
+  _persistFilters() {
+    try {
+      localStorage.setItem(this.STORAGE_KEY, JSON.stringify({
+        version: this.STORAGE_VERSION,
+        filters: this._filters,
+        savedAt: new Date().toISOString(),
+      }));
+    } catch (_) {}
+  },
+
+  // _applyClientFilters narrows the backend response by the chips that
+  // /scans doesn't natively support: status (tab), template_id, range.
+  _applyClientFilters(scans) {
+    let out = scans || [];
+    if (this._filters.status) out = out.filter(s => s.status === this._filters.status);
+    if (this._filters.template_id) out = out.filter(s => s.template_id === this._filters.template_id);
+    if (this._filters.range) {
+      const since = this._rangeToSinceMs(this._filters.range);
+      if (since != null) {
+        out = out.filter(s => {
+          const t = new Date(s.started_at || s.created_at).getTime();
+          return !isNaN(t) && t >= since;
+        });
+      }
+    }
+    return out;
+  },
+
+  _rangeToSinceMs(range) {
+    const now = Date.now();
+    switch (range) {
+      case '24h': return now - 24 * 3600 * 1000;
+      case '7d':  return now - 7 * 24 * 3600 * 1000;
+      case '30d': return now - 30 * 24 * 3600 * 1000;
+      default:    return null;
     }
   },
 
@@ -94,7 +171,11 @@ const ScansPage = {
       `;
     }
 
-    const rows = data.scans.map(s => {
+    const filtered = this._applyClientFilters(data.scans);
+    const tabsHtml = this._statusTabsHtml(data.scans);
+    const stripHtml = this._chipStripHtml();
+
+    const rows = filtered.map(s => {
       let dur = '-';
       if (s.started_at && s.finished_at) {
         dur = Components.formatDuration(Math.floor((new Date(s.finished_at) - new Date(s.started_at)) / 1000));
@@ -112,18 +193,80 @@ const ScansPage = {
       `;
     }).join('');
 
+    const filteredCount = filtered.length;
+    const totalCount = data.scans.length;
+    const counterText = (filteredCount === totalCount)
+      ? `${data.total} total scans`
+      : `${filteredCount} shown of ${totalCount} loaded · ${data.total} total`;
+
     return `
       <div class="page-header">
         <h2>Scans</h2>
-        <p>${data.total} total scans</p>
+        <p>${counterText}</p>
       </div>
       ${scanForm}
       ${activeBanner}
-      ${Components.table(['ID', 'Target', 'Status', 'Type', 'Duration', 'Results', 'Date'], [rows])}
+      ${tabsHtml}
+      ${stripHtml}
+      ${filteredCount === 0
+        ? `<div class="table-container"><table>
+            <thead><tr><th>ID</th><th>Target</th><th>Status</th><th>Type</th><th>Duration</th><th>Results</th><th>Date</th></tr></thead>
+            <tbody><tr><td colspan="7" class="empty-state">No scans match the current filters.</td></tr></tbody>
+          </table></div>`
+        : Components.table(['ID', 'Target', 'Status', 'Type', 'Duration', 'Results', 'Date'], [rows])}
     `;
   },
 
+  _statusTabsHtml(allScans) {
+    const counts = { running: 0, completed: 0, cancelled: 0, failed: 0 };
+    (allScans || []).forEach(s => { if (counts[s.status] != null) counts[s.status]++; });
+    const total = (allScans || []).length;
+    const tabs = [
+      { key: '',          label: 'All',       count: total },
+      { key: 'running',   label: 'Running',   count: counts.running },
+      { key: 'completed', label: 'Completed', count: counts.completed },
+      { key: 'cancelled', label: 'Cancelled', count: counts.cancelled },
+      { key: 'failed',    label: 'Failed',    count: counts.failed },
+    ];
+    const active = this._filters.status || '';
+    return `<div class="sev-tabs" role="tablist" aria-label="Filter by status">
+      ${tabs.map(t => {
+        const isActive = t.key === active;
+        const cls = 'sev-tab' + (isActive ? ' sev-tab-active' : '');
+        return `<button type="button" class="${cls}" role="tab" aria-selected="${isActive}" data-scan-status="${escapeHtml(t.key)}">
+          ${escapeHtml(t.label)}<span class="sev-tab-count">${t.count}</span>
+        </button>`;
+      }).join('')}
+    </div>`;
+  },
+
+  _chipStripHtml() {
+    const f = this._filters;
+    const chips = [];
+    if (f.target_id) {
+      const t = this._allTargets.find(x => x.id === f.target_id);
+      chips.push({ key: 'target_id', label: 'Target: ' + (t ? t.value : f.target_id) });
+    }
+    if (f.template_id) chips.push({ key: 'template_id', label: 'Template: ' + f.template_id });
+    if (f.range) chips.push({ key: 'range', label: 'Range: ' + f.range });
+
+    const chipMounts = chips.map((c, i) =>
+      `<span class="filter-chip-mount" data-chip-idx="${i}" data-chip-key="${c.key}" data-chip-label="${escapeHtml(c.label)}"></span>`
+    ).join('');
+
+    return `<div class="filter-strip" role="group" aria-label="Active scan filters">
+      <div class="filter-strip-chips">${chipMounts}</div>
+      <button type="button" class="filter-add-btn" data-add-filter>
+        ${Components.icon('plus', 14)}<span>Filter</span>
+      </button>
+    </div>`;
+  },
+
   bindEvents(app, targetsData) {
+    // Status tabs + filter chips first — these must wire even when the
+    // page renders without #new-scan-form (no targets configured).
+    this._wireFilterUI(app);
+
     const form = document.getElementById('new-scan-form');
     if (!form) return;
 
@@ -165,6 +308,159 @@ const ScansPage = {
         btn.textContent = 'Start Scan';
       }
     });
+  },
+
+  // _wireFilterUI binds status tab clicks, chip removal, and the
+  // "+ Filter" menu. Mounted via bindEvents so it runs after every
+  // template re-render.
+  _wireFilterUI(app) {
+    app.querySelectorAll('[data-scan-status]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        this._filters.status = btn.getAttribute('data-scan-status') || '';
+        this._persistFilters();
+        ScansPage.render(app);
+      });
+    });
+
+    app.querySelectorAll('.filter-chip-mount').forEach(slot => {
+      const key = slot.getAttribute('data-chip-key');
+      const label = slot.getAttribute('data-chip-label');
+      const chip = Components.filterChip(label, () => {
+        this._filters[key] = '';
+        this._persistFilters();
+        ScansPage.render(app);
+      });
+      slot.replaceWith(chip);
+    });
+
+    const addBtn = app.querySelector('[data-add-filter]');
+    if (addBtn) {
+      addBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this._openFilterMenu(addBtn, app);
+      });
+    }
+  },
+
+  _openFilterMenu(anchor, app) {
+    this._closeFilterMenu();
+    const menu = document.createElement('div');
+    menu.className = 'filter-menu';
+    menu.setAttribute('role', 'menu');
+    const items = [];
+    if (!this._filters.target_id)   items.push({ key: 'target_id',   label: 'Target' });
+    if (!this._filters.template_id) items.push({ key: 'template_id', label: 'Template' });
+    if (!this._filters.range)       items.push({ key: 'range',       label: 'Range' });
+    items.push({ key: '__reset__', label: 'Reset filters', divider: true });
+    menu.innerHTML = items.map(it => {
+      if (it.divider) return `<div class="filter-menu-divider"></div>
+        <button type="button" class="filter-menu-item filter-menu-reset" data-mi-key="${it.key}" role="menuitem">${escapeHtml(it.label)}</button>`;
+      return `<button type="button" class="filter-menu-item" data-mi-key="${it.key}" role="menuitem">${escapeHtml(it.label)}</button>`;
+    }).join('');
+    document.body.appendChild(menu);
+    this._positionMenu(menu, anchor);
+    this._filterMenu = menu;
+    menu.querySelectorAll('[data-mi-key]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const k = btn.getAttribute('data-mi-key');
+        this._closeFilterMenu();
+        if (k === '__reset__') {
+          this._filters = { status: '', target_id: '', template_id: '', range: '' };
+          try { localStorage.removeItem(this.STORAGE_KEY); } catch (_) {}
+          ScansPage.render(app);
+          return;
+        }
+        this._openFilterSubmenu(anchor, k, app);
+      });
+    });
+    setTimeout(() => {
+      document.addEventListener('click', this._onMenuOutside);
+      document.addEventListener('keydown', this._onMenuKey);
+    }, 0);
+  },
+
+  _openFilterSubmenu(anchor, key, app) {
+    this._closeFilterMenu();
+    const menu = document.createElement('div');
+    menu.className = 'filter-menu filter-submenu';
+    menu.setAttribute('role', 'menu');
+
+    if (key === 'target_id') {
+      const targets = this._allTargets || [];
+      menu.innerHTML = `<input type="text" class="filter-menu-search" placeholder="Search targets…" aria-label="Search targets" />
+        <div class="filter-menu-list">
+          ${targets.map(t => `<button type="button" class="filter-menu-item" data-mi-pick="${escapeHtml(t.id)}" data-mi-text="${escapeHtml(t.value)}" role="menuitem">${escapeHtml(t.value)}</button>`).join('')}
+        </div>`;
+    } else if (key === 'template_id') {
+      const tmpls = Array.from(new Set((this._allScans || []).map(s => s.template_id).filter(Boolean))).sort();
+      menu.innerHTML = tmpls.length
+        ? tmpls.map(t => `<button type="button" class="filter-menu-item" data-mi-pick="${escapeHtml(t)}" role="menuitem">${escapeHtml(t)}</button>`).join('')
+        : `<div class="filter-menu-empty">No template IDs in current view.</div>`;
+    } else if (key === 'range') {
+      const opts = [['24h', 'Last 24 hours'], ['7d', 'Last 7 days'], ['30d', 'Last 30 days']];
+      menu.innerHTML = opts.map(([v, l]) =>
+        `<button type="button" class="filter-menu-item" data-mi-pick="${v}" role="menuitem">${escapeHtml(l)}</button>`
+      ).join('');
+    }
+
+    document.body.appendChild(menu);
+    this._positionMenu(menu, anchor);
+    this._filterMenu = menu;
+
+    menu.querySelectorAll('[data-mi-pick]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        this._closeFilterMenu();
+        this._filters[key] = btn.getAttribute('data-mi-pick');
+        this._persistFilters();
+        ScansPage.render(app);
+      });
+    });
+
+    const search = menu.querySelector('.filter-menu-search');
+    if (search) {
+      search.focus();
+      if (key === 'target_id') {
+        search.addEventListener('input', () => {
+          const q = search.value.toLowerCase();
+          menu.querySelectorAll('[data-mi-pick]').forEach(btn => {
+            const txt = (btn.getAttribute('data-mi-text') || '').toLowerCase();
+            btn.style.display = (!q || txt.includes(q)) ? '' : 'none';
+          });
+        });
+      }
+    }
+    setTimeout(() => {
+      document.addEventListener('click', this._onMenuOutside);
+      document.addEventListener('keydown', this._onMenuKey);
+    }, 0);
+  },
+
+  _onMenuOutside: (e) => {
+    const menu = ScansPage._filterMenu;
+    if (!menu) return;
+    if (menu.contains(e.target)) return;
+    ScansPage._closeFilterMenu();
+  },
+
+  _onMenuKey: (e) => {
+    if (e.key === 'Escape') ScansPage._closeFilterMenu();
+  },
+
+  _closeFilterMenu() {
+    if (this._filterMenu) {
+      this._filterMenu.remove();
+      this._filterMenu = null;
+    }
+    document.removeEventListener('click', this._onMenuOutside);
+    document.removeEventListener('keydown', this._onMenuKey);
+  },
+
+  _positionMenu(menu, anchor) {
+    const r = anchor.getBoundingClientRect();
+    menu.style.position = 'fixed';
+    menu.style.top = (r.bottom + 4) + 'px';
+    menu.style.left = r.left + 'px';
+    menu.style.zIndex = 100;
   },
 
   async loadToolCheckboxes() {

--- a/internal/webui/static/js/pages/scans.js
+++ b/internal/webui/static/js/pages/scans.js
@@ -2,6 +2,13 @@
 const ScansPage = {
   pollTimer: null,
 
+  // Set of tool_run.id values whose pipeline-detail accordion is open.
+  // Survives the 3s polling re-render of the scan detail page so the
+  // user's expansion stays put. Keyed by id (not idx) because the sort
+  // by started_at can re-order running tools as new started_at values
+  // come in.
+  _openToolRunIds: new Set(),
+
   // PR5 (#38): scans list adds status tabs + filter chips (target /
   // template / range). Bulk actions are explicitly out of scope; the
   // backend doesn't yet accept template_id or range params either, so
@@ -684,7 +691,10 @@ const ScansPage = {
       // Providing a hint chevron makes the affordance discoverable.
       const hasLogs = this.toolRunHasLogs(tr);
 
-      return `<div class="pipeline-node ${statusClass}${hasLogs ? ' pipeline-node-clickable' : ''}" data-tr-idx="${i}"${hasLogs ? ' title="Click to view logs"' : ''}>
+      const trID = tr.id || '';
+      const isOpen = hasLogs && trID && this._openToolRunIds.has(trID);
+      const nodeClasses = `pipeline-node ${statusClass}${hasLogs ? ' pipeline-node-clickable' : ''}${isOpen ? ' pipeline-node-open' : ''}`;
+      return `<div class="${nodeClasses}" data-tr-idx="${i}" data-tr-id="${escapeHtml(trID)}"${hasLogs ? ' title="Click to view logs"' : ''}>
         <div class="pipeline-connector">
           <div class="pipeline-dot"></div>
           ${isLast ? '' : '<div class="pipeline-vline"></div>'}
@@ -698,7 +708,7 @@ const ScansPage = {
             ${hasLogs ? '<span class="pipeline-chevron text-muted" aria-hidden="true">▸</span>' : ''}
           </div>
           ${stats.length > 0 ? `<div class="pipeline-stats">${stats.join('')}</div>` : ''}
-          ${hasLogs ? `<div class="pipeline-detail" data-tr-idx="${i}" hidden>${this.renderToolRunDetail(tr)}</div>` : ''}
+          ${hasLogs ? `<div class="pipeline-detail" data-tr-idx="${i}" data-tr-id="${escapeHtml(trID)}"${isOpen ? '' : ' hidden'}>${this.renderToolRunDetail(tr)}</div>` : ''}
         </div>
       </div>`;
     }).join('');
@@ -789,21 +799,27 @@ const ScansPage = {
 
   // bindPipelineAccordion wires click handlers on pipeline nodes.
   // Re-invoked after every render (polling re-renders the whole detail)
-  // so listeners are always fresh.
+  // so listeners are always fresh. Open state is persisted in
+  // _openToolRunIds so the accordion stays expanded across re-renders;
+  // the renderPipeline template applies the persisted state during
+  // render, this handler only mutates the Set on click.
   bindPipelineAccordion() {
     document.querySelectorAll('.pipeline-node-clickable').forEach(node => {
       node.addEventListener('click', (e) => {
         if (e.target.closest('a, button')) return;
         const idx = node.dataset.trIdx;
+        const trID = node.dataset.trId || '';
         const detail = node.querySelector(`.pipeline-detail[data-tr-idx="${idx}"]`);
         if (!detail) return;
         const isOpen = !detail.hasAttribute('hidden');
         if (isOpen) {
           detail.setAttribute('hidden', '');
           node.classList.remove('pipeline-node-open');
+          if (trID) this._openToolRunIds.delete(trID);
         } else {
           detail.removeAttribute('hidden');
           node.classList.add('pipeline-node-open');
+          if (trID) this._openToolRunIds.add(trID);
         }
       });
     });
@@ -1295,6 +1311,12 @@ const ScansPage = {
 
   async renderDetail(app, id) {
     this.stopPolling();
+    // New scan: reset accordion open-state so we don't carry stale
+    // tool_run.ids from a different scan into the new render.
+    if (this._openScanID !== id) {
+      this._openToolRunIds.clear();
+      this._openScanID = id;
+    }
     app.innerHTML = '<div class="loading">Loading scan...</div>';
 
     // Reset the main scroll container so navigating between scan details

--- a/internal/webui/static/js/pages/targets.js
+++ b/internal/webui/static/js/pages/targets.js
@@ -1,5 +1,26 @@
-// Targets page (list + detail)
+// Targets page (list + detail).
+//
+// PR5 (#38) adds:
+//   - type tabs (All / Domain / IPv4 / IPv6 / CIDR / etc.) as pills
+//   - live name search (client-side over target.value)
+//   - bulk select with two actions: Run scan, Delete (with confirm)
+//   - row click still navigates to detail; checkbox click stops propagation
 const TargetsPage = {
+  // Persisted across re-renders so paginating or refetching doesn't drop
+  // the operator's selection.
+  _selectedIds: new Set(),
+
+  // Last-fetched data — needed by the bulk handlers + filter handlers
+  // without a re-fetch (no pagination on this page yet).
+  _allTargets: [],
+
+  // Type tab + search filter state. Persisted on every change.
+  _typeFilter: '',
+  _searchTerm: '',
+
+  STORAGE_KEY: 'surfbot_targets_filters',
+  STORAGE_VERSION: 1,
+
   async render(app, params) {
     if (params && params.id) {
       return this.renderDetail(app, params.id);
@@ -9,15 +30,17 @@ const TargetsPage = {
 
     try {
       const data = await API.targets();
-      app.innerHTML = this.template(data);
+      this._allTargets = data.targets || [];
+      this._restoreFilters();
+      app.innerHTML = this.template();
       this.bindEvents(app);
     } catch (err) {
       app.innerHTML = Components.emptyState('Error', 'Failed to load targets: ' + err.message);
     }
   },
 
-  template(data) {
-    const targets = data.targets || [];
+  template() {
+    const targets = this._allTargets || [];
 
     const addForm = `
       <div class="add-form">
@@ -42,73 +65,325 @@ const TargetsPage = {
       `;
     }
 
-    // Rows navigate to the detail view on click. The actions cell stops
-    // propagation per-button so the row-level handler doesn't swallow the
-    // scan/findings/delete clicks.
-    const rows = targets.map(t => `
-      <tr class="clickable" onclick="location.hash='#/targets/${t.id}'">
-        <td class="mono">${escapeHtml(t.value)}</td>
-        <td><span class="badge badge-info">${t.type}</span></td>
-        <td>${t.scope}</td>
-        <td>${t.finding_count}</td>
-        <td>${t.asset_count}</td>
-        <td>${t.scan_count}</td>
-        <td class="text-muted">${t.last_scan_at ? Components.timeAgo(t.last_scan_at) : 'never'}</td>
-        <td>${t.enabled ? '<span style="color:var(--success)">active</span>' : '<span class="text-muted">disabled</span>'}</td>
-        <td class="actions-cell" onclick="event.stopPropagation()">
-          <button class="btn btn-sm btn-accent" onclick="TargetsPage.scanTarget('${t.id}', '${escapeHtml(t.value)}')" title="Scan">
-            <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"/></svg>
-          </button>
-          <button class="btn btn-sm btn-ghost" onclick="TargetsPage.viewFindings('${t.id}')" title="Findings">
-            <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
-          </button>
-          <button class="btn btn-sm btn-danger" onclick="TargetsPage.deleteTarget('${t.id}', '${escapeHtml(t.value)}')" title="Remove">
-            <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
-          </button>
-        </td>
-      </tr>
-    `).join('');
+    const filtered = this._filteredTargets();
+    const typeTabs = this._typeTabsHtml(targets);
+    const searchInput = `<input type="text" class="form-input tgt-search" id="tgt-search-input" placeholder="Filter by name…" value="${escapeHtml(this._searchTerm)}" aria-label="Filter targets by name" />`;
+
+    const rows = filtered.map(t => {
+      const sel = this._selectedIds.has(t.id);
+      const selCls = sel ? ' tgt-row-selected' : '';
+      return `
+        <tr class="tgt-row clickable${selCls}" data-target-id="${escapeHtml(t.id)}" onclick="TargetsPage.handleRowClick(event, '${t.id}')">
+          <td class="fnd-cb-col" onclick="event.stopPropagation()">
+            <input type="checkbox" class="tgt-checkbox" value="${escapeHtml(t.id)}" ${sel ? 'checked' : ''}
+              aria-label="Select target ${escapeHtml(t.value)}"
+              onclick="event.stopPropagation(); TargetsPage.onCheckboxChange(this)" />
+          </td>
+          <td class="mono">${escapeHtml(t.value)}</td>
+          <td><span class="badge badge-info">${escapeHtml(t.type || '')}</span></td>
+          <td>${escapeHtml(t.scope || '')}</td>
+          <td>${t.finding_count}</td>
+          <td>${t.asset_count}</td>
+          <td>${t.scan_count}</td>
+          <td class="text-muted">${t.last_scan_at ? Components.timeAgo(t.last_scan_at) : 'never'}</td>
+          <td>${t.enabled ? '<span style="color:var(--success)">active</span>' : '<span class="text-muted">disabled</span>'}</td>
+          <td class="actions-cell" onclick="event.stopPropagation()">
+            <button class="btn btn-sm btn-accent" onclick="TargetsPage.scanTarget('${t.id}', '${escapeHtml(t.value)}')" title="Scan">
+              <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"/></svg>
+            </button>
+            <button class="btn btn-sm btn-ghost" onclick="TargetsPage.viewFindings('${t.id}')" title="Findings">
+              <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+            </button>
+            <button class="btn btn-sm btn-danger" onclick="TargetsPage.deleteTarget('${t.id}', '${escapeHtml(t.value)}')" title="Remove">
+              <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+            </button>
+          </td>
+        </tr>
+      `;
+    }).join('');
+
+    const tableHtml = filtered.length > 0
+      ? `<div class="table-container"><table>
+          <thead><tr>
+            <th class="fnd-cb-col"><input type="checkbox" id="targets-select-all" aria-label="Select all visible targets" /></th>
+            <th scope="col">Target</th>
+            <th scope="col">Type</th>
+            <th scope="col">Scope</th>
+            <th scope="col">Findings</th>
+            <th scope="col">Assets</th>
+            <th scope="col">Scans</th>
+            <th scope="col">Last Scan</th>
+            <th scope="col">Status</th>
+            <th scope="col" aria-label="actions"></th>
+          </tr></thead>
+          <tbody>${rows}</tbody>
+        </table></div>`
+      : `<div class="table-container"><table>
+          <thead><tr><th class="fnd-cb-col"></th><th>Target</th></tr></thead>
+          <tbody><tr><td colspan="2" class="empty-state">No targets match the current filter.</td></tr></tbody>
+        </table></div>`;
 
     return `
       <div class="page-header">
         <h2>Targets</h2>
-        <p>${targets.length} configured target${targets.length !== 1 ? 's' : ''}</p>
+        <p>${targets.length} configured target${targets.length !== 1 ? 's' : ''}${this._typeFilter || this._searchTerm ? ` · ${filtered.length} shown` : ''}</p>
       </div>
       ${addForm}
-      ${Components.table(
-        ['Target', 'Type', 'Scope', 'Findings', 'Assets', 'Scans', 'Last Scan', 'Status', ''],
-        [rows]
-      )}
+      ${typeTabs}
+      <div class="filter-strip" role="group" aria-label="Targets filter">
+        ${searchInput}
+        <span class="filter-strip-spacer"></span>
+      </div>
+      <div data-bulk-slot>${Components.bulkBar({ count: this._selectedIds.size, actions: this._bulkActionDescriptors() })}</div>
+      ${tableHtml}
     `;
+  },
+
+  // _typeTabsHtml builds the pill-strip with one tab per distinct
+  // target.type plus an "All" leader. Counts come from the full list.
+  _typeTabsHtml(allTargets) {
+    const counts = {};
+    allTargets.forEach(t => {
+      const k = (t.type || '').trim() || 'unknown';
+      counts[k] = (counts[k] || 0) + 1;
+    });
+    const types = Object.keys(counts).sort();
+    const tabs = [{ key: '', label: 'All', count: allTargets.length }]
+      .concat(types.map(t => ({ key: t, label: this._humanType(t), count: counts[t] })));
+    const html = tabs.map(t => {
+      const active = t.key === this._typeFilter;
+      const cls = 'sev-tab' + (active ? ' sev-tab-active' : '');
+      return `<button type="button" class="${cls}" role="tab" aria-selected="${active}" data-tgt-type="${escapeHtml(t.key)}">
+        ${escapeHtml(t.label)}<span class="sev-tab-count">${t.count}</span>
+      </button>`;
+    }).join('');
+    return `<div class="sev-tabs" role="tablist" aria-label="Filter targets by type">${html}</div>`;
+  },
+
+  _humanType(t) {
+    const map = { domain: 'Domain', ipv4: 'IPv4', ipv6: 'IPv6', cidr: 'CIDR', external: 'External', internal: 'Internal' };
+    return map[t] || t.charAt(0).toUpperCase() + t.slice(1);
+  },
+
+  _filteredTargets() {
+    const all = this._allTargets || [];
+    const term = (this._searchTerm || '').toLowerCase();
+    return all.filter(t => {
+      if (this._typeFilter && (t.type || '') !== this._typeFilter) return false;
+      if (term && !(t.value || '').toLowerCase().includes(term)) return false;
+      return true;
+    });
+  },
+
+  _restoreFilters() {
+    try {
+      const raw = localStorage.getItem(this.STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (!parsed || parsed.version !== this.STORAGE_VERSION) return;
+      this._typeFilter = parsed.type || '';
+      this._searchTerm = parsed.search || '';
+    } catch (_) {}
+  },
+
+  _persistFilters() {
+    try {
+      localStorage.setItem(this.STORAGE_KEY, JSON.stringify({
+        version: this.STORAGE_VERSION,
+        type: this._typeFilter,
+        search: this._searchTerm,
+        savedAt: new Date().toISOString(),
+      }));
+    } catch (_) {}
   },
 
   bindEvents(app) {
     const form = document.getElementById('add-target-form');
-    if (!form) return;
+    if (form) {
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const value = document.getElementById('target-value').value.trim();
+        const scope = document.getElementById('target-scope').value;
+        const errorEl = document.getElementById('add-target-error');
+        const btn = form.querySelector('button[type="submit"]');
+        if (!value) return;
+        btn.disabled = true;
+        btn.textContent = 'Adding...';
+        errorEl.style.display = 'none';
+        try {
+          await API.createTarget(value, '', scope);
+          TargetsPage.render(app);
+        } catch (err) {
+          errorEl.textContent = err.message;
+          errorEl.style.display = 'block';
+          btn.disabled = false;
+          btn.textContent = 'Add Target';
+        }
+      });
+    }
 
-    form.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const value = document.getElementById('target-value').value.trim();
-      const scope = document.getElementById('target-scope').value;
-      const errorEl = document.getElementById('add-target-error');
-      const btn = form.querySelector('button[type="submit"]');
-
-      if (!value) return;
-
-      btn.disabled = true;
-      btn.textContent = 'Adding...';
-      errorEl.style.display = 'none';
-
-      try {
-        await API.createTarget(value, '', scope);
-        TargetsPage.render(app);
-      } catch (err) {
-        errorEl.textContent = err.message;
-        errorEl.style.display = 'block';
-        btn.disabled = false;
-        btn.textContent = 'Add Target';
-      }
+    // Type-tab clicks. Filter change resets selection because the
+    // visible row set is changing under the operator.
+    app.querySelectorAll('[data-tgt-type]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        this._typeFilter = btn.getAttribute('data-tgt-type') || '';
+        this._selectedIds.clear();
+        this._persistFilters();
+        app.innerHTML = this.template();
+        this.bindEvents(app);
+      });
     });
+
+    // Live search.
+    const search = document.getElementById('tgt-search-input');
+    if (search) {
+      search.addEventListener('input', () => {
+        this._searchTerm = search.value;
+        this._selectedIds.clear();
+        this._persistFilters();
+        // Re-render the table only — keep input focus.
+        const cur = document.activeElement === search ? search.selectionStart : null;
+        app.innerHTML = this.template();
+        this.bindEvents(app);
+        const next = document.getElementById('tgt-search-input');
+        if (next) {
+          next.focus();
+          if (cur != null) next.setSelectionRange(cur, cur);
+        }
+      });
+    }
+
+    // Header select-all.
+    const selAll = document.getElementById('targets-select-all');
+    if (selAll) {
+      this._syncSelectAllState(selAll);
+      selAll.addEventListener('click', () => this.toggleAll(selAll.checked));
+    }
+
+    this._wireBulkBarActions(app);
+  },
+
+  // --- Bulk select & actions --------------------------------------
+
+  _bulkActionDescriptors() {
+    return [
+      { label: 'Run scan', primary: true, onClick: () => this.bulkRunScan() },
+      { label: 'Delete',   danger: true,  onClick: () => this.bulkDelete() },
+      { label: 'Clear',    onClick: () => this.clearSelection() },
+    ];
+  },
+
+  _wireBulkBarActions(app) {
+    const bar = app.querySelector('[data-bulk-slot] .bulk-bar');
+    if (!bar) return;
+    const descriptors = this._bulkActionDescriptors();
+    bar.querySelectorAll('[data-bulk-action]').forEach(btn => {
+      const i = parseInt(btn.getAttribute('data-bulk-action'), 10);
+      const a = descriptors[i];
+      if (!a || typeof a.onClick !== 'function') return;
+      btn.addEventListener('click', () => a.onClick());
+    });
+  },
+
+  onCheckboxChange(input) {
+    const id = input.value;
+    if (input.checked) this._selectedIds.add(id);
+    else this._selectedIds.delete(id);
+    this._refreshBulkBar();
+    const row = document.querySelector(`tr.tgt-row[data-target-id="${cssAttrEscape(id)}"]`);
+    if (row) row.classList.toggle('tgt-row-selected', input.checked);
+    const selAll = document.getElementById('targets-select-all');
+    if (selAll) this._syncSelectAllState(selAll);
+  },
+
+  toggleAll(checked) {
+    document.querySelectorAll('.tgt-checkbox').forEach(cb => {
+      cb.checked = checked;
+      const id = cb.value;
+      if (checked) this._selectedIds.add(id);
+      else this._selectedIds.delete(id);
+      const row = document.querySelector(`tr.tgt-row[data-target-id="${cssAttrEscape(id)}"]`);
+      if (row) row.classList.toggle('tgt-row-selected', checked);
+    });
+    this._refreshBulkBar();
+  },
+
+  clearSelection() {
+    this._selectedIds.clear();
+    document.querySelectorAll('.tgt-checkbox').forEach(cb => { cb.checked = false; });
+    document.querySelectorAll('.tgt-row').forEach(r => r.classList.remove('tgt-row-selected'));
+    this._refreshBulkBar();
+    const selAll = document.getElementById('targets-select-all');
+    if (selAll) this._syncSelectAllState(selAll);
+  },
+
+  _syncSelectAllState(el) {
+    const visible = Array.from(document.querySelectorAll('.tgt-checkbox'));
+    if (visible.length === 0) { el.checked = false; el.indeterminate = false; return; }
+    const checkedCount = visible.filter(cb => cb.checked).length;
+    if (checkedCount === 0) { el.checked = false; el.indeterminate = false; }
+    else if (checkedCount === visible.length) { el.checked = true; el.indeterminate = false; }
+    else { el.checked = false; el.indeterminate = true; }
+  },
+
+  _refreshBulkBar() {
+    const slot = document.querySelector('[data-bulk-slot]');
+    if (!slot) return;
+    slot.innerHTML = Components.bulkBar({
+      count: this._selectedIds.size,
+      actions: this._bulkActionDescriptors(),
+    });
+    this._wireBulkBarActions(document);
+  },
+
+  async bulkRunScan() {
+    const ids = Array.from(this._selectedIds);
+    if (ids.length === 0) return;
+    const ok = await Components.confirmDialog({
+      title: 'Start ' + ids.length + ' scan' + (ids.length !== 1 ? 's' : '') + '?',
+      message: 'A full scan will be queued for each selected target.',
+      confirmLabel: 'Start scans',
+    });
+    if (!ok) return;
+    const results = await Promise.allSettled(ids.map(id => API.startScan(id, 'full')));
+    const failed = results.filter(r => r.status === 'rejected').length;
+    const ok2 = results.length - failed;
+    if (failed === 0) {
+      Components.toast.success(`${ok2} scan${ok2 !== 1 ? 's' : ''} started`);
+    } else {
+      Components.toast.error(`${ok2}/${results.length} started · ${failed} failed`);
+    }
+    this.clearSelection();
+  },
+
+  async bulkDelete() {
+    const ids = Array.from(this._selectedIds);
+    if (ids.length === 0) return;
+    const ok = await Components.confirmDialog({
+      title: 'Delete ' + ids.length + ' target' + (ids.length !== 1 ? 's' : '') + '?',
+      message: 'This removes their associated assets and findings. Cannot be undone.',
+      confirmLabel: 'Delete',
+      danger: true,
+    });
+    if (!ok) return;
+    const results = await Promise.allSettled(ids.map(id => API.deleteTarget(id)));
+    const failed = results.filter(r => r.status === 'rejected').length;
+    const ok2 = results.length - failed;
+    if (failed === 0) {
+      Components.toast.success(`${ok2} target${ok2 !== 1 ? 's' : ''} deleted`);
+    } else {
+      Components.toast.error(`${ok2}/${results.length} deleted · ${failed} failed`);
+    }
+    this._selectedIds.clear();
+    TargetsPage.render(document.getElementById('app'));
+  },
+
+  // handleRowClick navigates to the detail view but ignores clicks that
+  // originated on the checkbox column or any per-row action button.
+  handleRowClick(evt, id) {
+    const t = evt.target;
+    if (t && t.closest && t.closest('input, button, a, .actions-cell, .fnd-cb-col')) return;
+    location.hash = '#/targets/' + id;
   },
 
   // --- Target Detail View ---


### PR DESCRIPTION
## Summary

UI v2 sprint · PR5 (#38). Implements filter chips persistentes + bulk actions for findings, targets, and scans.

- **findings**: severity tabs as pills (single-select including "All"), removable filter chips for status/target/tool/host/template via "+ Filter" popup menu, save-view indicator that opens Reset filters when active. Bulk-bar with Acknowledge / Resolve (confirm) / False positive (confirm) / Ignore / Clear; runs N parallel `PATCH /findings/{id}/status` with `Promise.allSettled` and preserves failed IDs for retry. Filters auto-persist to localStorage (`surfbot_findings_filters`); URL hash params win over storage so dashboard "Triage →" deep links stay deterministic. Legacy `<select id="filter-*">` and inline `.status-select` are gone — single-finding status changes flow through PR4's slide-over.
- **targets**: type tabs (Domain/IPv4/IPv6/CIDR/...) with counts, client-side name search, bulk-bar with Run scan + Delete (confirm). Storage key `surfbot_targets_filters`.
- **scans**: status tabs + chips for Target/Template/Range. No bulk-bar (per non-goal #1). Backend gap: `template_id` and `range` filter client-side because `/scans` doesn't accept them. Storage key `surfbot_scans_filters`.
- **CSS**: `.sev-tabs`, `.filter-strip`, `.filter-menu` (popup + submenu), `.save-view-pill`, `.fnd-cb-col`, `.{fnd,tgt}-row-selected`. Mobile (<768px) scrolls chips and bulk-bar horizontally.
- **tests**: extended `foundation_assets_test.go` with PR5 legacy/foundation/CSS guards. New `findings_filter_test.go` covers `severity/status/host/tool/template_id` filter params and the permissive enum behavior (`severity=banana` → 200 with 0 rows, the chip submenu type-ahead expects this).

## Test plan
- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run ./internal/webui/...` — 0 issues
- [x] `node --check` on findings/targets/scans.js — syntax OK
- [ ] Smoke manual: header checkbox → bulk Acknowledge → status pills update in-place
- [ ] Smoke manual: Resolve opens confirm modal with severity breakdown
- [ ] Smoke manual: refresh with chips active preserves state; deep link `#/findings?status=open` not overwritten by storage
- [ ] Smoke manual: targets bulk Run scan dispatches N scans; bulk Delete with confirm
- [ ] Smoke manual: scans chips removable, persistence on refresh
- [ ] Smoke manual: 375px viewport — chips strip scrollable, bulk-bar legible

Closes #38