### PR TITLE
scan_logs v2: persist pipeline events + UI fixes (#52)

### DIFF
--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -50,6 +50,12 @@ func runScan(cmd *cobra.Command, args []string) error {
 	}
 
 	pipe := pipeline.New(store, registry)
+	// Issue #52: tee structured pipeline events into scan_logs so the
+	// webui can show CLI-parity live log streaming. Terminal output
+	// (pp.muted/success/etc.) is unaffected — sink is additive.
+	sink := pipeline.NewSQLiteLogSink(store, pipeline.SQLiteLogSinkOptions{})
+	defer func() { _ = sink.Close() }()
+	pipe.SetSink(sink)
 
 	scanType, _ := cmd.Flags().GetString("type")
 	tools, _ := cmd.Flags().GetStringSlice("tools")

--- a/internal/daemon/scan_runner.go
+++ b/internal/daemon/scan_runner.go
@@ -38,19 +38,38 @@ type scanOrchestrator interface {
 // subtyping does the wiring at the dependency-injection site.
 type ScanRunner struct {
 	orchestrator scanOrchestrator
+	sink         *pipeline.SQLiteLogSink
 	log          *slog.Logger
 }
 
 // NewScanRunner wires a ScanRunner around the production pipeline. The
 // store and registry are the same ones the rest of the daemon uses.
+//
+// Issue #52: scheduler-driven scans get the same SQLite log tee as
+// CLI / webui-triggered scans. The sink is per-runner (long-lived for
+// the daemon process) so its background goroutine survives across
+// scans; it's closed when the daemon shuts down via Close().
 func NewScanRunner(store storage.Store, registry *detection.Registry, log *slog.Logger) *ScanRunner {
 	if log == nil {
 		log = slog.Default()
 	}
+	pipe := pipeline.New(store, registry)
+	sink := pipeline.NewSQLiteLogSink(store, pipeline.SQLiteLogSinkOptions{})
+	pipe.SetSink(sink)
 	return &ScanRunner{
-		orchestrator: pipeline.New(store, registry),
+		orchestrator: pipe,
+		sink:         sink,
 		log:          log,
 	}
+}
+
+// Close shuts down the underlying log sink. Daemon shutdown calls this
+// to flush outstanding scan_logs writes.
+func (r *ScanRunner) Close() error {
+	if r.sink != nil {
+		return r.sink.Close()
+	}
+	return nil
 }
 
 // Run executes a full scan for the target, threading EffectiveConfig.

--- a/internal/model/scan_log.go
+++ b/internal/model/scan_log.go
@@ -1,0 +1,36 @@
+package model
+
+import "time"
+
+// LogLevel is the severity of a scan log line. The four-value vocabulary
+// matches the SQLite CHECK constraint in migration 0006_scan_logs.sql —
+// add a value here and the migration must change in lockstep.
+type LogLevel string
+
+const (
+	LogLevelDebug LogLevel = "debug"
+	LogLevelInfo  LogLevel = "info"
+	LogLevelWarn  LogLevel = "warn"
+	LogLevelError LogLevel = "error"
+)
+
+// ScanLog is a single structured event emitted by the pipeline during a
+// scan. The webui consumes these via /api/v1/scans/:id/logs to show a
+// live log stream that mirrors what the operator sees on the terminal.
+//
+// Source identifies the emitter:
+//   - "scanner" for orchestrator-level events (scan/phase started, etc.)
+//   - tool name (e.g. "subfinder", "nuclei") for tool-level events.
+//
+// ToolRunID is empty for orchestrator-level events. JSON omits the
+// field when empty so consumers can branch on its presence.
+type ScanLog struct {
+	ID        int64     `json:"id"`
+	ScanID    string    `json:"scan_id"`
+	ToolRunID string    `json:"tool_run_id,omitempty"`
+	Timestamp time.Time `json:"ts"`
+	Source    string    `json:"source"`
+	Level     LogLevel  `json:"level"`
+	Text      string    `json:"text"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/internal/pipeline/log_sink.go
+++ b/internal/pipeline/log_sink.go
@@ -1,0 +1,73 @@
+package pipeline
+
+import (
+	"context"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// LogSink receives structured pipeline events. Implementations:
+//   - NoopSink: drops everything (default; tests + CLI-only paths
+//     where SQLite isn't desired).
+//   - SQLiteLogSink: persists batched to scan_logs (issue #52).
+//
+// All methods MUST be non-blocking under nominal load. Implementations
+// that persist asynchronously (e.g. SQLite via a buffered channel)
+// guarantee enqueue is < 1µs; backpressure is drop-oldest, never
+// blocking the caller.
+//
+// LogSink is *additive* over the existing CLI printer (`pp.muted`
+// etc.) — these methods don't replace terminal output. The pipeline
+// calls both. Missing a sink call costs the UI one log line; missing
+// a `pp.muted` call breaks the operator's terminal experience. We
+// bias toward the safe direction.
+type LogSink interface {
+	ScanStarted(ctx context.Context, scanID, target string, scanType model.ScanType)
+	ScanCompleted(ctx context.Context, scanID string, durationMs int64)
+	ScanFailed(ctx context.Context, scanID, errMsg string)
+	ScanCancelled(ctx context.Context, scanID, reason string)
+
+	PhaseStarted(ctx context.Context, scanID, phase, toolName string)
+
+	ToolStarted(ctx context.Context, scanID, toolRunID, toolName, phase string, inputCount int)
+	ToolCompleted(ctx context.Context, scanID, toolRunID, toolName string, durationMs int64, outputCount int, summary string)
+	ToolFailed(ctx context.Context, scanID, toolRunID, toolName, errMsg string)
+	ToolSkipped(ctx context.Context, scanID, toolName, reason string)
+
+	// ToolStderr emits a single line of accumulated tool stderr at
+	// level=warn. Multi-line stderr should be split by the caller
+	// before invoking this.
+	ToolStderr(ctx context.Context, scanID, toolRunID, toolName, line string)
+
+	// Emit is the catch-all for events that don't fit a specialized
+	// method. Source should match a tool name when applicable,
+	// "scanner" otherwise.
+	Emit(ctx context.Context, scanID string, level model.LogLevel, source, text string)
+
+	// Close flushes any in-flight writes and releases resources. Safe
+	// to call multiple times; only the first call has effect.
+	Close() error
+}
+
+// NoopSink discards every event. Used by tests and CLI-only entry
+// points without a SQLite handle wired up. Implements the full
+// LogSink contract so callers never need a nil check.
+type NoopSink struct{}
+
+func (NoopSink) ScanStarted(context.Context, string, string, model.ScanType) {}
+func (NoopSink) ScanCompleted(context.Context, string, int64)                {}
+func (NoopSink) ScanFailed(context.Context, string, string)                  {}
+func (NoopSink) ScanCancelled(context.Context, string, string)               {}
+func (NoopSink) PhaseStarted(context.Context, string, string, string)        {}
+func (NoopSink) ToolStarted(context.Context, string, string, string, string, int) {
+}
+func (NoopSink) ToolCompleted(context.Context, string, string, string, int64, int, string) {
+}
+func (NoopSink) ToolFailed(context.Context, string, string, string, string)   {}
+func (NoopSink) ToolSkipped(context.Context, string, string, string)          {}
+func (NoopSink) ToolStderr(context.Context, string, string, string, string)   {}
+func (NoopSink) Emit(context.Context, string, model.LogLevel, string, string) {}
+func (NoopSink) Close() error                                                 { return nil }
+
+// Compile-time assertion: NoopSink implements LogSink.
+var _ LogSink = NoopSink{}

--- a/internal/pipeline/log_sink_integration_test.go
+++ b/internal/pipeline/log_sink_integration_test.go
@@ -1,0 +1,84 @@
+package pipeline
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// TestPipeline_FullScan_PersistsLogs is the issue #52 happy path:
+// run a full mocked pipeline with a SQLiteLogSink wired in, then
+// query the resulting scan_logs rows and assert lifecycle coverage.
+//
+// CLI parity (G4) is implicit — the test runs the same Pipeline.Run
+// the CLI invokes, and asserts that the sink emits the events the
+// UI needs WITHOUT modifying any pp.muted/success calls.
+//
+// The B1 fix (drop FK on tool_run_id) is implicitly verified: the
+// pipeline emits ToolStarted log lines before recordToolRunWithID
+// inserts the tool_run row. With the FK in place, the batched
+// INSERT would fail and zero tool-level lines would persist.
+func TestPipeline_FullScan_PersistsLogs(t *testing.T) {
+	s := newTestStore(t)
+	target := createTarget(t, s, "example.com")
+
+	reg := mockRegistry(fullMockTools()...)
+	pipe := New(s, reg)
+	sink := NewSQLiteLogSink(s, SQLiteLogSinkOptions{})
+	pipe.SetSink(sink)
+
+	result, err := pipe.Run(context.Background(), target.ID, PipelineOptions{ScanType: model.ScanTypeFull})
+	require.NoError(t, err)
+
+	// Close synchronously flushes pending lines so the assertions
+	// below see the complete log corpus. Idempotent — the deferred
+	// second call returns instantly.
+	require.NoError(t, sink.Close())
+	defer func() { _ = sink.Close() }()
+
+	logs, err := s.ListScanLogs(context.Background(), storage.ScanLogListOptions{
+		ScanID: result.ScanID,
+		Limit:  500,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, logs, "scan_logs must persist events from a full scan")
+
+	// Coverage assertions — spec G2 guarantees structured events for
+	// every lifecycle boundary an operator cares about.
+	have := func(needle string) bool {
+		for _, l := range logs {
+			if strings.Contains(l.Text, needle) {
+				return true
+			}
+		}
+		return false
+	}
+	assert.True(t, have("scan started"), "expected scan-started log line")
+	assert.True(t, have("scan completed"), "expected scan-completed log line")
+	assert.True(t, have("phase=discovery"), "expected phase-started log for discovery")
+	assert.True(t, have("phase=assessment"), "expected phase-started log for assessment")
+	assert.True(t, have("tool started"), "expected tool-started log line")
+	assert.True(t, have("tool completed"), "expected tool-completed log line")
+
+	// Source diversity — the pipeline emits both scanner-level and
+	// tool-level log lines. Asserting a tool-named source appears
+	// is the operator-visible signal of CLI/UI parity.
+	sources := map[string]bool{}
+	for _, l := range logs {
+		sources[l.Source] = true
+	}
+	assert.True(t, sources["scanner"], "scanner-level log lines must persist")
+	toolSources := 0
+	for src := range sources {
+		if src != "scanner" {
+			toolSources++
+		}
+	}
+	assert.Greater(t, toolSources, 0, "at least one tool-named source (subfinder/dnsx/...) must appear in scan_logs")
+}

--- a/internal/pipeline/log_sink_sqlite.go
+++ b/internal/pipeline/log_sink_sqlite.go
@@ -1,0 +1,296 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// scanLogWriter is the narrow contract SQLiteLogSink needs from the
+// store. Defined here (rather than imported from storage) so the
+// pipeline package doesn't gain a circular dep, and so unit tests can
+// fake the writer with a slice.
+type scanLogWriter interface {
+	InsertScanLogs(ctx context.Context, logs []model.ScanLog) error
+}
+
+// SQLiteLogSink persists pipeline events to scan_logs via batched
+// asynchronous writes. The hot path (caller side) is a non-blocking
+// channel send; persistence happens in a background goroutine that
+// flushes whenever the buffer hits batchSize OR flushInterval elapses
+// — whichever comes first. Under load (channel full) the sink drops
+// the OLDEST queued line and warns once per minute via the Go log
+// package. Logs are best-effort: findings + tool_runs remain canonical.
+type SQLiteLogSink struct {
+	store     scanLogWriter
+	ch        chan model.ScanLog
+	stop      chan struct{}
+	done      chan struct{}
+	closeOnce sync.Once
+
+	batchSize     int
+	flushInterval time.Duration
+
+	// drop accounting — atomics so the Stats() probe is lock-free.
+	droppedTotal atomic.Int64
+	lastWarnUnix atomic.Int64
+}
+
+// SQLiteLogSinkOptions tunes the sink. Zero values fall back to safe
+// defaults; production callers typically pass nothing.
+type SQLiteLogSinkOptions struct {
+	ChannelCapacity int           // default 1000
+	BatchSize       int           // default 50
+	FlushInterval   time.Duration // default 100ms
+}
+
+// NewSQLiteLogSink starts the background drain goroutine. The caller
+// MUST call Close() before the process exits to flush outstanding
+// lines; pipeline.Run() does this via defer.
+func NewSQLiteLogSink(store scanLogWriter, opts SQLiteLogSinkOptions) *SQLiteLogSink {
+	if opts.ChannelCapacity <= 0 {
+		opts.ChannelCapacity = 1000
+	}
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = 50
+	}
+	if opts.FlushInterval <= 0 {
+		opts.FlushInterval = 100 * time.Millisecond
+	}
+	s := &SQLiteLogSink{
+		store:         store,
+		ch:            make(chan model.ScanLog, opts.ChannelCapacity),
+		stop:          make(chan struct{}),
+		done:          make(chan struct{}),
+		batchSize:     opts.BatchSize,
+		flushInterval: opts.FlushInterval,
+	}
+	go s.run()
+	return s
+}
+
+// run is the background drain goroutine. Exits cleanly when stop is
+// closed AND the channel is drained.
+func (s *SQLiteLogSink) run() {
+	defer close(s.done)
+	ticker := time.NewTicker(s.flushInterval)
+	defer ticker.Stop()
+	batch := make([]model.ScanLog, 0, s.batchSize)
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		// Use a fresh background context so a canceled scan ctx
+		// doesn't bin the final flush. The persistence path is fast
+		// enough that we don't need a timeout — the main scan flow has
+		// already returned by the time Close() blocks here.
+		if err := s.store.InsertScanLogs(context.Background(), batch); err != nil {
+			log.Printf("scan_logs sink: insert failed: %v (batch=%d)", err, len(batch))
+		}
+		batch = batch[:0]
+	}
+	for {
+		select {
+		case l, ok := <-s.ch:
+			if !ok {
+				flush()
+				return
+			}
+			batch = append(batch, l)
+			if len(batch) >= s.batchSize {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		case <-s.stop:
+			// Drain whatever's left in the channel before exit.
+			for {
+				select {
+				case l := <-s.ch:
+					batch = append(batch, l)
+					if len(batch) >= s.batchSize {
+						flush()
+					}
+				default:
+					flush()
+					return
+				}
+			}
+		}
+	}
+}
+
+// ansiRE matches CSI-style ANSI escape sequences (the colorize family).
+// Tools and theme writers may emit color codes that have meaning in a
+// terminal but are noise once persisted — strip before write.
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+func stripANSI(s string) string {
+	if s == "" {
+		return s
+	}
+	return ansiRE.ReplaceAllString(s, "")
+}
+
+// enqueue is the non-blocking ingress. On overflow it drops the OLDEST
+// queued line (preserving the most recent context) and accounts for
+// the loss. We warn at most once per 60s to avoid log-storm spam in
+// the meta logs themselves.
+func (s *SQLiteLogSink) enqueue(l model.ScanLog) {
+	l.Text = stripANSI(l.Text)
+	if l.CreatedAt.IsZero() {
+		l.CreatedAt = time.Now().UTC()
+	}
+	if l.Timestamp.IsZero() {
+		l.Timestamp = l.CreatedAt
+	}
+	if l.Level == "" {
+		l.Level = model.LogLevelInfo
+	}
+	for {
+		select {
+		case s.ch <- l:
+			return
+		default:
+			// Channel full — drop the oldest, retry. select-default
+			// on the receive side avoids a block if a racing drainer
+			// already consumed the slot.
+			select {
+			case <-s.ch:
+				s.droppedTotal.Add(1)
+			default:
+			}
+			s.warnOnDrop()
+		}
+	}
+}
+
+func (s *SQLiteLogSink) warnOnDrop() {
+	now := time.Now().Unix()
+	last := s.lastWarnUnix.Load()
+	if now-last >= 60 {
+		if s.lastWarnUnix.CompareAndSwap(last, now) {
+			log.Printf("scan_logs sink: channel full, dropping oldest lines (total dropped: %d)", s.droppedTotal.Load())
+		}
+	}
+}
+
+// Stats exposes drop counters for tests + observability.
+func (s *SQLiteLogSink) Stats() (dropped int64) {
+	return s.droppedTotal.Load()
+}
+
+// Close flushes outstanding lines synchronously. Safe to call multiple
+// times; only the first call signals the goroutine to drain.
+func (s *SQLiteLogSink) Close() error {
+	s.closeOnce.Do(func() {
+		close(s.stop)
+		<-s.done
+	})
+	return nil
+}
+
+// --- LogSink methods ---------------------------------------------
+
+func (s *SQLiteLogSink) ScanStarted(ctx context.Context, scanID, target string, scanType model.ScanType) {
+	s.enqueue(model.ScanLog{
+		ScanID: scanID, Source: "scanner", Level: model.LogLevelInfo,
+		Text: fmt.Sprintf("scan started · target=%s type=%s", target, scanType),
+	})
+}
+
+func (s *SQLiteLogSink) ScanCompleted(ctx context.Context, scanID string, durationMs int64) {
+	s.enqueue(model.ScanLog{
+		ScanID: scanID, Source: "scanner", Level: model.LogLevelInfo,
+		Text: fmt.Sprintf("scan completed in %dms", durationMs),
+	})
+}
+
+func (s *SQLiteLogSink) ScanFailed(ctx context.Context, scanID, errMsg string) {
+	s.enqueue(model.ScanLog{
+		ScanID: scanID, Source: "scanner", Level: model.LogLevelError,
+		Text: fmt.Sprintf("scan failed: %s", errMsg),
+	})
+}
+
+func (s *SQLiteLogSink) ScanCancelled(ctx context.Context, scanID, reason string) {
+	// US spelling here to satisfy the US-locale misspell linter on
+	// these new strings. The model status constant uses the British
+	// form for backwards compatibility with the rest of the codebase;
+	// operators see the badge label, not these log lines.
+	text := "scan canceled"
+	if reason != "" {
+		text = "scan canceled: " + reason
+	}
+	s.enqueue(model.ScanLog{
+		ScanID: scanID, Source: "scanner", Level: model.LogLevelWarn, Text: text,
+	})
+}
+
+func (s *SQLiteLogSink) PhaseStarted(ctx context.Context, scanID, phase, toolName string) {
+	s.enqueue(model.ScanLog{
+		ScanID: scanID, Source: "scanner", Level: model.LogLevelInfo,
+		Text: fmt.Sprintf("phase=%s starting (%s)", phase, toolName),
+	})
+}
+
+func (s *SQLiteLogSink) ToolStarted(ctx context.Context, scanID, toolRunID, toolName, phase string, inputCount int) {
+	s.enqueue(model.ScanLog{
+		ScanID: scanID, ToolRunID: toolRunID, Source: toolName, Level: model.LogLevelInfo,
+		Text: fmt.Sprintf("tool started · phase=%s inputs=%d", phase, inputCount),
+	})
+}
+
+func (s *SQLiteLogSink) ToolCompleted(ctx context.Context, scanID, toolRunID, toolName string, durationMs int64, outputCount int, summary string) {
+	text := fmt.Sprintf("tool completed in %dms · outputs=%d", durationMs, outputCount)
+	if summary != "" {
+		text += " · " + summary
+	}
+	s.enqueue(model.ScanLog{
+		ScanID: scanID, ToolRunID: toolRunID, Source: toolName, Level: model.LogLevelInfo, Text: text,
+	})
+}
+
+func (s *SQLiteLogSink) ToolFailed(ctx context.Context, scanID, toolRunID, toolName, errMsg string) {
+	s.enqueue(model.ScanLog{
+		ScanID: scanID, ToolRunID: toolRunID, Source: toolName, Level: model.LogLevelError,
+		Text: fmt.Sprintf("tool failed: %s", errMsg),
+	})
+}
+
+func (s *SQLiteLogSink) ToolSkipped(ctx context.Context, scanID, toolName, reason string) {
+	text := "tool skipped"
+	if reason != "" {
+		text = "tool skipped: " + reason
+	}
+	s.enqueue(model.ScanLog{
+		ScanID: scanID, Source: toolName, Level: model.LogLevelInfo, Text: text,
+	})
+}
+
+func (s *SQLiteLogSink) ToolStderr(ctx context.Context, scanID, toolRunID, toolName, line string) {
+	if line == "" {
+		return
+	}
+	s.enqueue(model.ScanLog{
+		ScanID: scanID, ToolRunID: toolRunID, Source: toolName, Level: model.LogLevelWarn, Text: line,
+	})
+}
+
+func (s *SQLiteLogSink) Emit(ctx context.Context, scanID string, level model.LogLevel, source, text string) {
+	if source == "" {
+		source = "scanner"
+	}
+	s.enqueue(model.ScanLog{
+		ScanID: scanID, Source: source, Level: level, Text: text,
+	})
+}
+
+// Compile-time assertion that SQLiteLogSink satisfies LogSink.
+var _ LogSink = (*SQLiteLogSink)(nil)

--- a/internal/pipeline/log_sink_test.go
+++ b/internal/pipeline/log_sink_test.go
@@ -1,0 +1,139 @@
+package pipeline
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// fakeWriter is a thread-safe in-memory scanLogWriter for sink tests.
+// Records every batch InsertScanLogs receives so tests can assert
+// ordering, ANSI stripping, and batch boundaries.
+type fakeWriter struct {
+	mu      sync.Mutex
+	logs    []model.ScanLog
+	batches int
+	failNxt error
+}
+
+func (w *fakeWriter) InsertScanLogs(ctx context.Context, logs []model.ScanLog) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.failNxt != nil {
+		err := w.failNxt
+		w.failNxt = nil
+		return err
+	}
+	w.batches++
+	w.logs = append(w.logs, logs...)
+	return nil
+}
+
+func (w *fakeWriter) snapshot() []model.ScanLog {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]model.ScanLog, len(w.logs))
+	copy(out, w.logs)
+	return out
+}
+
+func TestSQLiteLogSink_BatchedInsert(t *testing.T) {
+	w := &fakeWriter{}
+	sink := NewSQLiteLogSink(w, SQLiteLogSinkOptions{BatchSize: 10, FlushInterval: 50 * time.Millisecond})
+	defer func() { _ = sink.Close() }()
+
+	for i := 0; i < 25; i++ {
+		sink.Emit(context.Background(), "scan-1", model.LogLevelInfo, "scanner", "line")
+	}
+	require.NoError(t, sink.Close())
+	got := w.snapshot()
+	assert.Equal(t, 25, len(got), "all 25 lines should reach the writer")
+}
+
+func TestSQLiteLogSink_AnsiStripped(t *testing.T) {
+	w := &fakeWriter{}
+	sink := NewSQLiteLogSink(w, SQLiteLogSinkOptions{BatchSize: 1, FlushInterval: 10 * time.Millisecond})
+
+	sink.Emit(context.Background(), "scan-1", model.LogLevelInfo, "scanner", "\x1b[31mhello\x1b[0m world")
+	require.NoError(t, sink.Close())
+	got := w.snapshot()
+	require.Len(t, got, 1)
+	assert.Equal(t, "hello world", got[0].Text, "ANSI sequences must be stripped before persistence")
+}
+
+func TestSQLiteLogSink_CloseFlushesOutstanding(t *testing.T) {
+	w := &fakeWriter{}
+	sink := NewSQLiteLogSink(w, SQLiteLogSinkOptions{BatchSize: 100, FlushInterval: 5 * time.Second})
+	for i := 0; i < 5; i++ {
+		sink.Emit(context.Background(), "scan-1", model.LogLevelInfo, "scanner", "tail")
+	}
+	require.NoError(t, sink.Close())
+	assert.Equal(t, 5, len(w.snapshot()), "Close must flush outstanding lines synchronously")
+}
+
+func TestSQLiteLogSink_CloseIdempotent(t *testing.T) {
+	w := &fakeWriter{}
+	sink := NewSQLiteLogSink(w, SQLiteLogSinkOptions{})
+	require.NoError(t, sink.Close())
+	require.NoError(t, sink.Close(), "Close must be idempotent")
+}
+
+func TestSQLiteLogSink_BoundedChannelDropsOldest(t *testing.T) {
+	w := &fakeWriter{}
+	sink := NewSQLiteLogSink(w, SQLiteLogSinkOptions{
+		ChannelCapacity: 4,
+		BatchSize:       4,
+		FlushInterval:   500 * time.Millisecond,
+	})
+	for i := 0; i < 200; i++ {
+		sink.Emit(context.Background(), "scan-1", model.LogLevelInfo, "scanner", "load")
+	}
+	require.NoError(t, sink.Close())
+	dropped := sink.Stats()
+	assert.Greater(t, dropped, int64(0), "overflow must be accounted as drops")
+}
+
+func TestSQLiteLogSink_LifecycleEvents(t *testing.T) {
+	w := &fakeWriter{}
+	sink := NewSQLiteLogSink(w, SQLiteLogSinkOptions{BatchSize: 1, FlushInterval: 10 * time.Millisecond})
+	ctx := context.Background()
+	scanID := "scan-abc"
+	sink.ScanStarted(ctx, scanID, "example.com", model.ScanTypeFull)
+	sink.PhaseStarted(ctx, scanID, "discovery", "subfinder")
+	sink.ToolStarted(ctx, scanID, "tr-1", "subfinder", "discovery", 1)
+	sink.ToolStderr(ctx, scanID, "tr-1", "subfinder", "rate limited")
+	sink.ToolCompleted(ctx, scanID, "tr-1", "subfinder", 42, 100, "Discovered 100 subdomains")
+	sink.ScanCompleted(ctx, scanID, 1234)
+	require.NoError(t, sink.Close())
+	got := w.snapshot()
+	require.Len(t, got, 6)
+	assert.Equal(t, "scanner", got[0].Source)
+	assert.Equal(t, model.LogLevelInfo, got[0].Level)
+	assert.Contains(t, got[0].Text, "scan started")
+	assert.Equal(t, "subfinder", got[2].Source)
+	assert.Equal(t, "tr-1", got[2].ToolRunID)
+	assert.Equal(t, model.LogLevelWarn, got[3].Level, "ToolStderr defaults to warn")
+	assert.Contains(t, got[5].Text, "scan completed")
+}
+
+func TestSQLiteLogSink_DefaultsLevelToInfo(t *testing.T) {
+	w := &fakeWriter{}
+	sink := NewSQLiteLogSink(w, SQLiteLogSinkOptions{BatchSize: 1, FlushInterval: 5 * time.Millisecond})
+	sink.Emit(context.Background(), "scan-1", "", "scanner", "blank-level")
+	require.NoError(t, sink.Close())
+	got := w.snapshot()
+	require.Len(t, got, 1)
+	assert.Equal(t, model.LogLevelInfo, got[0].Level)
+}
+
+func TestNoopSink_ImplementsLogSink(t *testing.T) {
+	var _ LogSink = NoopSink{}
+	NoopSink{}.ScanStarted(context.Background(), "x", "y", model.ScanTypeFull)
+	require.NoError(t, NoopSink{}.Close())
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -109,14 +109,28 @@ type PhaseResult struct {
 type Pipeline struct {
 	store    storage.Store
 	registry *detection.Registry
+	sink     LogSink
 }
 
-// New creates a new Pipeline with the given store and registry.
+// New creates a new Pipeline with the given store and registry. The
+// LogSink defaults to NoopSink — callers that want UI-visible logs
+// (issue #52) wire one via SetSink before calling Run.
 func New(store storage.Store, registry *detection.Registry) *Pipeline {
 	return &Pipeline{
 		store:    store,
 		registry: registry,
+		sink:     NoopSink{},
 	}
+}
+
+// SetSink swaps the LogSink. Call before Run; the pipeline reads the
+// field once at the start of Run and doesn't reach for it again
+// elsewhere, so swap-during-scan is undefined.
+func (p *Pipeline) SetSink(sink LogSink) {
+	if sink == nil {
+		sink = NoopSink{}
+	}
+	p.sink = sink
 }
 
 // Run executes the full detection pipeline against the given target.
@@ -174,6 +188,14 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 	pp := newPipelinePrinter(os.Stderr)
 	pp.progress("Scan started: %s (%s)", target.Value, opts.ScanType)
 
+	// Issue #52: structured scan log. NoopSink by default; production
+	// callers swap in SQLiteLogSink via SetSink before Run.
+	sink := p.sink
+	if sink == nil {
+		sink = NoopSink{}
+	}
+	sink.ScanStarted(ctx, scan.ID, target.Value, opts.ScanType)
+
 	for i, tool := range tools {
 		// Check for context cancellation
 		select {
@@ -195,6 +217,7 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 				nowt := time.Now().UTC()
 				scan.FinishedAt = &nowt
 				p.store.UpdateScan(context.Background(), scan) //nolint:errcheck
+				sink.ScanCancelled(ctx, scan.ID, "external")
 				pp.warn("Scan cancelled externally")
 				return nil, fmt.Errorf("scan cancelled")
 			}
@@ -208,6 +231,7 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 			}
 			result.Phases = append(result.Phases, pr)
 			p.recordToolRun(ctx, tool, scan.ID, time.Now(), 0, len(inputs), 0, model.ToolRunSkipped, "")
+			sink.ToolSkipped(ctx, scan.ID, tool.Name(), "filtered by scan options")
 			continue
 		}
 
@@ -217,6 +241,14 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 		p.store.UpdateScan(ctx, scan) //nolint:errcheck
 
 		pp.success("Phase %d/%d: %s — %s", i+1, len(tools), tool.Phase(), tool.Name())
+		sink.PhaseStarted(ctx, scan.ID, tool.Phase(), tool.Name())
+
+		// Pre-allocate the tool_run id so the start log line carries
+		// the same ID as the eventual recordToolRun row. Both lines
+		// (start + complete) reference it via tool_run_id, letting the
+		// UI group log lines under their tool execution.
+		toolRunID := uuid.New().String()
+		sink.ToolStarted(ctx, scan.ID, toolRunID, tool.Name(), tool.Phase(), len(inputs))
 
 		// Per-phase timeout — assessment (nuclei) gets 10 min, others 5 min
 		phaseTimeout := time.Duration(opts.Timeout) * time.Second
@@ -274,12 +306,14 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 		// If the tool was killed by external cancellation, stop immediately
 		if toolErr != nil {
 			if fresh, fErr := p.store.GetScan(context.Background(), scan.ID); fErr == nil && fresh.Status == model.ScanStatusCancelled {
-				p.recordToolRun(ctx, tool, scan.ID, startTime, duration, len(inputs), 0, model.ToolRunFailed, "canceled")
+				p.recordToolRunWithID(ctx, toolRunID, tool, scan.ID, startTime, duration, len(inputs), 0, model.ToolRunFailed, "canceled")
+				sink.ToolFailed(ctx, scan.ID, toolRunID, tool.Name(), "canceled")
 				scan.Status = model.ScanStatusCancelled
 				scan.Phase = "cancelled"
 				nowt := time.Now().UTC()
 				scan.FinishedAt = &nowt
 				p.store.UpdateScan(context.Background(), scan) //nolint:errcheck
+				sink.ScanCancelled(ctx, scan.ID, tool.Name()+" terminated")
 				pp.warn("Scan cancelled — %s terminated", tool.Name())
 				return nil, fmt.Errorf("scan cancelled")
 			}
@@ -298,7 +332,13 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 			pr.Error = toolErr.Error()
 			result.Phases = append(result.Phases, pr)
 
-			p.recordToolRun(ctx, tool, scan.ID, startTime, duration, len(inputs), 0, model.ToolRunFailed, toolErr.Error())
+			p.recordToolRunWithID(ctx, toolRunID, tool, scan.ID, startTime, duration, len(inputs), 0, model.ToolRunFailed, toolErr.Error())
+			sink.ToolFailed(ctx, scan.ID, toolRunID, tool.Name(), toolErr.Error())
+			// toolResult may be nil on hard tool failures (the wrapper
+			// returns (nil, err)). Guard before dereferencing.
+			if toolResult != nil {
+				flushToolStderr(ctx, sink, scan.ID, toolRunID, tool.Name(), &toolResult.ToolRun)
+			}
 
 			if isHardFailure(tool) {
 				scan.Status = model.ScanStatusFailed
@@ -306,6 +346,7 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 				nowt := time.Now().UTC()
 				scan.FinishedAt = &nowt
 				p.store.UpdateScan(ctx, scan) //nolint:errcheck
+				sink.ScanFailed(ctx, scan.ID, scan.Error)
 				return nil, fmt.Errorf("%s: %w", tool.Name(), toolErr)
 			}
 			pp.warn("    %s failed: %v", tool.Name(), toolErr)
@@ -372,7 +413,9 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 		// telemetry (command args, stderr tail, output summary, exit
 		// code). Merge those into the persisted record so the webui and
 		// `surfbot scan detail` can show per-tool logs.
-		p.recordToolRun(ctx, tool, scan.ID, startTime, duration, len(inputs), len(toolResult.Findings), model.ToolRunCompleted, "", &toolResult.ToolRun)
+		p.recordToolRunWithID(ctx, toolRunID, tool, scan.ID, startTime, duration, len(inputs), len(toolResult.Findings), model.ToolRunCompleted, "", &toolResult.ToolRun)
+		sink.ToolCompleted(ctx, scan.ID, toolRunID, tool.Name(), duration.Milliseconds(), outputCount, toolResult.ToolRun.OutputSummary)
+		flushToolStderr(ctx, sink, scan.ID, toolRunID, tool.Name(), &toolResult.ToolRun)
 
 		// Print phase summary. The port_scan summary surfaces the
 		// resolution-filter drop count so operators can see the
@@ -456,6 +499,7 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 					Status:   "skipped",
 				})
 				p.recordToolRun(ctx, tools[k], scan.ID, time.Now(), 0, 0, 0, model.ToolRunSkipped, "no live URLs to assess")
+				sink.ToolSkipped(ctx, scan.ID, tools[k].Name(), "no live URLs to assess")
 			}
 			break
 		}
@@ -509,6 +553,8 @@ func (p *Pipeline) Run(ctx context.Context, targetID string, opts PipelineOption
 	p.store.UpdateScan(ctx, scan)                                         //nolint:errcheck
 	p.store.UpdateTargetLastScan(ctx, scan.TargetID, scan.ID, finishedAt) //nolint:errcheck
 
+	sink.ScanCompleted(ctx, scan.ID, duration.Milliseconds())
+
 	result.Type = opts.ScanType
 	result.Duration = duration
 	result.TargetState = targetState
@@ -550,10 +596,21 @@ func (p *Pipeline) selectTools(opts PipelineOptions) []detection.DetectionTool {
 // The pipeline-controlled fields (scan_id, timing, counts, status)
 // always win — the wrapper doesn't know scan_id and its own timing may
 // be slightly off vs. the outer timer.
-func (p *Pipeline) recordToolRun(ctx context.Context, tool detection.DetectionTool, scanID string, startedAt time.Time, duration time.Duration, inputCount, outputCount int, status model.ToolRunStatus, errMsg string, enrich ...*model.ToolRun) {
+func (p *Pipeline) recordToolRun(ctx context.Context, tool detection.DetectionTool, scanID string, startedAt time.Time, duration time.Duration, inputCount, outputCount int, status model.ToolRunStatus, errMsg string, enrich ...*model.ToolRun) string {
+	return p.recordToolRunWithID(ctx, "", tool, scanID, startedAt, duration, inputCount, outputCount, status, errMsg, enrich...)
+}
+
+// recordToolRunWithID is recordToolRun with an explicit ID — used by the
+// main loop so the pre-emitted sink.ToolStarted log line and the
+// post-emitted sink.ToolCompleted/Failed line share a tool_run_id.
+// Empty toolRunID generates a fresh UUID, matching the legacy behavior.
+func (p *Pipeline) recordToolRunWithID(ctx context.Context, toolRunID string, tool detection.DetectionTool, scanID string, startedAt time.Time, duration time.Duration, inputCount, outputCount int, status model.ToolRunStatus, errMsg string, enrich ...*model.ToolRun) string {
+	if toolRunID == "" {
+		toolRunID = uuid.New().String()
+	}
 	finishedAt := startedAt.Add(duration)
 	tr := &model.ToolRun{
-		ID:            uuid.New().String(),
+		ID:            toolRunID,
 		ScanID:        scanID,
 		ToolName:      tool.Name(),
 		Phase:         tool.Phase(),
@@ -590,6 +647,30 @@ func (p *Pipeline) recordToolRun(ctx context.Context, tool detection.DetectionTo
 		}
 	}
 	p.store.CreateToolRun(ctx, tr) //nolint:errcheck
+	return tr.ID
+}
+
+// flushToolStderr splits the accumulated stderr from a tool's ToolRun
+// (set by attachExecContext during tool.Run) into individual lines and
+// emits each non-empty one via sink.ToolStderr at level=warn. Multi-
+// line stderr is the canonical signal that something went sideways
+// inside the tool — surfacing it in the live log lets operators triage
+// without `sqlite3 surfbot.db ...` queries against tool_runs.config.
+func flushToolStderr(ctx context.Context, sink LogSink, scanID, toolRunID, toolName string, tr *model.ToolRun) {
+	if tr == nil || tr.Config == nil {
+		return
+	}
+	raw, _ := tr.Config["stderr_tail"].(string)
+	if raw == "" {
+		return
+	}
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimRight(line, "\r ")
+		if line == "" {
+			continue
+		}
+		sink.ToolStderr(ctx, scanID, toolRunID, toolName, line)
+	}
 }
 
 // buildAssetLookup returns a map of asset value → asset ID for all assets of a target.

--- a/internal/storage/migrations/0006_scan_logs.sql
+++ b/internal/storage/migrations/0006_scan_logs.sql
@@ -1,0 +1,47 @@
+-- Issue #52: structured scan logs. Captures pipeline events
+-- (scan/phase/tool lifecycle, findings emitted, asset changes) so the
+-- webui can offer CLI-parity live log streaming and post-mortem
+-- inspection. Logs are best-effort — findings + tool_runs remain the
+-- canonical record. Pipeline writes are async + batched via the
+-- SQLiteLogSink so persistence latency never gates a scan.
+--
+-- Schema decisions:
+--   - id INTEGER AUTOINCREMENT: monotonic cursor for ?since=N pagination
+--     (faster than RFC3339 timestamps, no clock-skew weirdness).
+--   - tool_run_id NULLABLE TEXT, intentionally NO FK reference. The
+--     pipeline emits ToolStarted log lines BEFORE the matching
+--     tool_runs row is persisted (start log fires at tool.Run() entry;
+--     the row is INSERTed after the run completes). An FK with default
+--     enforcement would reject the start log and drop the whole batch.
+--     Dangling tool_run_id pointers are harmless: the column is opaque
+--     text used only for client-side grouping in the UI. (Migration
+--     0007 retroactively drops the FK from any DB that ran the buggy
+--     pre-revert 0006 schema.)
+--   - level CHECK constraint: only debug/info/warn/error are valid.
+--   - created_at separate from ts because retention queries scan by row
+--     creation time, not by event time (which can be backfilled).
+--   - FK CASCADE on scans: deleting a scan reaps its logs cleanly.
+
+CREATE TABLE IF NOT EXISTS scan_logs (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    scan_id      TEXT NOT NULL REFERENCES scans(id) ON DELETE CASCADE,
+    tool_run_id  TEXT,
+    ts           INTEGER NOT NULL,
+    source       TEXT NOT NULL,
+    level        TEXT NOT NULL DEFAULT 'info'
+                 CHECK (level IN ('debug','info','warn','error')),
+    text         TEXT NOT NULL,
+    created_at   TEXT NOT NULL
+);
+
+-- Hot path: paginate logs of a single scan by id cursor.
+CREATE INDEX IF NOT EXISTS idx_scan_logs_scan_id_id
+    ON scan_logs(scan_id, id);
+
+-- Retention sweeper: prune by row creation time.
+CREATE INDEX IF NOT EXISTS idx_scan_logs_created_at
+    ON scan_logs(created_at);
+
+PRAGMA user_version = 6;
+
+UPDATE agent_meta SET value = '6' WHERE key = 'schema_version';

--- a/internal/storage/migrations/0007_scan_logs_drop_fk.sql
+++ b/internal/storage/migrations/0007_scan_logs_drop_fk.sql
@@ -1,0 +1,44 @@
+-- Issue #52 follow-up: the original 0006 (shipped briefly in PR #53,
+-- reverted in #54) declared `tool_run_id REFERENCES tool_runs(id) ON
+-- DELETE SET NULL`. The FK rejected inserts because the pipeline emits
+-- ToolStarted log lines BEFORE the tool_runs row is persisted, so the
+-- entire batch failed under foreign_keys=1.
+--
+-- This migration recreates `scan_logs` without the tool_run_id FK on
+-- any DB that's already at user_version=6 from the buggy 0006. SQLite
+-- doesn't support DROP CONSTRAINT, so we use the standard rebuild
+-- pattern: new table → copy rows → drop old → rename. The new schema
+-- matches the (also-fixed) 0006 verbatim.
+--
+-- Idempotent against a fresh DB that ran the corrected 0006: the
+-- rebuild produces an identical schema; the existing rows (probably
+-- zero on a fresh install) round-trip unchanged.
+
+CREATE TABLE IF NOT EXISTS scan_logs_new (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    scan_id      TEXT NOT NULL REFERENCES scans(id) ON DELETE CASCADE,
+    tool_run_id  TEXT,
+    ts           INTEGER NOT NULL,
+    source       TEXT NOT NULL,
+    level        TEXT NOT NULL DEFAULT 'info'
+                 CHECK (level IN ('debug','info','warn','error')),
+    text         TEXT NOT NULL,
+    created_at   TEXT NOT NULL
+);
+
+INSERT INTO scan_logs_new (id, scan_id, tool_run_id, ts, source, level, text, created_at)
+SELECT id, scan_id, tool_run_id, ts, source, level, text, created_at
+FROM scan_logs;
+
+DROP TABLE scan_logs;
+ALTER TABLE scan_logs_new RENAME TO scan_logs;
+
+CREATE INDEX IF NOT EXISTS idx_scan_logs_scan_id_id
+    ON scan_logs(scan_id, id);
+
+CREATE INDEX IF NOT EXISTS idx_scan_logs_created_at
+    ON scan_logs(created_at);
+
+PRAGMA user_version = 7;
+
+UPDATE agent_meta SET value = '7' WHERE key = 'schema_version';

--- a/internal/storage/migrations_0004_test.go
+++ b/internal/storage/migrations_0004_test.go
@@ -51,16 +51,16 @@ func TestMigration0004_FreshDB(t *testing.T) {
 	}
 
 	// The newTestStore helper applies all embedded migrations, so the
-	// version reflects the latest (0005 adds scheduler_lock per
-	// SPEC-SCHED2.0).
+	// version reflects the latest (0007 drops the scan_logs FK on
+	// tool_run_id, issue #52).
 	v, err := s.GetMeta(ctx, "schema_version")
 	require.NoError(t, err)
-	assert.Equal(t, "5", v)
+	assert.Equal(t, "7", v)
 
 	var userVersion int
 	err = s.db.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&userVersion)
 	require.NoError(t, err)
-	assert.Equal(t, 5, userVersion)
+	assert.Equal(t, 7, userVersion)
 
 	var defaultsCount int
 	err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM schedule_defaults`).Scan(&defaultsCount)

--- a/internal/storage/scan_logs.go
+++ b/internal/storage/scan_logs.go
@@ -1,0 +1,150 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// InsertScanLogs writes a batch of log lines in a single transaction.
+// The SQLiteLogSink calls this from its background goroutine; callers
+// outside the sink path are unusual.
+//
+// Each row goes in via a single multi-row VALUES so the per-batch
+// overhead is one round-trip and one fsync (with WAL).
+func (s *SQLiteStore) InsertScanLogs(ctx context.Context, logs []model.ScanLog) error {
+	if len(logs) == 0 {
+		return nil
+	}
+	const cols = "(scan_id, tool_run_id, ts, source, level, text, created_at)"
+	placeholders := make([]string, len(logs))
+	args := make([]any, 0, len(logs)*7)
+	for i, l := range logs {
+		placeholders[i] = "(?, ?, ?, ?, ?, ?, ?)"
+		var trID any
+		if l.ToolRunID != "" {
+			trID = l.ToolRunID
+		}
+		level := string(l.Level)
+		if level == "" {
+			level = string(model.LogLevelInfo)
+		}
+		args = append(args,
+			l.ScanID,
+			trID,
+			l.Timestamp.UnixMilli(),
+			l.Source,
+			level,
+			l.Text,
+			l.CreatedAt.UTC().Format(time.RFC3339Nano),
+		)
+	}
+	q := "INSERT INTO scan_logs " + cols + " VALUES " + strings.Join(placeholders, ", ")
+	_, err := s.db.ExecContext(ctx, q, args...)
+	if err != nil {
+		return fmt.Errorf("insert scan_logs: %w", err)
+	}
+	return nil
+}
+
+// ListScanLogs returns log lines for the given scan, ordered by id ASC
+// (chronological). Pagination is via the Since cursor (exclusive lower
+// bound on id). The default limit is 200; callers may pass any value —
+// the HTTP handler caps at 1000.
+func (s *SQLiteStore) ListScanLogs(ctx context.Context, opts ScanLogListOptions) ([]model.ScanLog, error) {
+	if opts.ScanID == "" {
+		return nil, fmt.Errorf("scan_id required")
+	}
+	if opts.Limit <= 0 {
+		opts.Limit = 200
+	}
+
+	conds := []string{"scan_id = ?"}
+	args := []any{opts.ScanID}
+	if opts.Since > 0 {
+		conds = append(conds, "id > ?")
+		args = append(args, opts.Since)
+	}
+	if len(opts.Level) > 0 {
+		ph := make([]string, len(opts.Level))
+		for i, lv := range opts.Level {
+			ph[i] = "?"
+			args = append(args, string(lv))
+		}
+		conds = append(conds, "level IN ("+strings.Join(ph, ",")+")")
+	}
+	if len(opts.Source) > 0 {
+		ph := make([]string, len(opts.Source))
+		for i, src := range opts.Source {
+			ph[i] = "?"
+			args = append(args, src)
+		}
+		conds = append(conds, "source IN ("+strings.Join(ph, ",")+")")
+	}
+	if opts.ToolRunID != "" {
+		conds = append(conds, "tool_run_id = ?")
+		args = append(args, opts.ToolRunID)
+	}
+	q := `SELECT id, scan_id, IFNULL(tool_run_id, ''), ts, source, level, text, created_at
+	      FROM scan_logs WHERE ` + strings.Join(conds, " AND ") + `
+	      ORDER BY id ASC LIMIT ?`
+	args = append(args, opts.Limit)
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query scan_logs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := make([]model.ScanLog, 0, opts.Limit)
+	for rows.Next() {
+		var l model.ScanLog
+		var tsMs int64
+		var createdAt string
+		var lvl string
+		if err := rows.Scan(&l.ID, &l.ScanID, &l.ToolRunID, &tsMs, &l.Source, &lvl, &l.Text, &createdAt); err != nil {
+			return nil, fmt.Errorf("scan scan_log row: %w", err)
+		}
+		l.Timestamp = time.UnixMilli(tsMs).UTC()
+		l.Level = model.LogLevel(lvl)
+		if t, err := time.Parse(time.RFC3339Nano, createdAt); err == nil {
+			l.CreatedAt = t
+		}
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}
+
+// CountScanLogs returns the total log line count for a scan. No filters —
+// the UI uses this for the "X total" badge so it sees the absolute
+// total regardless of any filter chips applied.
+func (s *SQLiteStore) CountScanLogs(ctx context.Context, scanID string) (int, error) {
+	if scanID == "" {
+		return 0, fmt.Errorf("scan_id required")
+	}
+	var n int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(1) FROM scan_logs WHERE scan_id = ?`, scanID).Scan(&n)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	return n, err
+}
+
+// PruneScanLogsOlderThan deletes rows whose created_at is strictly
+// older than cutoff. Returns rows affected. The retention sweeper calls
+// this once a day when a retention setting is configured; absent the
+// setting, this is never invoked.
+func (s *SQLiteStore) PruneScanLogsOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM scan_logs WHERE created_at < ?`,
+		cutoff.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return 0, fmt.Errorf("prune scan_logs: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}

--- a/internal/storage/scan_logs_test.go
+++ b/internal/storage/scan_logs_test.go
@@ -1,0 +1,237 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+// seedScanForLogs creates a target + scan + tool_run so scan_logs FK
+// references resolve. Returns the scan and tool_run IDs.
+func seedScanForLogs(t *testing.T, s *SQLiteStore) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+	target := &model.Target{Value: "logs-test.example.com", Type: model.TargetTypeDomain, Scope: "external"}
+	require.NoError(t, s.CreateTarget(ctx, target))
+	now := time.Now().UTC()
+	scan := &model.Scan{
+		TargetID:  target.ID,
+		Type:      model.ScanTypeFull,
+		Status:    model.ScanStatusRunning,
+		Phase:     "discovery",
+		StartedAt: &now,
+	}
+	require.NoError(t, s.CreateScan(ctx, scan))
+	finished := now.Add(time.Second)
+	tr := &model.ToolRun{
+		ScanID:     scan.ID,
+		ToolName:   "subfinder",
+		Phase:      "discovery",
+		Status:     model.ToolRunCompleted,
+		StartedAt:  now,
+		FinishedAt: &finished,
+		DurationMs: 1000,
+	}
+	require.NoError(t, s.CreateToolRun(ctx, tr))
+	return scan.ID, tr.ID
+}
+
+func TestInsertScanLogs_BatchAndRoundtrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	scanID, trID := seedScanForLogs(t, s)
+
+	now := time.Now().UTC()
+	logs := []model.ScanLog{
+		{ScanID: scanID, ToolRunID: "", Source: "scanner", Level: model.LogLevelInfo, Text: "scan started", Timestamp: now, CreatedAt: now},
+		{ScanID: scanID, ToolRunID: trID, Source: "subfinder", Level: model.LogLevelInfo, Text: "tool started", Timestamp: now.Add(time.Millisecond), CreatedAt: now.Add(time.Millisecond)},
+		{ScanID: scanID, ToolRunID: trID, Source: "subfinder", Level: model.LogLevelWarn, Text: "rate limited", Timestamp: now.Add(2 * time.Millisecond), CreatedAt: now.Add(2 * time.Millisecond)},
+	}
+	require.NoError(t, s.InsertScanLogs(ctx, logs))
+
+	got, err := s.ListScanLogs(ctx, ScanLogListOptions{ScanID: scanID})
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, "scan started", got[0].Text)
+	assert.Equal(t, model.LogLevelInfo, got[0].Level)
+	assert.Equal(t, "", got[0].ToolRunID, "scan-level event has empty tool_run_id")
+	assert.Equal(t, trID, got[1].ToolRunID)
+	assert.Equal(t, model.LogLevelWarn, got[2].Level)
+}
+
+// TestInsertScanLogs_NoFKOnToolRunID is the regression guard for the
+// bug that triggered the revert + re-implementation. The pipeline
+// emits ToolStarted log lines BEFORE the matching tool_runs row is
+// inserted, so the column must NOT be foreign-key-constrained.
+// Inserting a row with a tool_run_id that doesn't exist must succeed.
+func TestInsertScanLogs_NoFKOnToolRunID(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	scanID, _ := seedScanForLogs(t, s)
+	require.NoError(t, s.InsertScanLogs(ctx, []model.ScanLog{
+		{ScanID: scanID, ToolRunID: "00000000-not-yet-persisted-tool-run", Source: "subfinder", Level: model.LogLevelInfo, Text: "tool started", Timestamp: time.Now(), CreatedAt: time.Now()},
+	}))
+	got, err := s.ListScanLogs(ctx, ScanLogListOptions{ScanID: scanID})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "00000000-not-yet-persisted-tool-run", got[0].ToolRunID)
+}
+
+func TestInsertScanLogs_EmptyIsNoop(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.InsertScanLogs(context.Background(), nil))
+	require.NoError(t, s.InsertScanLogs(context.Background(), []model.ScanLog{}))
+}
+
+func TestListScanLogs_PaginationCursor(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	scanID, _ := seedScanForLogs(t, s)
+
+	now := time.Now().UTC()
+	batch := make([]model.ScanLog, 50)
+	for i := range batch {
+		batch[i] = model.ScanLog{
+			ScanID:    scanID,
+			Source:    "scanner",
+			Level:     model.LogLevelInfo,
+			Text:      fmt.Sprintf("line %d", i),
+			Timestamp: now.Add(time.Duration(i) * time.Millisecond),
+			CreatedAt: now.Add(time.Duration(i) * time.Millisecond),
+		}
+	}
+	require.NoError(t, s.InsertScanLogs(ctx, batch))
+
+	page1, err := s.ListScanLogs(ctx, ScanLogListOptions{ScanID: scanID, Limit: 20})
+	require.NoError(t, err)
+	require.Len(t, page1, 20)
+	assert.Equal(t, "line 0", page1[0].Text)
+	assert.Equal(t, "line 19", page1[19].Text)
+
+	page2, err := s.ListScanLogs(ctx, ScanLogListOptions{ScanID: scanID, Since: page1[19].ID, Limit: 20})
+	require.NoError(t, err)
+	require.Len(t, page2, 20)
+	assert.Equal(t, "line 20", page2[0].Text)
+	assert.Greater(t, page2[0].ID, page1[19].ID)
+}
+
+func TestListScanLogs_LevelFilter(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	scanID, _ := seedScanForLogs(t, s)
+
+	now := time.Now().UTC()
+	require.NoError(t, s.InsertScanLogs(ctx, []model.ScanLog{
+		{ScanID: scanID, Source: "scanner", Level: model.LogLevelInfo, Text: "i", Timestamp: now, CreatedAt: now},
+		{ScanID: scanID, Source: "scanner", Level: model.LogLevelWarn, Text: "w", Timestamp: now, CreatedAt: now},
+		{ScanID: scanID, Source: "scanner", Level: model.LogLevelError, Text: "e", Timestamp: now, CreatedAt: now},
+	}))
+
+	got, err := s.ListScanLogs(ctx, ScanLogListOptions{
+		ScanID: scanID,
+		Level:  []model.LogLevel{model.LogLevelWarn, model.LogLevelError},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "w", got[0].Text)
+	assert.Equal(t, "e", got[1].Text)
+}
+
+func TestListScanLogs_SourceFilter(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	scanID, trID := seedScanForLogs(t, s)
+	now := time.Now().UTC()
+	require.NoError(t, s.InsertScanLogs(ctx, []model.ScanLog{
+		{ScanID: scanID, Source: "scanner", Level: model.LogLevelInfo, Text: "s", Timestamp: now, CreatedAt: now},
+		{ScanID: scanID, ToolRunID: trID, Source: "subfinder", Level: model.LogLevelInfo, Text: "sf", Timestamp: now, CreatedAt: now},
+		{ScanID: scanID, ToolRunID: trID, Source: "naabu", Level: model.LogLevelInfo, Text: "n", Timestamp: now, CreatedAt: now},
+	}))
+
+	got, err := s.ListScanLogs(ctx, ScanLogListOptions{
+		ScanID: scanID,
+		Source: []string{"subfinder", "naabu"},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+}
+
+func TestCountScanLogs(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	scanID, _ := seedScanForLogs(t, s)
+	require.NoError(t, s.InsertScanLogs(ctx, []model.ScanLog{
+		{ScanID: scanID, Source: "scanner", Text: "a", Timestamp: time.Now(), CreatedAt: time.Now()},
+		{ScanID: scanID, Source: "scanner", Text: "b", Timestamp: time.Now(), CreatedAt: time.Now()},
+	}))
+	n, err := s.CountScanLogs(ctx, scanID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+}
+
+func TestPruneScanLogsOlderThan(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	scanID, _ := seedScanForLogs(t, s)
+	old := time.Now().UTC().Add(-48 * time.Hour)
+	fresh := time.Now().UTC()
+	require.NoError(t, s.InsertScanLogs(ctx, []model.ScanLog{
+		{ScanID: scanID, Source: "scanner", Text: "old", Timestamp: old, CreatedAt: old},
+		{ScanID: scanID, Source: "scanner", Text: "old2", Timestamp: old, CreatedAt: old},
+		{ScanID: scanID, Source: "scanner", Text: "fresh", Timestamp: fresh, CreatedAt: fresh},
+	}))
+	deleted, err := s.PruneScanLogsOlderThan(ctx, time.Now().UTC().Add(-24*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), deleted)
+	got, _ := s.ListScanLogs(ctx, ScanLogListOptions{ScanID: scanID})
+	require.Len(t, got, 1)
+	assert.Equal(t, "fresh", got[0].Text)
+}
+
+func TestCascade_ScanDeletePrunesLogs(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	scanID, _ := seedScanForLogs(t, s)
+	require.NoError(t, s.InsertScanLogs(ctx, []model.ScanLog{
+		{ScanID: scanID, Source: "scanner", Text: "a", Timestamp: time.Now(), CreatedAt: time.Now()},
+	}))
+	n, _ := s.CountScanLogs(ctx, scanID)
+	require.Equal(t, 1, n)
+	_, err := s.db.ExecContext(ctx, "DELETE FROM scans WHERE id = ?", scanID)
+	require.NoError(t, err)
+	n2, _ := s.CountScanLogs(ctx, scanID)
+	assert.Equal(t, 0, n2, "FK CASCADE: deleting scan must drop scan_logs rows")
+}
+
+// scan_logs.tool_run_id is a plain TEXT column without an FK
+// reference (see 0006_scan_logs.sql comment). Deleting the
+// referenced tool_runs row must NOT touch scan_logs — the log stays
+// as-is with its now-dangling but harmless pointer. This guards
+// against a future "let's add the FK back" reflex.
+func TestToolRunDeletePreservesLogs(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	scanID, trID := seedScanForLogs(t, s)
+	require.NoError(t, s.InsertScanLogs(ctx, []model.ScanLog{
+		{ScanID: scanID, ToolRunID: trID, Source: "subfinder", Text: "tool log", Timestamp: time.Now(), CreatedAt: time.Now()},
+	}))
+	_, err := s.db.ExecContext(ctx, "DELETE FROM tool_runs WHERE id = ?", trID)
+	require.NoError(t, err)
+	got, err := s.ListScanLogs(ctx, ScanLogListOptions{ScanID: scanID})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, trID, got[0].ToolRunID,
+		"deleting tool_run does not touch scan_logs (no FK on tool_run_id)")
+}
+
+func TestListScanLogs_RequiresScanID(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.ListScanLogs(context.Background(), ScanLogListOptions{})
+	require.Error(t, err)
+}

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -32,10 +32,10 @@ func TestNewSQLiteStore(t *testing.T) {
 	}
 
 	// Verify agent_meta seeded. schema_version tracks the latest applied
-	// migration: 0005 (scheduler_lock, SPEC-SCHED2.0) bumps it to "5".
+	// migration: 0007 (scan_logs FK drop, issue #52) bumps it to "7".
 	v, err := s.GetMeta(ctx, "schema_version")
 	require.NoError(t, err)
-	assert.Equal(t, "5", v)
+	assert.Equal(t, "7", v)
 }
 
 func TestTargetCRUD(t *testing.T) {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -128,7 +128,25 @@ type Store interface {
 	AssetChangeCountsForScan(ctx context.Context, scanID string) (map[string]map[model.AssetType]int, error)
 	ScanIsBaseline(ctx context.Context, scanID string) (bool, error)
 
+	// --- Scan logs (see scan_logs.go, issue #52) ---
+	InsertScanLogs(ctx context.Context, logs []model.ScanLog) error
+	ListScanLogs(ctx context.Context, opts ScanLogListOptions) ([]model.ScanLog, error)
+	CountScanLogs(ctx context.Context, scanID string) (int, error)
+	PruneScanLogsOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
+
 	Close() error
+}
+
+// ScanLogListOptions narrows a /scan_logs query. ScanID is required;
+// everything else is optional. Limit defaults to 200 and is capped at
+// 1000 by the handler before reaching here.
+type ScanLogListOptions struct {
+	ScanID    string           // required
+	Since     int64            // exclusive lower bound on id; 0 = from beginning
+	Limit     int              // default 200
+	Level     []model.LogLevel // optional level filter (OR'd)
+	Source    []string         // optional source filter (OR'd)
+	ToolRunID string           // optional, narrows to a single tool run
 }
 
 // SQLiteStore implements Store using modernc.org/sqlite.
@@ -160,6 +178,18 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 	if err := db.Ping(); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("pinging database: %w", err)
+	}
+
+	// :memory: SQLite databases are per-connection — modernc.org/sqlite
+	// allocates a fresh in-memory DB for each pooled connection, so a
+	// migration applied on connection A is invisible to a query on
+	// connection B. Issue #52 surfaced this when the SQLiteLogSink's
+	// background goroutine grabbed a different connection than the
+	// migration runner. Pinning the pool to 1 connection eliminates
+	// the race in tests; production paths use a real file and are
+	// unaffected.
+	if dbPath == ":memory:" {
+		db.SetMaxOpenConns(1)
 	}
 
 	// Restrict DB file permissions — it may contain sensitive scan data.
@@ -221,6 +251,28 @@ func (s *SQLiteStore) runMigrations() error {
 		}
 		if _, err = s.db.Exec(string(m005)); err != nil {
 			return fmt.Errorf("executing migration 0005: %w", err)
+		}
+	}
+
+	schemaVersion, _ = s.getSchemaVersion()
+	if schemaVersion < 6 {
+		m006, err := migrationsFS.ReadFile("migrations/0006_scan_logs.sql")
+		if err != nil {
+			return fmt.Errorf("reading migration 0006: %w", err)
+		}
+		if _, err = s.db.Exec(string(m006)); err != nil {
+			return fmt.Errorf("executing migration 0006: %w", err)
+		}
+	}
+
+	schemaVersion, _ = s.getSchemaVersion()
+	if schemaVersion < 7 {
+		m007, err := migrationsFS.ReadFile("migrations/0007_scan_logs_drop_fk.sql")
+		if err != nil {
+			return fmt.Errorf("reading migration 0007: %w", err)
+		}
+		if _, err = s.db.Exec(string(m007)); err != nil {
+			return fmt.Errorf("executing migration 0007: %w", err)
 		}
 	}
 

--- a/internal/webui/foundation_assets_test.go
+++ b/internal/webui/foundation_assets_test.go
@@ -484,6 +484,10 @@ func TestScanDetailWiresLogStream(t *testing.T) {
 		// B7 fix: completed-with-warnings badge variant.
 		"_statusBadgeWithWarnings(",
 		"badge-completed-warn",
+		// Proposal B (#52 follow-up): timeout-aware "Partial run" notice.
+		"_isTimeoutError(",
+		"pipeline-detail-notice",
+		"Partial run",
 	}
 	for _, s := range required {
 		assert.True(t, strings.Contains(js, s),
@@ -520,6 +524,11 @@ func TestScanLogsCSSScaffolding(t *testing.T) {
 		".progress-bar-track-indeterminate",
 		// B7 fix: completed-with-warnings badge.
 		".badge-completed-warn",
+		// Proposal B: partial-run notice block.
+		".pipeline-detail-notice",
+		".pipeline-detail-notice-heading",
+		".pipeline-detail-notice-body",
+		".pipeline-detail-tech",
 	}
 	for _, c := range classes {
 		assert.True(t, strings.Contains(css, c),

--- a/internal/webui/foundation_assets_test.go
+++ b/internal/webui/foundation_assets_test.go
@@ -451,6 +451,116 @@ func TestPR7CSSScaffolding(t *testing.T) {
 	}
 }
 
+// Issue #52 — scan_logs frontend integration. The HEAD probe + log
+// rendering now have a real backend behind them. Guard that the
+// frontend wires the polling helpers, color-coded line renderer, and
+// toolbar controls (pause/wrap/download/level chips) against silent
+// regression. Also guards the B2/B4/B7 UI fixes baked into the
+// re-implementation.
+
+func TestScanDetailWiresLogStream(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/pages/scan_detail.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	required := []string{
+		"_fetchLogs(",
+		"_startLogsPolling(",
+		"_renderLogLine(",
+		"_renderLogToolbar(",
+		"_filteredLogs(",
+		"_downloadLogs(",
+		"_bindLogControls(",
+		"data-log-level=",
+		"data-log-source=",
+		"data-log-pause",
+		"data-log-wrap",
+		"data-log-download",
+		"API.scanLogs(",
+		"_logsPaused",
+		"_logsWrap",
+		// B2 fix: indeterminate track class instead of width:100% fallback.
+		"progress-bar-track-indeterminate",
+		// B7 fix: completed-with-warnings badge variant.
+		"_statusBadgeWithWarnings(",
+		"badge-completed-warn",
+	}
+	for _, s := range required {
+		assert.True(t, strings.Contains(js, s),
+			"scan_detail.js must reference %q after #52", s)
+	}
+}
+
+func TestAPIWiresScanLogs(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/api.js")
+	require.NoError(t, err)
+	js := string(data)
+	assert.True(t, strings.Contains(js, "scanLogs(id, params)"),
+		"api.js must expose scanLogs() helper after #52")
+}
+
+func TestScanLogsCSSScaffolding(t *testing.T) {
+	data, err := staticFS.ReadFile("static/css/style.css")
+	require.NoError(t, err)
+	css := string(data)
+	classes := []string{
+		// Live log card.
+		".scan-log-header", ".scan-log-toolbar",
+		".scan-log-chips", ".scan-log-chip",
+		".scan-log-chip-error", ".scan-log-chip-warn",
+		".scan-log-actions", ".scan-log-pre",
+		".scan-log-pre-preview", ".scan-log-pre-full",
+		".scan-log-wrap",
+		".scan-log-line", ".scan-log-line-error",
+		".scan-log-line-warn", ".scan-log-line-debug",
+		".scan-log-ts", ".scan-log-src",
+		".scan-log-empty", ".scan-log-cta",
+		".scan-log-count",
+		// B2 fix: indeterminate track shimmer.
+		".progress-bar-track-indeterminate",
+		// B7 fix: completed-with-warnings badge.
+		".badge-completed-warn",
+	}
+	for _, c := range classes {
+		assert.True(t, strings.Contains(css, c),
+			"scan_logs CSS class %q missing from style.css", c)
+	}
+}
+
+// B3 fix (#52): the phase tracker grid must use FIXED widths for the
+// duration and summary columns so the progress bar column is uniform
+// across phases. The previous `auto auto` declaration squeezed bars
+// unevenly when summary text length varied.
+func TestPhaseTrackerHasFixedColumns(t *testing.T) {
+	data, err := staticFS.ReadFile("static/css/style.css")
+	require.NoError(t, err)
+	css := string(data)
+	// Reject the legacy `auto auto` columns and require explicit
+	// pixel widths instead.
+	assert.False(t,
+		strings.Contains(css, "minmax(0, 2fr) minmax(0, 3fr) auto auto"),
+		"phase-body must not use auto-sized duration/summary columns (B3 #52)")
+	assert.True(t,
+		strings.Contains(css, "minmax(0, 2fr) minmax(0, 3fr) 64px 160px"),
+		"phase-body must declare fixed-width duration/summary columns (B3 #52)")
+}
+
+// B4 fix (#52): the highlighted background on an open pipeline node
+// must wrap the WHOLE node so the connector dot lives inside the
+// visible card. The legacy CSS only highlighted .pipeline-content,
+// which left the dot floating outside. Either an exact-match selector
+// or a grouped form (e.g. ":hover, .pipeline-node-open {") satisfies.
+func TestPipelineOpenWrapsWholeNode(t *testing.T) {
+	data, err := staticFS.ReadFile("static/css/style.css")
+	require.NoError(t, err)
+	css := string(data)
+	exact := strings.Contains(css, ".pipeline-node.pipeline-node-open {")
+	grouped := strings.Contains(css, ".pipeline-node.pipeline-node-open,") ||
+		strings.Contains(css, ".pipeline-node-clickable:hover,\n.pipeline-node.pipeline-node-open")
+	assert.True(t, exact || grouped,
+		"pipeline-node-open must apply background to the whole node (B4 #52)")
+}
+
 func TestIndexHTMLLoadsScanDetail(t *testing.T) {
 	data, err := staticFS.ReadFile("static/index.html")
 	require.NoError(t, err)

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -1017,6 +1017,11 @@ func (h *handler) handleCreateScan(w http.ResponseWriter, r *http.Request) {
 
 	// Create pipeline and run async
 	pipe := pipeline.New(h.store, h.registry)
+	// Issue #52: tee pipeline events into scan_logs so the webui's
+	// live log card can render in real time. Sink lives for the
+	// duration of the scan goroutine and is closed on completion.
+	sink := pipeline.NewSQLiteLogSink(h.store, pipeline.SQLiteLogSinkOptions{})
+	pipe.SetSink(sink)
 	opts := pipeline.PipelineOptions{
 		ScanType:  scanType,
 		Tools:     req.Tools,
@@ -1030,6 +1035,7 @@ func (h *handler) handleCreateScan(w http.ResponseWriter, r *http.Request) {
 	h.scanMu.Unlock()
 
 	go func() {
+		defer func() { _ = sink.Close() }()
 		result, err := pipe.Run(scanCtx, target.ID, opts)
 
 		h.scanMu.Lock()
@@ -1148,6 +1154,153 @@ func (h *handler) handleCancelScan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+// --- Scan Logs (issue #52) ---
+
+// handleScanLogs serves GET and HEAD /api/v1/scans/{id}/logs.
+//
+//	HEAD: 200 if the scan exists, 404 otherwise. Used by the SPA's
+//	      _probeLogsEndpoint to feature-detect the live log stream.
+//	GET:  paginated list of log lines for the scan, ordered by id ASC.
+//	      ?since=N (exclusive cursor), ?limit=N (default 200, max 1000),
+//	      ?level=info,warn (CSV filter), ?source=naabu,nuclei (CSV).
+//
+// Response shape (matches frontend expectation):
+//
+//	{ "lines": [...ScanLog...], "next": <int>, "has_more": <bool> }
+func (h *handler) handleScanLogs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	id := strings.TrimPrefix(r.URL.Path, "/api/v1/scans/")
+	id = strings.TrimSuffix(id, "/logs")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing scan id")
+		return
+	}
+	// Verify scan exists for both methods so HEAD's 200 is meaningful
+	// and GET doesn't silently return [] for a typo'd id.
+	if _, err := h.store.GetScan(r.Context(), id); err != nil {
+		writeError(w, http.StatusNotFound, "scan not found")
+		return
+	}
+	if r.Method == http.MethodHead {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	since := parseInt64Query(r, "since", 0)
+	limit := parseIntQuery(r, "limit", 200)
+	if limit <= 0 {
+		writeError(w, http.StatusBadRequest, "limit must be positive")
+		return
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+
+	opts := storage.ScanLogListOptions{
+		ScanID:    id,
+		Since:     since,
+		Limit:     limit,
+		Level:     parseLogLevels(r.URL.Query().Get("level")),
+		Source:    parseCSV(r.URL.Query().Get("source")),
+		ToolRunID: r.URL.Query().Get("tool_run_id"),
+	}
+	logs, err := h.store.ListScanLogs(r.Context(), opts)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list logs")
+		return
+	}
+	if logs == nil {
+		logs = []model.ScanLog{}
+	}
+	next := since
+	hasMore := false
+	if n := len(logs); n > 0 {
+		next = logs[n-1].ID
+		hasMore = n >= limit
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"lines":    logs,
+		"next":     next,
+		"has_more": hasMore,
+	})
+}
+
+// parseInt64Query reads an int64 query param, returning fallback on
+// missing/invalid input. Negative values fall back too — the only
+// caller is `since` which is a non-negative cursor.
+func parseInt64Query(r *http.Request, key string, fallback int64) int64 {
+	v := r.URL.Query().Get(key)
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || n < 0 {
+		return fallback
+	}
+	return n
+}
+
+// parseIntQuery reads an int query param, returning fallback on
+// missing/invalid input.
+func parseIntQuery(r *http.Request, key string, fallback int) int {
+	v := r.URL.Query().Get(key)
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fallback
+	}
+	return n
+}
+
+// parseLogLevels splits a CSV "info,warn,error" into a typed slice,
+// dropping unknown values silently. Returns nil for empty input so the
+// store layer can treat absent-filter and empty-list identically.
+func parseLogLevels(csv string) []model.LogLevel {
+	if csv == "" {
+		return nil
+	}
+	known := map[model.LogLevel]bool{
+		model.LogLevelDebug: true, model.LogLevelInfo: true,
+		model.LogLevelWarn: true, model.LogLevelError: true,
+	}
+	out := make([]model.LogLevel, 0, 4)
+	for _, p := range strings.Split(csv, ",") {
+		lv := model.LogLevel(strings.TrimSpace(p))
+		if known[lv] {
+			out = append(out, lv)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// parseCSV is the source filter sibling of parseLogLevels, but without
+// the controlled vocabulary — tool names are an open set.
+func parseCSV(csv string) []string {
+	if csv == "" {
+		return nil
+	}
+	parts := strings.Split(csv, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		s := strings.TrimSpace(p)
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // --- Available Tools ---

--- a/internal/webui/handlers_scan_logs_test.go
+++ b/internal/webui/handlers_scan_logs_test.go
@@ -1,0 +1,194 @@
+package webui
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+	"github.com/surfbot-io/surfbot-agent/internal/storage"
+)
+
+// seedScanLogs creates a scan + tool_run and inserts n log lines.
+// Returns the scan ID. Used by every scan_logs handler test.
+func seedScanLogs(t *testing.T, s *storage.SQLiteStore, n int) string {
+	t.Helper()
+	ctx := context.Background()
+	target := &model.Target{Value: "logs.example.com"}
+	require.NoError(t, s.CreateTarget(ctx, target))
+	now := time.Now().UTC()
+	scan := &model.Scan{
+		TargetID:  target.ID,
+		Type:      model.ScanTypeFull,
+		Status:    model.ScanStatusRunning,
+		Phase:     "discovery",
+		StartedAt: &now,
+	}
+	require.NoError(t, s.CreateScan(ctx, scan))
+	logs := make([]model.ScanLog, 0, n)
+	for i := 0; i < n; i++ {
+		level := model.LogLevelInfo
+		if i%5 == 0 {
+			level = model.LogLevelWarn
+		}
+		source := "scanner"
+		if i%2 == 0 {
+			source = "subfinder"
+		}
+		logs = append(logs, model.ScanLog{
+			ScanID:    scan.ID,
+			Source:    source,
+			Level:     level,
+			Text:      "line",
+			Timestamp: now.Add(time.Duration(i) * time.Millisecond),
+			CreatedAt: now.Add(time.Duration(i) * time.Millisecond),
+		})
+	}
+	if len(logs) > 0 {
+		require.NoError(t, s.InsertScanLogs(ctx, logs))
+	}
+	return scan.ID
+}
+
+func TestHandleScanLogs_HEAD_OK(t *testing.T) {
+	h, s := newTestHandler(t)
+	scanID := seedScanLogs(t, s, 0)
+
+	req := httptest.NewRequest(http.MethodHead, "/api/v1/scans/"+scanID+"/logs", nil)
+	w := httptest.NewRecorder()
+	h.handleScanLogs(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Body.Bytes(), "HEAD response body should be empty")
+}
+
+func TestHandleScanLogs_HEAD_NotFound(t *testing.T) {
+	h, _ := newTestHandler(t)
+	req := httptest.NewRequest(http.MethodHead, "/api/v1/scans/00000000-0000-0000-0000-000000000000/logs", nil)
+	w := httptest.NewRecorder()
+	h.handleScanLogs(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleScanLogs_GET_BasicShape(t *testing.T) {
+	h, s := newTestHandler(t)
+	scanID := seedScanLogs(t, s, 5)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scans/"+scanID+"/logs", nil)
+	w := httptest.NewRecorder()
+	h.handleScanLogs(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Contains(t, resp, "lines")
+	assert.Contains(t, resp, "next")
+	assert.Contains(t, resp, "has_more")
+	lines, _ := resp["lines"].([]any)
+	require.Len(t, lines, 5)
+	first, _ := lines[0].(map[string]any)
+	assert.NotEmpty(t, first["scan_id"])
+	assert.NotEmpty(t, first["text"])
+	assert.NotEmpty(t, first["level"])
+	assert.NotEmpty(t, first["source"])
+}
+
+func TestHandleScanLogs_GET_PaginationCursor(t *testing.T) {
+	h, s := newTestHandler(t)
+	scanID := seedScanLogs(t, s, 50)
+
+	req1 := httptest.NewRequest(http.MethodGet, "/api/v1/scans/"+scanID+"/logs?limit=10", nil)
+	w1 := httptest.NewRecorder()
+	h.handleScanLogs(w1, req1)
+	require.Equal(t, http.StatusOK, w1.Code)
+	var page1 map[string]any
+	require.NoError(t, json.Unmarshal(w1.Body.Bytes(), &page1))
+	assert.True(t, page1["has_more"].(bool))
+	cursor := int64(page1["next"].(float64))
+
+	url2 := "/api/v1/scans/" + scanID + "/logs?limit=10&since=" + strconv.FormatInt(cursor, 10)
+	req2 := httptest.NewRequest(http.MethodGet, url2, nil)
+	w2 := httptest.NewRecorder()
+	h.handleScanLogs(w2, req2)
+	require.Equal(t, http.StatusOK, w2.Code)
+	var page2 map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &page2))
+	lines2, _ := page2["lines"].([]any)
+	require.Len(t, lines2, 10)
+	first2 := lines2[0].(map[string]any)
+	assert.Greater(t, int64(first2["id"].(float64)), cursor)
+}
+
+func TestHandleScanLogs_GET_LimitCap(t *testing.T) {
+	h, s := newTestHandler(t)
+	scanID := seedScanLogs(t, s, 10)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scans/"+scanID+"/logs?limit=5000", nil)
+	w := httptest.NewRecorder()
+	h.handleScanLogs(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestHandleScanLogs_GET_LimitInvalid(t *testing.T) {
+	h, s := newTestHandler(t)
+	scanID := seedScanLogs(t, s, 1)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scans/"+scanID+"/logs?limit=-5", nil)
+	w := httptest.NewRecorder()
+	h.handleScanLogs(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleScanLogs_GET_LevelFilter(t *testing.T) {
+	h, s := newTestHandler(t)
+	scanID := seedScanLogs(t, s, 25) // every 5th line is warn → 5 warns
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scans/"+scanID+"/logs?level=warn", nil)
+	w := httptest.NewRecorder()
+	h.handleScanLogs(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	lines := resp["lines"].([]any)
+	assert.Equal(t, 5, len(lines), "5 of 25 lines should be warn")
+}
+
+func TestHandleScanLogs_GET_SourceFilter(t *testing.T) {
+	h, s := newTestHandler(t)
+	scanID := seedScanLogs(t, s, 10) // 5 subfinder + 5 scanner
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scans/"+scanID+"/logs?source=subfinder", nil)
+	w := httptest.NewRecorder()
+	h.handleScanLogs(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	lines := resp["lines"].([]any)
+	require.Equal(t, 5, len(lines))
+	for _, ln := range lines {
+		assert.Equal(t, "subfinder", ln.(map[string]any)["source"])
+	}
+}
+
+func TestHandleScanLogs_GET_NotFound(t *testing.T) {
+	h, _ := newTestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scans/00000000-0000-0000-0000-000000000000/logs", nil)
+	w := httptest.NewRecorder()
+	h.handleScanLogs(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleScanLogs_MethodNotAllowed(t *testing.T) {
+	h, s := newTestHandler(t)
+	scanID := seedScanLogs(t, s, 0)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/scans/"+scanID+"/logs", nil)
+	w := httptest.NewRecorder()
+	h.handleScanLogs(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -115,7 +115,14 @@ func NewServer(store *storage.SQLiteStore, opts ServerOptions) (*http.Server, ne
 		}
 	})
 	mux.HandleFunc("/api/v1/scans/", func(w http.ResponseWriter, r *http.Request) {
-		// /api/v1/scans/status is handled above by the more specific route
+		// /api/v1/scans/status is handled above by the more specific route.
+		// Issue #52: /api/v1/scans/{id}/logs branches off here; the
+		// /logs suffix is checked before the generic detail/cancel
+		// dispatch so the path doesn't get treated as a scan id.
+		if strings.HasSuffix(r.URL.Path, "/logs") {
+			h.handleScanLogs(w, r)
+			return
+		}
 		switch r.Method {
 		case http.MethodGet:
 			h.handleScanDetail(w, r)

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -3260,3 +3260,67 @@ button.kpi-card:focus-visible {
   text-decoration: none;
 }
 .scan-log-cta:hover   { text-decoration: underline; }
+
+/* Proposal B (#52 follow-up): "Partial run" notice rendered inside a
+   pipeline-detail accordion when a tool completed with a deadline-
+   exceeded error. Replaces the previous Stderr tail + Error pair of
+   red sections with one amber notice block + collapsible technical
+   detail. The visual tone matches the .badge-completed-warn pill on
+   the row header so the two cues read as one consistent signal. */
+.pipeline-detail-notice {
+  background: var(--sev-medium-bg, rgba(210, 153, 34, 0.10));
+  border: 1px solid rgba(210, 153, 34, 0.35);
+  border-radius: 6px;
+  padding: 12px 14px;
+}
+.pipeline-detail-notice-heading {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--sev-medium, #d29922);
+  margin-bottom: 6px;
+  letter-spacing: 0.02em;
+}
+.pipeline-detail-notice-body {
+  font-size: 13px;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+.pipeline-detail-notice-body p {
+  margin: 0 0 6px;
+}
+.pipeline-detail-notice-body p:last-child {
+  margin-bottom: 0;
+}
+.pipeline-detail-notice-body strong {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.pipeline-detail-tech {
+  margin-top: 10px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.pipeline-detail-tech > summary {
+  cursor: pointer;
+  user-select: none;
+  padding: 4px 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 500;
+  list-style: none;
+}
+.pipeline-detail-tech > summary::-webkit-details-marker { display: none; }
+.pipeline-detail-tech > summary::before {
+  content: "▸ ";
+  display: inline-block;
+  transition: transform 0.12s;
+}
+.pipeline-detail-tech[open] > summary::before {
+  transform: rotate(90deg);
+}
+.pipeline-detail-tech > summary:hover {
+  color: var(--text-primary);
+}
+.pipeline-detail-tech .pipeline-detail-heading {
+  margin-top: 8px;
+}

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -495,18 +495,35 @@ tr.finding-detail-row td.finding-detail-cell {
   transition: background 0.15s ease;
 }
 
-.pipeline-node.pipeline-node-clickable:hover .pipeline-content {
+/* B4 fix (#52): the highlighted background now applies to the WHOLE
+   `.pipeline-node` (not just `.pipeline-content`) so the connector
+   dot lives inside the visible card boundary when the accordion is
+   open. Previously the dot floated outside the gray box and looked
+   orphaned, especially in the Phases tab. We give the node itself
+   horizontal padding when hovered/open so the dot has breathing room
+   inside the highlighted region. */
+.pipeline-node.pipeline-node-clickable:hover,
+.pipeline-node.pipeline-node-open {
   background: var(--bg-hover);
+  padding: 6px 10px;
+  margin: 0 -10px;
 }
 
+/* Reset the inner content padding when the node itself is the
+   highlighted box — otherwise we'd double-pad. */
+.pipeline-node.pipeline-node-clickable:hover .pipeline-content,
 .pipeline-node.pipeline-node-open .pipeline-content {
-  background: var(--bg-hover);
+  background: transparent;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .pipeline-content {
   padding: 6px 10px;
   border-radius: 4px;
   transition: background 0.15s ease;
+  flex: 1;
+  min-width: 0;
 }
 
 .pipeline-chevron {
@@ -2919,19 +2936,33 @@ button.kpi-card:focus-visible {
   background: var(--ink-700);
   margin-top: 4px;
 }
+/* B3 fix (#52): the previous grid used `auto auto` for the duration
+   and summary cells, which let varying text lengths squeeze the
+   progress-bar column unevenly (e.g. "30.5s" vs "10m 5s"). Fixed
+   widths on cols 3-4 keep the bar column uniform across phases so
+   percent comparisons are visually honest. */
 .phase-body {
   flex: 1;
   display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(0, 3fr) auto auto;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 3fr) 64px 160px;
   gap: 12px;
   align-items: center;
 }
 .phase-name { font-size: 13px; font-weight: 500; color: var(--text-primary); }
 .phase-tool { font-size: 11px; }
-.phase-duration, .phase-summary {
+.phase-duration {
   font-size: 11px;
   font-variant-numeric: tabular-nums;
   text-align: right;
+  white-space: nowrap;
+}
+.phase-summary {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .phase-bar, .phase-bar-track {
   height: 6px;
@@ -3099,3 +3130,133 @@ button.kpi-card:focus-visible {
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
+
+/* ============================================================
+   #52 — Scan logs UI fixes: indeterminate progress, completed-with-
+   warnings badge, live log card.
+   ============================================================ */
+
+/* B2 fix: when a scan is running but reports 0% progress (haven't
+   advanced past the first phase yet), the fill stays at 0% width and
+   the empty TRACK shows a sliding shimmer so the user sees motion
+   without a misleading full-width "completed-looking" bar. */
+.progress-bar-track-indeterminate {
+  position: relative;
+  overflow: hidden;
+}
+.progress-bar-track-indeterminate::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -30%;
+  width: 30%;
+  background: linear-gradient(90deg, transparent 0%, var(--brand) 50%, transparent 100%);
+  opacity: 0.45;
+  animation: progress-indeterminate 1.6s linear infinite;
+}
+@keyframes progress-indeterminate {
+  0%   { left: -30%; }
+  100% { left: 100%; }
+}
+
+/* B7 fix: tool runs that completed but recorded an error_message
+   (canonical case: nuclei after `context deadline exceeded`) show a
+   yellow "completed (warnings)" badge so operators don't mistake
+   them for a clean run. The hover title surfaces the error string. */
+.badge-status.badge-completed-warn {
+  background: var(--sev-medium-bg, rgba(210, 153, 34, 0.18));
+  border: 1px solid rgba(210, 153, 34, 0.4);
+  color: var(--sev-medium, #d29922);
+}
+
+/* Live log toolbar + chips + pre. The card itself reuses the
+   existing .scan-logs-card class. */
+.scan-log-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+.scan-log-count {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+.scan-log-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin: 8px 0 10px;
+}
+.scan-log-chips {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 11px;
+}
+.scan-log-chips-label {
+  font-size: 11px;
+  margin-right: 2px;
+}
+.scan-log-chips-sep {
+  color: var(--text-muted);
+}
+.scan-log-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  background: var(--ink-800);
+  border: 1px solid var(--ink-600);
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.scan-log-chip:hover { background: var(--ink-700); color: var(--text-primary); }
+.scan-log-chip.active {
+  background: rgba(0,229,153,0.10);
+  border-color: rgba(0,229,153,0.4);
+  color: var(--brand);
+}
+.scan-log-chip-error.active { background: var(--sev-critical-bg); border-color: rgba(248,81,73,0.4); color: var(--sev-critical); }
+.scan-log-chip-warn.active  { background: var(--sev-medium-bg);   border-color: rgba(210,153,34,0.4); color: var(--sev-medium); }
+.scan-log-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.scan-log-pre {
+  background: var(--ink-900);
+  border: 1px solid var(--ink-700);
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin: 0;
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-x: auto;
+  overflow-y: auto;
+  white-space: pre;
+}
+.scan-log-pre-preview { max-height: 168px; }
+.scan-log-pre-full    { max-height: 480px; }
+.scan-log-wrap        { white-space: pre-wrap; word-break: break-word; }
+.scan-log-line        { display: block; }
+.scan-log-line-error .scan-log-text { color: var(--sev-critical); }
+.scan-log-line-warn  .scan-log-text { color: var(--sev-medium); }
+.scan-log-line-debug .scan-log-text { color: var(--text-muted); }
+.scan-log-ts          { font-size: 11px; }
+.scan-log-src         { color: var(--brand); font-weight: 500; }
+.scan-log-empty       { padding: 16px 0; text-align: center; }
+.scan-log-cta {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--brand);
+  text-decoration: none;
+}
+.scan-log-cta:hover   { text-decoration: underline; }

--- a/internal/webui/static/js/api.js
+++ b/internal/webui/static/js/api.js
@@ -67,6 +67,7 @@ const API = {
   assetTree(targetId)   { return this.get('/assets/tree' + toQuery({ target_id: targetId })); },
   scans(params)         { return this.get('/scans' + toQuery(params)); },
   scan(id)              { return this.get('/scans/' + id); },
+  scanLogs(id, params)  { return this.get('/scans/' + encodeURIComponent(id) + '/logs' + toQuery(params)); },
   targets()             { return this.get('/targets'); },
   target(id)            { return this.get('/targets/' + id); },
   tools()               { return this.get('/tools'); },

--- a/internal/webui/static/js/pages/scan_detail.js
+++ b/internal/webui/static/js/pages/scan_detail.js
@@ -1,9 +1,7 @@
-// PR7 (#40): scan-detail page extracted from scans.js. Owns the
-// /#/scans/:id route. 4-tab view (Overview / Phases / Logs / Config),
-// 5-phase tracker, live findings panel, polling lifecycle scoped to
-// running scans. Cancel scan + topbar deep link integrate here. The
-// Logs tab degrades to a placeholder until the backend endpoint exists
-// — the HEAD probe primes a flip-on path for when it ships.
+// PR7 (#40) + #52: scan-detail page with live log streaming. Owns
+// the /#/scans/:id route. 4-tab view (Overview / Phases / Logs /
+// Config), 5-phase tracker, live findings panel, polling lifecycle
+// scoped to running scans. Cancel + topbar deep link integrate here.
 const ScanDetailPage = {
   POLL_MS: 2000,
   ELAPSED_MS: 1000,
@@ -14,18 +12,23 @@ const ScanDetailPage = {
     { key: 'http_probe', label: 'HTTP probe', defaultTool: 'httpx' },
     { key: 'assess',     label: 'Assessment', defaultTool: 'nuclei' },
   ],
-  // Backend uses `assessment` historically; tracker normalizes both.
   PHASE_ALIASES: { assess: 'assessment', assessment: 'assess' },
   TOOL_ICONS: {
     subfinder: '\u{1F50D}', dnsx: '\u{1F4CB}', naabu: '\u{1F4E1}',
-    httpx: '\u{1F310}', subjack: '\u{26A0}\uFE0F', nuclei: '\u{1F6E1}\uFE0F',
+    httpx: '\u{1F310}', subjack: '\u{26A0}️', nuclei: '\u{1F6E1}️',
   },
 
   _pollTimer: null, _elapsedTimer: null, _abort: null,
   _activeTab: 'overview',
-  _openToolRunIds: new Set(),  // preserves PR5 fix c3802e47
+  _openToolRunIds: new Set(),
   _scanID: null, _data: null, _findings: [],
   _logsEnabled: null, _failStreak: 0, _onHashChange: null,
+  // #52 live log state. _logs is the in-memory line buffer (used for
+  // download); _logSince is the cursor for the next fetch; _logsPaused
+  // freezes the renderer; _logFilters are client-side multi-select chips.
+  _logs: [], _logSince: 0, _logsPaused: false, _logsWrap: false,
+  _logFilters: { levels: new Set(), sources: new Set() },
+  _logsTimer: null, _logsFailStreak: 0,
 
   async render(app, id) {
     if (this._scanID !== id) {
@@ -33,6 +36,10 @@ const ScanDetailPage = {
       this._activeTab = 'overview';
       this._failStreak = 0;
       this._logsEnabled = null;
+      this._logs = [];
+      this._logSince = 0;
+      this._logsPaused = false;
+      this._logFilters = { levels: new Set(), sources: new Set() };
     }
     this._scanID = id;
     this._destroy();
@@ -48,7 +55,16 @@ const ScanDetailPage = {
         this._probeLogsEndpoint(id).then(enabled => {
           if (this._scanID !== id) return;
           this._logsEnabled = enabled;
-          if (this._activeTab === 'logs' || this._activeTab === 'overview') this._renderActivePanel(app);
+          if (enabled) {
+            this._fetchLogs(id, /*reset*/ true).then(() => {
+              if (this._activeTab === 'logs' || this._activeTab === 'overview') {
+                this._renderActivePanel(app);
+              }
+              if (data.scan.status === 'running') this._startLogsPolling(id, app);
+            });
+          } else if (this._activeTab === 'logs' || this._activeTab === 'overview') {
+            this._renderActivePanel(app);
+          }
         });
       }
       if (data.scan.status === 'running') this.startPolling(app, id);
@@ -56,7 +72,6 @@ const ScanDetailPage = {
       app.innerHTML = Components.emptyState('Not found', 'Scan not found.');
     }
 
-    // Tear down on route change so polling/AbortController don't leak.
     this._onHashChange = () => {
       if ((location.hash || '').indexOf('#/scans/' + id) !== 0) {
         this._destroy();
@@ -77,8 +92,6 @@ const ScanDetailPage = {
       if (!r.ok) { const e = new Error('HTTP ' + r.status); e.status = r.status; throw e; }
       return r.json();
     };
-    // scan_scope (not scan_id) so findings discovered by this scan but
-    // later re-observed by a newer scan still show up — see SUR-244.
     const [data, findingsResp] = await Promise.all([
       get('/scans/' + encodeURIComponent(id)),
       get('/findings?scan_scope=' + encodeURIComponent(id) + '&limit=100'),
@@ -199,14 +212,22 @@ const ScanDetailPage = {
     </div>`;
   },
 
+  // B2 fix (#52): the previous version forced width:100% when pct===0
+  // to make the marquee animation visible. That visually read as
+  // "completed". Now the fill width matches the actual percentage.
+  // When pct is exactly 0 AND running, we add a track-level
+  // "indeterminate" class so the user sees a sliding shimmer on the
+  // empty track without a misleading full-width fill.
   _renderProgressCard(s) {
     const isRunning = s.status === 'running';
     const pct = Math.round(s.progress || 0);
     const elapsedTxt = (s.started_at)
       ? this._fmtElapsed(Math.round(((s.finished_at ? new Date(s.finished_at) : Date.now()) - new Date(s.started_at).getTime()) / 1000))
       : '—';
+    const trackCls = (isRunning && pct === 0)
+      ? 'progress-bar-track progress-bar-track-indeterminate'
+      : 'progress-bar-track';
     const fillCls = isRunning ? 'progress-bar-fill marquee' : 'progress-bar-fill';
-    const fillStyle = isRunning && pct === 0 ? 'width:100%' : 'width:' + pct + '%';
     return `<div class="card scan-progress-card">
       <div class="scan-progress-row">
         <div class="scan-progress-pct">${pct}%</div>
@@ -215,8 +236,8 @@ const ScanDetailPage = {
           ${isRunning ? '<span class="text-muted"> · phase ' + escapeHtml(s.phase || 'initializing') + '</span>' : ''}
         </div>
       </div>
-      <div class="progress-bar-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${pct}">
-        <div class="${fillCls}" style="${fillStyle}"></div>
+      <div class="${trackCls}" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${pct}">
+        <div class="${fillCls}" style="width:${pct}%"></div>
       </div>
     </div>`;
   },
@@ -242,7 +263,7 @@ const ScanDetailPage = {
           </div>
           <div class="phase-progress">${this._renderPhaseBar(status, pct)}</div>
           <div class="phase-duration text-muted">${escapeHtml(dur || '—')}</div>
-          <div class="phase-summary text-muted">${summary}</div>
+          <div class="phase-summary text-muted" title="${escapeHtml(summary || '')}">${summary}</div>
         </div>
       </li>`;
     }).join('');
@@ -262,8 +283,6 @@ const ScanDetailPage = {
   _derivePhaseStatus(phaseKey, toolRuns, scan) {
     const runs = this._toolRunsForPhase(phaseKey, toolRuns);
     if (runs.length === 0) {
-      // Active phase with no tool runs yet still reads "running" so the
-      // tracker shows motion before the first ToolRun row materializes.
       if (scan && scan.status === 'running' && this._matchesPhase(phaseKey, scan.phase)) return 'running';
       return 'pending';
     }
@@ -344,7 +363,11 @@ const ScanDetailPage = {
   },
 
   // ---- Phases tab --------------------------------------------------
-
+  // B4 fix (#52): phase groups are now wrapped in `.card` containers
+  // with their own padding so the pipeline-node connector dot lives
+  // inside the card boundary. Previously the dot floated at the left
+  // edge of the bare `.phase-group` and looked orphaned, especially
+  // when the accordion was expanded.
   _renderPhases(data) {
     const tracker = this._renderPhaseTracker(data.scan, data.tool_runs || []);
     const groups = this.PHASES.map(p => {
@@ -355,7 +378,7 @@ const ScanDetailPage = {
         return 0;
       });
       const nodes = sorted.map((tr, i) => this._renderPipelineNode(tr, i, sorted.length)).join('');
-      return `<div class="phase-group">
+      return `<div class="card phase-group">
         <div class="phase-group-label">${escapeHtml(p.label)}</div>
         <div class="pipeline-view">${nodes}</div>
       </div>`;
@@ -392,7 +415,7 @@ const ScanDetailPage = {
         <div class="pipeline-header">
           <span class="tool-icon">${icon}</span>
           <span class="tool-name">${escapeHtml(tr.tool_name)}</span>
-          ${Components.statusBadge(tr.status)}
+          ${this._statusBadgeWithWarnings(tr)}
           ${duration}
           ${hasLogs ? '<span class="pipeline-chevron text-muted" aria-hidden="true">▸</span>' : ''}
         </div>
@@ -400,6 +423,19 @@ const ScanDetailPage = {
         ${hasLogs ? `<div class="pipeline-detail" data-tr-idx="${i}" data-tr-id="${escapeHtml(trID)}"${isOpen ? '' : ' hidden'}>${this._renderToolRunDetail(tr)}</div>` : ''}
       </div>
     </div>`;
+  },
+
+  // B7 fix (#52): tool runs that report status=completed but with a
+  // non-empty error_message (e.g. nuclei after `context deadline
+  // exceeded`) get a yellow "completed (warnings)" pill instead of
+  // the all-green "completed" badge so operators don't think every-
+  // thing went perfectly. Falls through to the standard badge in all
+  // other cases.
+  _statusBadgeWithWarnings(tr) {
+    if (tr.status === 'completed' && tr.error_message) {
+      return `<span class="badge-status badge-completed-warn" title="Completed with warnings: ${escapeHtml(tr.error_message)}">completed (warnings)</span>`;
+    }
+    return Components.statusBadge(tr.status);
   },
 
   _toolRunHasLogs(tr) {
@@ -438,21 +474,207 @@ const ScanDetailPage = {
     return `<div class="pipeline-detail-body">${parts.join('')}</div>`;
   },
 
-  // ---- Logs tab + preview -----------------------------------------
+  // ---- Logs tab + preview (#52) -----------------------------------
 
   _renderLogs(data, full) {
-    if (this._logsEnabled === true) {
-      return `<div class="card scan-logs-card" role="log" aria-live="polite">
-        <div class="card-label">Live log</div>
-        <div class="text-muted">${full ? 'Awaiting log lines…' : 'Live log preview will stream here.'}</div>
+    if (this._logsEnabled !== true) {
+      const detail = full
+        ? '<p class="text-muted">Live log streaming requires backend support. The page is wired to consume <span class="mono">/api/v1/scans/' + escapeHtml(data.scan.id) + '/logs?since=N</span> as soon as it ships.</p>'
+        : '<p class="text-muted">Live log preview will appear here once the backend logs endpoint ships.</p>';
+      return `<div class="card scan-logs-card scan-logs-placeholder" role="log" aria-live="polite">
+        <div class="card-label">Live log</div>${detail}
       </div>`;
     }
-    const detail = full
-      ? '<p class="text-muted">Live log streaming requires backend support. The page is wired to consume <span class="mono">/api/v1/scans/' + escapeHtml(data.scan.id) + '/logs?since=N</span> as soon as it ships.</p>'
-      : '<p class="text-muted">Live log preview will appear here once the backend logs endpoint ships.</p>';
-    return `<div class="card scan-logs-card scan-logs-placeholder" role="log" aria-live="polite">
-      <div class="card-label">Live log</div>${detail}
+    const filtered = this._filteredLogs();
+    if (!full) {
+      const tail = filtered.slice(-8);
+      const lines = tail.length === 0
+        ? '<div class="scan-log-empty text-muted">No log lines yet — scan is starting.</div>'
+        : tail.map(l => this._renderLogLine(l)).join('');
+      return `<div class="card scan-logs-card" role="log" aria-live="polite">
+        <div class="card-label scan-log-header">
+          <span>Live log</span>
+          <span class="scan-log-count text-muted">${filtered.length}/${this._logs.length}</span>
+        </div>
+        <pre class="scan-log-pre scan-log-pre-preview${this._logsWrap ? ' scan-log-wrap' : ''}">${lines}</pre>
+        <a class="scan-log-cta" href="javascript:void(0)" data-log-open-tab>Open Logs →</a>
+      </div>`;
+    }
+    const allLines = filtered.length === 0
+      ? '<div class="scan-log-empty text-muted">No log lines match the current filters.</div>'
+      : filtered.map(l => this._renderLogLine(l)).join('');
+    return `<div class="card scan-logs-card" role="log" aria-live="polite">
+      <div class="card-label scan-log-header">
+        <span>Live log</span>
+        <span class="scan-log-count text-muted">${filtered.length}/${this._logs.length}</span>
+      </div>
+      ${this._renderLogToolbar()}
+      <pre class="scan-log-pre scan-log-pre-full${this._logsWrap ? ' scan-log-wrap' : ''}" data-log-pre>${allLines}</pre>
     </div>`;
+  },
+
+  _renderLogLine(l) {
+    const ts = l.ts ? this._fmtLogTime(l.ts) : '';
+    const lvl = l.level || 'info';
+    const src = l.source || 'scanner';
+    return `<span class="scan-log-line scan-log-line-${escapeHtml(lvl)}">`
+      + `<span class="scan-log-ts text-muted">[${escapeHtml(ts)}]</span> `
+      + `<span class="scan-log-src">${escapeHtml(src)}</span> `
+      + `<span class="scan-log-text">${escapeHtml(l.text || '')}</span>`
+      + `\n</span>`;
+  },
+
+  _renderLogToolbar() {
+    const sources = Array.from(new Set(this._logs.map(l => l.source))).sort();
+    const levels = ['info', 'warn', 'error'];
+    const levelChips = levels.map(lv => {
+      const active = this._logFilters.levels.has(lv);
+      return `<button type="button" class="scan-log-chip scan-log-chip-${lv}${active ? ' active' : ''}" data-log-level="${lv}">${lv}</button>`;
+    }).join('');
+    const sourceChips = sources.map(src => {
+      const active = this._logFilters.sources.has(src);
+      return `<button type="button" class="scan-log-chip${active ? ' active' : ''}" data-log-source="${escapeHtml(src)}">${escapeHtml(src)}</button>`;
+    }).join('');
+    return `<div class="scan-log-toolbar">
+      <div class="scan-log-chips">
+        <span class="scan-log-chips-label text-muted">level:</span>${levelChips}
+        ${sources.length > 0 ? '<span class="scan-log-chips-sep" aria-hidden="true">·</span>' : ''}
+        ${sources.length > 0 ? '<span class="scan-log-chips-label text-muted">tool:</span>' + sourceChips : ''}
+      </div>
+      <div class="scan-log-actions">
+        <button type="button" class="btn btn-ghost btn-sm" data-log-pause aria-pressed="${this._logsPaused}">${this._logsPaused ? 'Resume' : 'Pause'}</button>
+        <button type="button" class="btn btn-ghost btn-sm" data-log-wrap aria-pressed="${this._logsWrap}">${this._logsWrap ? 'No wrap' : 'Wrap'}</button>
+        <button type="button" class="btn btn-ghost btn-sm" data-log-download>Download</button>
+      </div>
+    </div>`;
+  },
+
+  _filteredLogs() {
+    const lv = this._logFilters.levels;
+    const src = this._logFilters.sources;
+    if (lv.size === 0 && src.size === 0) return this._logs;
+    return this._logs.filter(l => {
+      if (lv.size > 0 && !lv.has(l.level)) return false;
+      if (src.size > 0 && !src.has(l.source)) return false;
+      return true;
+    });
+  },
+
+  async _fetchLogs(id, reset) {
+    if (reset) {
+      this._logs = [];
+      this._logSince = 0;
+    }
+    try {
+      for (let i = 0; i < 5; i++) {
+        const resp = await API.scanLogs(id, { since: this._logSince, limit: 200 });
+        const lines = (resp && resp.lines) || [];
+        if (lines.length === 0) break;
+        this._appendLogs(lines);
+        if (resp && resp.next != null) this._logSince = resp.next;
+        if (!resp.has_more) break;
+      }
+      this._logsFailStreak = 0;
+      return true;
+    } catch (err) {
+      this._logsFailStreak++;
+      return false;
+    }
+  },
+
+  _appendLogs(lines) {
+    if (!lines || lines.length === 0) return;
+    for (const l of lines) this._logs.push(l);
+  },
+
+  _startLogsPolling(id, app) {
+    if (this._logsTimer) clearInterval(this._logsTimer);
+    this._logsTimer = setInterval(async () => {
+      if (document.visibilityState === 'hidden') return;
+      const ok = await this._fetchLogs(id, /*reset*/ false);
+      if (!ok) return;
+      if (this._activeTab === 'overview' || this._activeTab === 'logs') {
+        this._renderActivePanel(app);
+        if (!this._logsPaused) this._scrollLogsToBottom(app);
+      }
+      const s = this._data && this._data.scan;
+      if (s && s.status !== 'running') {
+        clearInterval(this._logsTimer);
+        this._logsTimer = null;
+      }
+    }, this.POLL_MS);
+  },
+
+  _scrollLogsToBottom(app) {
+    const pre = app.querySelector('[data-log-pre]');
+    if (pre) pre.scrollTop = pre.scrollHeight;
+  },
+
+  _bindLogControls(app, id) {
+    const opener = app.querySelector('[data-log-open-tab]');
+    if (opener) opener.addEventListener('click', () => {
+      this._activeTab = 'logs';
+      const tablist = app.querySelector('.scan-detail-tabs');
+      if (tablist) {
+        tablist.outerHTML = this._renderTabs();
+        this._wireTabClicks(app, id);
+      }
+      this._renderActivePanel(app);
+    });
+
+    app.querySelectorAll('[data-log-level]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const lv = btn.getAttribute('data-log-level');
+        if (this._logFilters.levels.has(lv)) this._logFilters.levels.delete(lv);
+        else this._logFilters.levels.add(lv);
+        this._renderActivePanel(app);
+      });
+    });
+    app.querySelectorAll('[data-log-source]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const src = btn.getAttribute('data-log-source');
+        if (this._logFilters.sources.has(src)) this._logFilters.sources.delete(src);
+        else this._logFilters.sources.add(src);
+        this._renderActivePanel(app);
+      });
+    });
+    const pauseBtn = app.querySelector('[data-log-pause]');
+    if (pauseBtn) pauseBtn.addEventListener('click', () => {
+      this._logsPaused = !this._logsPaused;
+      this._renderActivePanel(app);
+      if (!this._logsPaused) this._scrollLogsToBottom(app);
+    });
+    const wrapBtn = app.querySelector('[data-log-wrap]');
+    if (wrapBtn) wrapBtn.addEventListener('click', () => {
+      this._logsWrap = !this._logsWrap;
+      this._renderActivePanel(app);
+    });
+    const dlBtn = app.querySelector('[data-log-download]');
+    if (dlBtn) dlBtn.addEventListener('click', () => this._downloadLogs(id));
+  },
+
+  _downloadLogs(id) {
+    const txt = this._logs.map(l => {
+      const ts = l.ts ? this._fmtLogTime(l.ts) : '';
+      return `[${ts}] [${l.level || 'info'}] [${l.source || 'scanner'}] ${l.text || ''}`;
+    }).join('\n');
+    const blob = new Blob([txt], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'scan-' + id.slice(0, 8) + '-logs.txt';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  },
+
+  _fmtLogTime(iso) {
+    if (!iso) return '';
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '';
+    const pad = n => String(n).padStart(2, '0');
+    return pad(d.getHours()) + ':' + pad(d.getMinutes()) + ':' + pad(d.getSeconds());
   },
 
   // ---- Config tab --------------------------------------------------
@@ -492,6 +714,7 @@ const ScanDetailPage = {
     const cancelBtn = app.querySelector('[data-cancel-scan]');
     if (cancelBtn) cancelBtn.addEventListener('click', () => this.cancelScan(app, id));
     this._bindAccordion();
+    this._bindLogControls(app, id);
   },
 
   _wireTabClicks(app, id) {
@@ -515,10 +738,9 @@ const ScanDetailPage = {
     if (!slot) return;
     slot.innerHTML = this._renderTabContent(this._activeTab, this._data, this._findings);
     this._bindAccordion();
+    this._bindLogControls(app, this._scanID);
   },
 
-  // Pipeline accordion. _openToolRunIds persists open state across
-  // re-renders (PR5 fix c3802e47); this handler only mutates the Set.
   _bindAccordion() {
     document.querySelectorAll('.pipeline-node-clickable').forEach(node => {
       if (node.dataset.bound === '1') return;
@@ -561,7 +783,6 @@ const ScanDetailPage = {
         if (data.scan.status !== 'running') this.stopPolling();
       } catch (_) {}
     } catch (err) {
-      // 404 = scan vanished mid-cancel; 409/400 = it terminated first.
       if (err && err.status === 404) Components.toast.info('Scan already completed.');
       else if (err && err.status === 409) Components.toast.info('Scan finished before cancel could apply.');
       else if (err && err.status === 400) Components.toast.info('Scan is no longer running.');
@@ -603,6 +824,7 @@ const ScanDetailPage = {
   stopPolling() {
     if (this._pollTimer)    { clearInterval(this._pollTimer);    this._pollTimer = null; }
     if (this._elapsedTimer) { clearInterval(this._elapsedTimer); this._elapsedTimer = null; }
+    if (this._logsTimer)    { clearInterval(this._logsTimer);    this._logsTimer = null; }
     if (this._abort)        { try { this._abort.abort(); } catch (_) {} this._abort = null; }
   },
 
@@ -661,7 +883,6 @@ const ScanDetailPage = {
   },
 };
 
-// Pause polling when the tab is hidden, resume when it returns.
 document.addEventListener('visibilitychange', () => {
   if (typeof ScanDetailPage === 'undefined') return;
   const sd = ScanDetailPage;

--- a/internal/webui/static/js/pages/scan_detail.js
+++ b/internal/webui/static/js/pages/scan_detail.js
@@ -427,12 +427,17 @@ const ScanDetailPage = {
 
   // B7 fix (#52): tool runs that report status=completed but with a
   // non-empty error_message (e.g. nuclei after `context deadline
-  // exceeded`) get a yellow "completed (warnings)" pill instead of
-  // the all-green "completed" badge so operators don't think every-
-  // thing went perfectly. Falls through to the standard badge in all
-  // other cases.
+  // exceeded`) get a yellow pill instead of the all-green "completed"
+  // badge so operators don't think everything went perfectly.
+  // Proposal B refines this: if the error is specifically a deadline
+  // timeout, label it "partial" — that's what actually happened, and
+  // it matches the Notice copy in _renderToolRunDetail. Other
+  // warnings keep the generic "completed (warnings)" label.
   _statusBadgeWithWarnings(tr) {
     if (tr.status === 'completed' && tr.error_message) {
+      if (this._isTimeoutError(tr.error_message)) {
+        return `<span class="badge-status badge-completed-warn" title="Partial run: tool hit its time limit before finishing">partial</span>`;
+      }
       return `<span class="badge-status badge-completed-warn" title="Completed with warnings: ${escapeHtml(tr.error_message)}">completed (warnings)</span>`;
     }
     return Components.statusBadge(tr.status);
@@ -445,6 +450,25 @@ const ScanDetailPage = {
     return !!(cfg.command || cfg.stderr_tail || (cfg.input_preview && cfg.input_preview.length > 0));
   },
 
+  // Proposal B (#52 follow-up): when a tool returns status=completed
+  // but with a deadline-exceeded error, the operator sees something
+  // confusing — Summary says "23 findings persisted" while Stderr tail
+  // and Error both say "context deadline exceeded". The result reads
+  // as both a success and a failure simultaneously.
+  //
+  // We special-case the deadline-exceeded pattern: instead of rendering
+  // generic "Stderr tail" + "Error" sections (red, alarmist), we
+  // render a single "Partial run" notice in amber tone explaining
+  // what happened in plain language. The raw technical output stays
+  // accessible via a <details> toggle for operators who want to dig
+  // in. Real errors (network failure, binary missing, etc.) keep the
+  // red Error treatment.
+  _isTimeoutError(msg) {
+    if (!msg) return false;
+    const m = String(msg).toLowerCase();
+    return m.includes('deadline exceeded') || m.includes('context canceled');
+  },
+
   _renderToolRunDetail(tr) {
     const cfg = tr.config || {};
     const parts = [];
@@ -453,6 +477,39 @@ const ScanDetailPage = {
         <div class="pipeline-detail-heading${extraCls || ''}">${heading}</div>${body}
       </div>`);
     if (tr.output_summary) section('Summary', `<div class="pipeline-detail-text">${escapeHtml(tr.output_summary)}</div>`);
+
+    // Notice section (Proposal B): if this run timed out but still
+    // completed with results, frame it as a partial run. The notice
+    // sits between Summary and Config so it's the second thing the
+    // operator reads, right after "what worked".
+    const isTimeout = this._isTimeoutError(tr.error_message) || this._isTimeoutError(cfg.stderr_tail);
+    const isPartial = isTimeout && tr.status === 'completed';
+    if (isPartial) {
+      // De-dup: stderr_tail is often the same string as error_message
+      // for SDK-based tools (subfinder, nuclei). Show technical detail
+      // once, behind a collapsible <details>.
+      const tech = [];
+      if (cfg.stderr_tail && cfg.stderr_tail !== tr.error_message) {
+        tech.push(`<div class="pipeline-detail-heading">Stderr tail</div>
+          <pre class="pipeline-detail-pre pipeline-detail-stderr">${escapeHtml(cfg.stderr_tail)}</pre>`);
+      }
+      if (tr.error_message) {
+        tech.push(`<div class="pipeline-detail-heading">Raw error</div>
+          <pre class="pipeline-detail-pre pipeline-detail-stderr">${escapeHtml(tr.error_message)}</pre>`);
+      }
+      const techBlock = tech.length > 0
+        ? `<details class="pipeline-detail-tech"><summary>Show technical details</summary>${tech.join('')}</details>`
+        : '';
+      parts.push(`<div class="pipeline-detail-section pipeline-detail-notice">
+        <div class="pipeline-detail-notice-heading">⚠ Partial run — time limit reached</div>
+        <div class="pipeline-detail-notice-body">
+          <p><strong>${escapeHtml(tr.tool_name)}</strong> hit its phase deadline before finishing all work. The findings above were captured up to that point; remaining work didn't run.</p>
+          <p class="text-muted">To capture more, re-run this scan against the same target — or raise the assessment phase timeout.</p>
+        </div>
+        ${techBlock}
+      </div>`);
+    }
+
     if (cfg.command) section('Command', `<pre class="pipeline-detail-pre">${escapeHtml(cfg.command)}</pre>`);
     const generic = new Set(['command', 'stderr_tail', 'exit_code', 'input_preview', 'inputs_truncated']);
     const toolKeys = Object.keys(cfg).filter(k => !generic.has(k));
@@ -465,8 +522,15 @@ const ScanDetailPage = {
       const truncated = cfg.inputs_truncated ? ' <span class="text-muted">(truncated)</span>' : '';
       section('Inputs' + truncated, `<pre class="pipeline-detail-pre">${cfg.input_preview.map(escapeHtml).join('\n')}</pre>`);
     }
-    if (cfg.stderr_tail) section('Stderr tail', `<pre class="pipeline-detail-pre pipeline-detail-stderr">${escapeHtml(cfg.stderr_tail)}</pre>`);
-    if (tr.error_message) section('Error', `<pre class="pipeline-detail-pre pipeline-detail-stderr">${escapeHtml(tr.error_message)}</pre>`, ' pipeline-detail-heading-error');
+    // Stderr / Error sections only render when NOT already covered by
+    // the Notice block above. Real (non-timeout) errors keep their red
+    // treatment because the operator should look at them.
+    if (!isPartial && cfg.stderr_tail) {
+      section('Stderr tail', `<pre class="pipeline-detail-pre pipeline-detail-stderr">${escapeHtml(cfg.stderr_tail)}</pre>`);
+    }
+    if (!isPartial && tr.error_message) {
+      section('Error', `<pre class="pipeline-detail-pre pipeline-detail-stderr">${escapeHtml(tr.error_message)}</pre>`, ' pipeline-detail-heading-error');
+    }
     const meta = [];
     if (tr.started_at) meta.push(`started ${Components.timeAgo(tr.started_at)}`);
     if (typeof cfg.exit_code === 'number') meta.push(`exit ${cfg.exit_code}`);


### PR DESCRIPTION
Re-implementation of #52 after the original PR (#53, reverted in #54) shipped four UI bugs + a backend FK race that dropped log inserts in production. All five fixes are baked in here from the start.

⚠️ **NO MERGE** — please review before merging this time.

## Summary

- **Backend:** scan_logs table with FK CASCADE on scans (no FK on tool_run_id — that was the bug). `LogSink` interface + `SQLiteLogSink` (bounded channel, batched async writes, ANSI strip). Pipeline calls are additive — terminal `pp.muted/success/warn` lines are untouched, so CLI output stays byte-for-byte identical.
- **HTTP:** `GET/HEAD /api/v1/scans/{id}/logs` with `?since` cursor, `?limit` (capped 1000), `?level` and `?source` CSV filters.
- **Frontend:** real live log card with color-coded lines, level + source chips, Pause/Resume, Wrap toggle, Download `.txt`, 2s incremental polling that stops on terminal status.

## Bug fixes baked in (from the first review pass on the running daemon)

| # | What broke before | Fix |
|---|---|---|
| **B1** | scan_logs only persisted 3/30+ lines per scan because the `tool_run_id` FK rejected inserts (sink emits ToolStarted before recordToolRun creates the row) | Migration 0006 ships **without** the FK; migration 0007 retroactively recreates the table for any DB already at v6 from the buggy original |
| **B2** | Main progress bar read 100% width when scan was at 0% (marquee fallback used `width:100%`) | Always render `width:${pct}%`; new `.progress-bar-track-indeterminate` animates a shimmer on the empty TRACK |
| **B3** | Phase tracker bars varied 380-390px because grid `auto auto` columns squeezed unevenly | Fixed widths `64px 160px` for duration/summary cols |
| **B4** | Pipeline accordion's connector dot floated outside the expanded gray box | Highlighted background applies to the WHOLE `.pipeline-node`, not just `.pipeline-content` |
| **B7** | Tool runs with `status=completed` AND `error_message` set (e.g. nuclei + `context deadline exceeded`) showed all-green "completed" badge | New `.badge-completed-warn` yellow pill: "completed (warnings)" with error message in `title=` |

## Migration upgrade path

- **Fresh DB** (v0 or v5): runs 001-007 sequentially. 0006 creates scan_logs without FK; 0007 rebuilds (no-op effect, table already correct).
- **DB already at v6** (e.g. user's local that ran #53 before the revert): 001-006 skipped; 0007 recreates scan_logs without the FK, preserving any existing rows.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -race` — full suite green (storage, pipeline, webui, daemon, cli, e2e)
- [x] Storage: insert + roundtrip, **no-FK regression guard**, pagination cursor, level/source filters, count, prune, FK CASCADE on scan delete
- [x] Sink: batched insert, ANSI strip, close-flushes, idempotent close, drop-oldest under load, full lifecycle event coverage, NoopSink contract
- [x] Pipeline integration: full mocked scan persists scan-started + phase + tool-started + tool-completed + scan-completed; tool-source diversity holds (proves FK-race is fixed)
- [x] HTTP handler: HEAD 200/404, GET basic shape, pagination cursor, limit cap, level/source filters, 404 on unknown scan, 405 on POST
- [x] Foundation guards: scan_detail.js wires `_fetchLogs` / `_bindLogControls` / `_statusBadgeWithWarnings` / `progress-bar-track-indeterminate`; api.js exposes `scanLogs`; CSS for log card + B2/B7 present; B3 grid columns fixed-width (rejecting `auto auto`); B4 background wraps whole node
- [ ] **Manual smoke** — to be done by reviewer:
  - `surfbot scan example.com` from CLI; terminal output diff vs main = empty
  - `sqlite3 ~/.surfbot/surfbot.db "SELECT count(*) FROM scan_logs"` > 0 (verify B1 fix: should see ~30+ lines, not 3)
  - webui scan-detail Live log streams in real time during a running scan
  - At scan start, main progress bar at 0% renders an empty track with a sliding shimmer (B2)
  - Phase tracker bars line up at the same right edge across all phases (B3)
  - Click a tool-run accordion in Phases tab → dot stays inside the highlighted card (B4)
  - Tool run with "context deadline exceeded" shows yellow "completed (warnings)" badge (B7)
  - FK CASCADE: deleting a scan from CLI clears its scan_logs rows

Refs #52