### PR TITLE
webui: ui v2 changes + blackouts CTA + settings consolidation (PR8 #41)

### DIFF
--- a/internal/webui/assets_route_test.go
+++ b/internal/webui/assets_route_test.go
@@ -1,0 +1,81 @@
+package webui
+
+// PR8 (#41) — /assets accepts a `status` query param so the UI v2 Changes
+// page can fetch the new/disappeared/returned columns from a single
+// endpoint without an extra time-windowed diff handler. Validation
+// matches /findings: an unknown status passes straight through to the
+// store, which yields zero rows. Test covers the happy path (status
+// filters down) plus regression on the no-filter case.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/surfbot-io/surfbot-agent/internal/model"
+)
+
+func TestAssetsListAcceptsStatusParam(t *testing.T) {
+	h, s := newTestHandler(t)
+	ctx := context.Background()
+
+	target := &model.Target{Value: "example.com"}
+	require.NoError(t, s.CreateTarget(ctx, target))
+
+	mk := func(value string, status model.AssetStatus) {
+		a := &model.Asset{
+			TargetID: target.ID,
+			Type:     model.AssetTypeSubdomain,
+			Value:    value,
+			Status:   status,
+		}
+		require.NoError(t, s.UpsertAsset(ctx, a))
+	}
+	mk("api.example.com", model.AssetStatusNew)
+	mk("staging.example.com", model.AssetStatusNew)
+	mk("old.example.com", model.AssetStatusDisappeared)
+	mk("blog.example.com", model.AssetStatusActive)
+
+	cases := []struct {
+		status string
+		want   int
+	}{
+		{"new", 2},
+		{"disappeared", 1},
+		{"active", 1},
+		{"returned", 0},
+		// Unknown status: handler does not 400; store returns zero rows.
+		{"banana", 0},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.status, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/assets?status="+c.status, nil)
+			w := httptest.NewRecorder()
+			h.handleAssets(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			var resp assetsResponse
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			assert.Equal(t, c.want, len(resp.Assets), "status=%s should return %d assets", c.status, c.want)
+			for _, a := range resp.Assets {
+				if c.status != "banana" {
+					assert.Equal(t, model.AssetStatus(c.status), a.Status)
+				}
+			}
+		})
+	}
+
+	// Regression: no status filter still returns every asset.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/assets", nil)
+	w := httptest.NewRecorder()
+	h.handleAssets(w, req)
+	var resp assetsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 4, len(resp.Assets), "/assets without status must return all rows")
+}

--- a/internal/webui/foundation_assets_test.go
+++ b/internal/webui/foundation_assets_test.go
@@ -654,6 +654,229 @@ func TestAssetsCSSScaffolding(t *testing.T) {
 	}
 }
 
+// PR8 #41 — Changes + Blackouts CTA + Settings consolidation + Topbar
+// +New dropdown. Each subscope ships independently but the invariants
+// fit naturally next to the rest of the foundation_assets guards.
+
+func TestChangesPageExists(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/pages/changes.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	required := []string{
+		"const ChangesPage",
+		// Three-column diff: status filters per column.
+		"status: 'new'",
+		"status: 'disappeared'",
+		"status: 'returned'",
+		// Foundation helpers.
+		"Components.icon(",
+		"Components.emptyState(",
+		"Components.errorBanner(",
+		// Sidebar badge sync — count of disappeared assets.
+		"_syncSidebarBadge(",
+		"changes-badge",
+		// Click row → asset deep link.
+		"#/assets?id=",
+	}
+	for _, s := range required {
+		assert.True(t, strings.Contains(js, s),
+			"changes.js must reference %q after PR8 #41", s)
+	}
+
+	// Components.treeNode and Components.table are PR1-era helpers we
+	// explicitly do NOT want on the new page — the wireframe is bespoke.
+	legacy := []string{
+		"Components.treeNode",
+		"Components.table",
+	}
+	for _, s := range legacy {
+		assert.False(t, strings.Contains(js, s),
+			"changes.js must not reference legacy helper %q", s)
+	}
+}
+
+func TestSettingsPageExists(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/pages/settings.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	// Section keys mirror the wireframe sub-nav. The order is part of
+	// the contract — when v0.6 fills out a section, we don't want the
+	// nav to silently shuffle.
+	sections := []string{
+		"'general'", "'scan-defaults'", "'notifications'",
+		"'integrations'", "'api-tokens'", "'storage'", "'about'",
+	}
+	for _, s := range sections {
+		assert.True(t, strings.Contains(js, s),
+			"settings.js must declare section %q", s)
+	}
+
+	required := []string{
+		"const SettingsPage",
+		"DEFAULT_SECTION:",
+		"_renderSection(",
+		// Scan defaults reuses the existing form.
+		"SettingsDefaultsPage.render(",
+	}
+	for _, s := range required {
+		assert.True(t, strings.Contains(js, s),
+			"settings.js must reference %q", s)
+	}
+}
+
+func TestAppJSRoutesPR8Pages(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/app.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	required := []string{
+		// Changes route + ChangesPage entry point.
+		"ChangesPage.render(",
+		// Settings shell + section sub-route.
+		"SettingsPage.render(",
+		// Legacy /settings/defaults must redirect — the rule rewrites
+		// the hash to the canonical scan-defaults section.
+		"location.replace('#/settings/scan-defaults')",
+		// Topbar +New dropdown wiring.
+		"TopbarNewMenu",
+		"data-new-action=",
+		"TargetsPage.openCreateModal",
+		"SchedulesPage.openCreateModal",
+		"BlackoutsPage.openCreateModal",
+	}
+	for _, s := range required {
+		assert.True(t, strings.Contains(js, s),
+			"app.js must reference %q after PR8 #41", s)
+	}
+
+	// The PR2 placeholder fall-through to AdHoc on +New click is gone.
+	// The dropdown owns dispatch now.
+	assert.False(t, strings.Contains(js, "Placeholder — PR3 wires"),
+		"app.js must drop the PR2 +New placeholder comment after PR8 #41")
+}
+
+func TestIndexHTMLLoadsPR8Pages(t *testing.T) {
+	data, err := staticFS.ReadFile("static/index.html")
+	require.NoError(t, err)
+	html := string(data)
+
+	required := []string{
+		"/js/pages/changes.js",
+		"/js/pages/settings.js",
+		// Sidebar Settings link points at the canonical /settings, not
+		// /settings/defaults, after the consolidation.
+		`href="#/settings"`,
+		// Sidebar Changes badge slot — attack-surface loss counter.
+		`id="changes-badge"`,
+	}
+	for _, s := range required {
+		assert.True(t, strings.Contains(html, s),
+			"index.html must reference %q after PR8 #41", s)
+	}
+
+	// Page-script load order: every page module must load BEFORE app.js
+	// so the router can resolve the *Page globals.
+	appIdx := strings.Index(html, "/js/app.js")
+	require.Greater(t, appIdx, 0)
+	for _, p := range []string{"/js/pages/changes.js", "/js/pages/settings.js"} {
+		idx := strings.Index(html, p)
+		require.Greater(t, idx, 0, "%s must load", p)
+		assert.Less(t, idx, appIdx, "%s must load before app.js", p)
+	}
+}
+
+func TestBlackoutsEmptyStateHasPremiumCTA(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/pages/blackouts.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	required := []string{
+		// First-run empty state copy.
+		"No hay blackouts definidos",
+		"surfbot blackout create",
+		// CTA wires.
+		"blackouts-empty-new",
+		"openCreateModal",
+		// Calendar import is visible but disabled — keep that
+		// commitment so the v0.6 cleanup PR doesn't have to chase
+		// references.
+		"Importar desde calendario",
+	}
+	for _, s := range required {
+		assert.True(t, strings.Contains(js, s),
+			"blackouts.js must reference %q after PR8 #41", s)
+	}
+}
+
+func TestAssetsAddToBlackoutEnabled(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/pages/assets.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	// The PR10 #43 detail pane left "Add to blackout" disabled with
+	// the "Coming with PR8 blackouts integration" tooltip. PR8 enables
+	// the button and adds a public addToBlackout(targetID) method.
+	assert.False(t, strings.Contains(js, "Coming with PR8 blackouts integration"),
+		"PR10 disabled-button tooltip must be gone after PR8 #41")
+	required := []string{
+		"AssetsPage.addToBlackout(",
+		"BlackoutsPage.openCreateModal",
+		"data-asset-action=\"blackout\"",
+		"data-asset-target-id=",
+	}
+	for _, s := range required {
+		assert.True(t, strings.Contains(js, s),
+			"assets.js must reference %q after PR8 #41", s)
+	}
+}
+
+func TestPR8CSSScaffolding(t *testing.T) {
+	data, err := staticFS.ReadFile("static/css/style.css")
+	require.NoError(t, err)
+	css := string(data)
+
+	classes := []string{
+		// Changes page.
+		".changes-grid", ".changes-card", ".changes-card-header",
+		".changes-card-label", ".changes-card-count",
+		".changes-list", ".changes-row", ".changes-row-strike",
+		".changes-row-more", ".changes-empty",
+		".changes-count-new", ".changes-count-gone", ".changes-count-back",
+		// Blackouts empty state.
+		".blackouts-empty", ".blackouts-empty-icon",
+		".blackouts-empty-title", ".blackouts-empty-body",
+		".blackouts-empty-actions", ".blackouts-empty-cli",
+		// Settings shell.
+		".settings-grid", ".settings-subnav",
+		".settings-subnav-item", ".settings-subnav-item-active",
+		".settings-section", ".settings-placeholder",
+		".settings-placeholder-eyebrow", ".settings-placeholder-title",
+		// Topbar +New menu.
+		".topbar-new-menu", ".topbar-new-item", ".topbar-new-label",
+	}
+	for _, c := range classes {
+		assert.True(t, strings.Contains(css, c),
+			"PR8 CSS class %q missing from style.css", c)
+	}
+}
+
+func TestPR8IconsRegistered(t *testing.T) {
+	data, err := staticFS.ReadFile("static/js/components.js")
+	require.NoError(t, err)
+	js := string(data)
+
+	icons := []string{
+		"'eye-off':",
+		"play:",
+	}
+	for _, ic := range icons {
+		assert.True(t, strings.Contains(js, ic),
+			"PR8 icon %q missing from components.js ICONS registry", ic)
+	}
+}
+
 // TestPR5CSSScaffolding gates the CSS classes the new layout hard-codes:
 // severity tabs, filter strip, filter menu (popup + submenu), save-view
 // pill, and the table checkbox column.

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -477,6 +477,9 @@ func (h *handler) handleAssets(w http.ResponseWriter, r *http.Request) {
 	if targetID := r.URL.Query().Get("target_id"); targetID != "" {
 		opts.TargetID = targetID
 	}
+	if status := r.URL.Query().Get("status"); status != "" {
+		opts.Status = model.AssetStatus(status)
+	}
 
 	assets, err := h.store.ListAssets(r.Context(), opts)
 	if err != nil {

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -3558,3 +3558,262 @@ button.kpi-card:focus-visible {
   .tree-row { padding-left: 12px; }
   .assets-search-input { min-width: 140px; }
 }
+
+/* PR8 #41 — Changes page (3-column attack-surface diff). */
+.changes-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 12px;
+}
+.changes-card {
+  background: var(--ink-900);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+.changes-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.changes-card-label {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+.changes-card-count {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+.changes-count-new  { color: var(--brand);          background: rgba(59, 130, 246, 0.12); border-color: rgba(59, 130, 246, 0.35); }
+.changes-count-gone { color: var(--sev-critical);   background: rgba(239, 68, 68, 0.12);  border-color: rgba(239, 68, 68, 0.35); }
+.changes-count-back { color: var(--status-ack);     background: rgba(245, 158, 11, 0.12); border-color: rgba(245, 158, 11, 0.35); }
+.changes-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.changes-row {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-primary);
+  padding: 4px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  word-break: break-all;
+  transition: background-color 0.12s ease;
+}
+.changes-row:hover,
+.changes-row:focus {
+  background: var(--ink-800);
+  outline: none;
+}
+.changes-row:focus-visible {
+  box-shadow: 0 0 0 2px var(--brand);
+}
+.changes-row-strike {
+  text-decoration: line-through;
+  color: var(--text-secondary);
+}
+.changes-row-more {
+  font-size: 11px;
+  color: var(--text-secondary);
+  padding: 4px 6px;
+  font-style: italic;
+}
+.changes-empty {
+  font-size: 12px;
+  color: var(--text-secondary);
+  padding: 12px 6px;
+  text-align: center;
+  font-style: italic;
+}
+@media (max-width: 1024px) {
+  .changes-grid { grid-template-columns: 1fr; }
+}
+
+/* PR8 #41 — Blackouts premium empty state. Mirrors the wireframe at
+   surfbot-ui-redesign-wireframes.html lines 1473-1488. */
+.blackouts-empty {
+  padding: 64px 24px;
+  text-align: center;
+  max-width: 560px;
+  margin: 0 auto;
+}
+.blackouts-empty-icon {
+  width: 48px;
+  height: 48px;
+  margin: 0 auto 12px;
+  border-radius: 50%;
+  background: var(--ink-800);
+  border: 1px solid var(--border);
+  display: grid;
+  place-items: center;
+  color: var(--text-secondary);
+}
+.blackouts-empty-title {
+  color: var(--text-primary);
+  font-weight: 500;
+  margin: 0 0 4px 0;
+}
+.blackouts-empty-body {
+  color: var(--text-secondary);
+  font-size: 13px;
+  margin: 0;
+}
+.blackouts-empty-actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 16px;
+}
+.blackouts-empty-cli {
+  color: var(--text-secondary);
+  font-size: 11px;
+  margin-top: 16px;
+}
+.blackouts-empty-cli code {
+  color: var(--brand);
+}
+
+/* PR8 #41 — Settings consolidated page (sub-nav + section content). */
+.settings-grid {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  gap: 16px;
+  margin-top: 12px;
+}
+.settings-subnav {
+  background: var(--ink-900);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px;
+  align-self: start;
+}
+.settings-subnav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.settings-subnav-item {
+  display: block;
+  padding: 8px 12px;
+  border-radius: 6px;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: background-color 0.12s ease;
+}
+.settings-subnav-item:hover {
+  background: var(--ink-800);
+  color: var(--text-primary);
+}
+.settings-subnav-item-active {
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--brand);
+}
+.settings-subnav-item-active:hover {
+  background: rgba(59, 130, 246, 0.18);
+  color: var(--brand);
+}
+.settings-subnav-label { font-size: 13px; }
+.settings-subnav-desc {
+  font-size: 10px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+.settings-subnav-item-active .settings-subnav-desc {
+  color: var(--brand);
+  opacity: 0.8;
+}
+.settings-section { min-width: 0; }
+.settings-placeholder {
+  background: var(--ink-900);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 48px 24px;
+  text-align: center;
+}
+.settings-placeholder-eyebrow {
+  color: var(--text-secondary);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+.settings-placeholder-title {
+  color: var(--text-primary);
+  font-weight: 500;
+  margin: 0 0 4px 0;
+}
+.settings-placeholder-body {
+  color: var(--text-secondary);
+  font-size: 13px;
+  margin: 0 auto;
+  max-width: 400px;
+}
+@media (max-width: 768px) {
+  .settings-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* PR8 #41 — Topbar "+ New" dropdown menu. */
+.topbar-new-menu {
+  background: var(--ink-900);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  padding: 4px;
+  min-width: 220px;
+}
+.topbar-new-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  background: transparent;
+  border: 0;
+  color: var(--text-primary);
+  padding: 8px 10px;
+  font: inherit;
+  text-align: left;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.topbar-new-item:hover,
+.topbar-new-item:focus {
+  background: var(--ink-800);
+  outline: none;
+}
+.topbar-new-item:focus-visible {
+  box-shadow: 0 0 0 2px var(--brand);
+}
+.topbar-new-item .icon {
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+.topbar-new-label {
+  flex: 1;
+  font-size: 13px;
+}
+.topbar-new-item .kbd {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--text-secondary);
+}

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -41,6 +41,7 @@
             <li><a href="#/changes" class="nav-link" data-page="changes">
               <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 5a2 2 0 012-2h8a2 2 0 012 2v9a2 2 0 01-2 2h-3l-3 3v-3H6a2 2 0 01-2-2V5zm3 3a1 1 0 011-1h6a1 1 0 110 2H8a1 1 0 01-1-1zm0 3a1 1 0 011-1h4a1 1 0 110 2H8a1 1 0 01-1-1z" clip-rule="evenodd"/></svg>
               <span class="nav-label">Changes</span>
+              <span class="nav-badge" id="changes-badge" style="display:none"></span>
             </a></li>
           </ul>
         </div>
@@ -82,7 +83,7 @@
               <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z" clip-rule="evenodd"/><path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z"/></svg>
               <span class="nav-label">Blackouts</span>
             </a></li>
-            <li><a href="#/settings/defaults" class="nav-link" data-page="settings">
+            <li><a href="#/settings" class="nav-link" data-page="settings">
               <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd"/></svg>
               <span class="nav-label">Settings</span>
             </a></li>
@@ -147,6 +148,8 @@
   <script src="/js/pages/templates.js"></script>
   <script src="/js/pages/blackouts.js"></script>
   <script src="/js/pages/settings_defaults.js"></script>
+  <script src="/js/pages/settings.js"></script>
+  <script src="/js/pages/changes.js"></script>
   <script src="/js/pages/adhoc.js"></script>
   <script src="/js/app.js"></script>
 </body>

--- a/internal/webui/static/js/app.js
+++ b/internal/webui/static/js/app.js
@@ -29,7 +29,13 @@ const Router = {
     { pattern: /^#\/templates/, page: 'templates', render: () => TemplatesPage.render(app, parseQueryParams()) },
     { pattern: /^#\/blackouts\/(.+)$/, page: 'blackouts', render: (m) => BlackoutsPage.render(app, { id: decodeURIComponent(m[1]) }) },
     { pattern: /^#\/blackouts/, page: 'blackouts', render: () => BlackoutsPage.render(app, parseQueryParams()) },
-    { pattern: /^#\/settings\/defaults/, page: 'settings-defaults', render: () => SettingsDefaultsPage.render(app) },
+    { pattern: /^#\/changes/, page: 'changes', render: () => ChangesPage.render(app, parseQueryParams()) },
+    // PR8 #41: legacy URL — redirect transparent. Replace the hash so
+    // the redirect doesn't create a back-button trap and the canonical
+    // /settings/scan-defaults section opens.
+    { pattern: /^#\/settings\/defaults\b/, page: 'settings', render: () => { location.replace('#/settings/scan-defaults'); } },
+    { pattern: /^#\/settings\/([^/?]+)(\?.*)?$/, page: 'settings', render: (m) => SettingsPage.render(app, { section: decodeURIComponent(m[1]) }) },
+    { pattern: /^#\/settings(\?.*)?$/, page: 'settings', render: () => SettingsPage.render(app, {}) },
   ],
 
   // _lastHash captures the previous hash so the navigate() short-circuit
@@ -279,9 +285,166 @@ document.addEventListener('DOMContentLoaded', () => {
     // Placeholder — PR9 implements global search.
   });
   const newBtn = document.getElementById('topbar-new-btn');
-  if (newBtn) newBtn.addEventListener('click', () => {
-    // Placeholder — PR3 wires the "+ New" entry point. Falls back to
-    // the ad-hoc dispatcher so the button isn't dead in the meantime.
-    if (typeof AdHocPage !== 'undefined' && AdHocPage.open) AdHocPage.open();
-  });
+  if (newBtn) {
+    newBtn.setAttribute('aria-haspopup', 'menu');
+    newBtn.setAttribute('aria-expanded', 'false');
+    newBtn.removeAttribute('title');
+    newBtn.setAttribute('aria-label', 'New');
+    newBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      TopbarNewMenu.toggle(newBtn);
+    });
+  }
 });
+
+// PR8 #41 — Topbar "+ New" dropdown. Replaces the PR2 placeholder that
+// dispatched straight to the ad-hoc modal. Renders four entries:
+//   Add target  → TargetsPage.openCreateModal() | fallback to /targets
+//   Run scan    → AdHocPage.open()
+//   New schedule→ SchedulesPage.openCreateModal() | fallback to /schedules?new=1
+//   New blackout→ BlackoutsPage.openCreateModal() | fallback to /blackouts?new=1
+//
+// Keyboard shortcuts (T/S/⌘⇧S/B) are visual only in P0; PR9 #42 wires
+// the global handlers as part of Cmd+K.
+const TopbarNewMenu = {
+  _menu: null,
+  _anchor: null,
+
+  toggle(anchor) {
+    if (this._menu) {
+      this.close();
+      return;
+    }
+    this.open(anchor);
+  },
+
+  open(anchor) {
+    this.close();
+    const menu = document.createElement('div');
+    menu.className = 'topbar-new-menu';
+    menu.setAttribute('role', 'menu');
+    menu.setAttribute('aria-label', 'Create new resource');
+    menu.innerHTML = `
+      <button type="button" class="topbar-new-item" role="menuitem" data-new-action="target">
+        ${Components.icon('plus', 14)}<span class="topbar-new-label">Add target…</span>
+        <kbd class="kbd">T</kbd>
+      </button>
+      <button type="button" class="topbar-new-item" role="menuitem" data-new-action="scan">
+        ${Components.icon('play', 14)}<span class="topbar-new-label">Run scan…</span>
+        <kbd class="kbd">S</kbd>
+      </button>
+      <button type="button" class="topbar-new-item" role="menuitem" data-new-action="schedule">
+        ${Components.icon('clock', 14)}<span class="topbar-new-label">New schedule…</span>
+        <kbd class="kbd">⌘⇧S</kbd>
+      </button>
+      <button type="button" class="topbar-new-item" role="menuitem" data-new-action="blackout">
+        ${Components.icon('eye-off', 14)}<span class="topbar-new-label">New blackout…</span>
+        <kbd class="kbd">B</kbd>
+      </button>
+    `;
+    document.body.appendChild(menu);
+    this._position(menu, anchor);
+    this._menu = menu;
+    this._anchor = anchor;
+    if (anchor) anchor.setAttribute('aria-expanded', 'true');
+
+    menu.querySelectorAll('[data-new-action]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const kind = btn.getAttribute('data-new-action');
+        this.close();
+        TopbarNewMenu.dispatch(kind);
+      });
+    });
+
+    // Defer the global listeners so the click that opened the menu
+    // doesn't immediately close it.
+    setTimeout(() => {
+      document.addEventListener('click', this._onOutside);
+      document.addEventListener('keydown', this._onKey);
+    }, 0);
+
+    // Focus the first item so keyboard users can act immediately.
+    const first = menu.querySelector('[data-new-action]');
+    if (first) first.focus();
+  },
+
+  close() {
+    if (!this._menu) return;
+    if (this._menu.parentNode) this._menu.remove();
+    this._menu = null;
+    if (this._anchor) {
+      this._anchor.setAttribute('aria-expanded', 'false');
+      this._anchor = null;
+    }
+    document.removeEventListener('click', this._onOutside);
+    document.removeEventListener('keydown', this._onKey);
+  },
+
+  _position(menu, anchor) {
+    const rect = anchor.getBoundingClientRect();
+    menu.style.position = 'fixed';
+    menu.style.top = (rect.bottom + 4) + 'px';
+    menu.style.right = (window.innerWidth - rect.right) + 'px';
+    menu.style.zIndex = '40';
+  },
+
+  _onOutside(e) {
+    if (!TopbarNewMenu._menu) return;
+    if (TopbarNewMenu._menu.contains(e.target)) return;
+    if (TopbarNewMenu._anchor && TopbarNewMenu._anchor.contains(e.target)) return;
+    TopbarNewMenu.close();
+  },
+
+  _onKey(e) {
+    if (!TopbarNewMenu._menu) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      TopbarNewMenu.close();
+      if (TopbarNewMenu._anchor) TopbarNewMenu._anchor.focus();
+      return;
+    }
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      const items = Array.from(TopbarNewMenu._menu.querySelectorAll('[data-new-action]'));
+      if (!items.length) return;
+      const cur = document.activeElement;
+      let idx = items.indexOf(cur);
+      if (idx === -1) idx = 0;
+      const next = e.key === 'ArrowDown'
+        ? (idx + 1) % items.length
+        : (idx - 1 + items.length) % items.length;
+      items[next].focus();
+    }
+  },
+
+  dispatch(kind) {
+    switch (kind) {
+      case 'target':
+        if (typeof TargetsPage !== 'undefined' && TargetsPage.openCreateModal) {
+          TargetsPage.openCreateModal();
+        } else {
+          location.hash = '#/targets';
+        }
+        return;
+      case 'scan':
+        if (typeof AdHocPage !== 'undefined' && AdHocPage.open) {
+          AdHocPage.open();
+        }
+        return;
+      case 'schedule':
+        if (typeof SchedulesPage !== 'undefined' && SchedulesPage.openCreateModal) {
+          SchedulesPage.openCreateModal();
+        } else {
+          location.hash = '#/schedules?new=1';
+        }
+        return;
+      case 'blackout':
+        if (typeof BlackoutsPage !== 'undefined' && BlackoutsPage.openCreateModal) {
+          BlackoutsPage.openCreateModal();
+        } else {
+          location.hash = '#/blackouts?new=1';
+        }
+        return;
+    }
+  },
+};

--- a/internal/webui/static/js/components.js
+++ b/internal/webui/static/js/components.js
@@ -805,6 +805,10 @@ const ICONS = Object.freeze({
   copy:           '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>',
   refresh:        '<polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"/>',
   external:       '<path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>',
+  // PR8 (#41): eye-off for blackouts CTAs (empty state, topbar +New menu);
+  // play for the +New > Run scan item.
+  'eye-off':      '<path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19m-6.72-1.07a3 3 0 11-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/>',
+  play:           '<polygon points="5 3 19 12 5 21 5 3"/>',
 });
 
 function pad2(n) { return String(n).padStart(2, '0'); }

--- a/internal/webui/static/js/pages/assets.js
+++ b/internal/webui/static/js/pages/assets.js
@@ -634,9 +634,8 @@ const AssetsPage = {
       </div>
       <div class="assets-detail-actions">
         <button type="button" class="btn btn-primary" data-asset-action="run-scan">Run scan</button>
-        <button type="button" class="btn btn-ghost" data-asset-action="blackout" disabled
-          title="Coming with PR8 blackouts integration"
-          aria-disabled="true">Add to blackout</button>
+        <button type="button" class="btn btn-ghost" data-asset-action="blackout"
+          data-asset-target-id="${escapeHtml(node.target_id || '')}">Add to blackout</button>
         <button type="button" class="btn btn-danger" data-asset-action="remove" disabled
           title="Manual asset deletion coming with vacuum endpoint"
           aria-disabled="true">Remove</button>
@@ -748,6 +747,16 @@ const AssetsPage = {
       btn.addEventListener('click', () => {
         if (typeof AdHocPage === 'undefined' || !AdHocPage.open) return;
         AdHocPage.open({ prefillTargetID: this._activeTargetID, lockTargetID: true });
+      });
+    });
+
+    // PR8 #41 — Add-to-blackout CTA. Opens the blackout create modal
+    // pre-filled with scope=target + target_id of the selected asset.
+    // Falls back to a navigation hint if BlackoutsPage hasn't loaded.
+    app.querySelectorAll('[data-asset-action="blackout"]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const targetID = btn.getAttribute('data-asset-target-id') || this._activeTargetID;
+        AssetsPage.addToBlackout(targetID);
       });
     });
 
@@ -985,5 +994,29 @@ const AssetsPage = {
         }
       }
     }
+  },
+
+  // PR8 #41 — opens the BlackoutsPage create modal pre-filled with the
+  // asset's target. The blackout API scope is "target" + target_id —
+  // there's no per-asset scope, so multi-host targets get suppressed
+  // wholesale. Toast on success only; cancel is silent.
+  addToBlackout(targetID) {
+    if (typeof BlackoutsPage === 'undefined' || !BlackoutsPage.openCreateModal) {
+      Components.toast.error('Blackouts module not loaded');
+      return;
+    }
+    if (!targetID) {
+      Components.toast.error('Asset has no target — cannot scope blackout');
+      return;
+    }
+    BlackoutsPage.openCreateModal({
+      prefill: {
+        scope: 'target',
+        target_id: targetID,
+      },
+      onSaved: () => {
+        Components.toast.success('Blackout created. Scans on this target will be suppressed.');
+      },
+    });
   },
 };

--- a/internal/webui/static/js/pages/blackouts.js
+++ b/internal/webui/static/js/pages/blackouts.js
@@ -49,16 +49,42 @@ const BlackoutsPage = {
     const headerActions = '<div style="margin-left:auto"><button type="button" class="btn btn-primary" id="blackouts-new">New blackout</button></div>';
 
     if (items.length === 0) {
-      const hint = f.activeOnly
-        ? 'No blackouts are active right now.'
-        : 'No blackout windows defined. Click <strong>New blackout</strong> above or use <code class="mono">surfbot blackout create</code>.';
+      // PR8 #41 — premium empty state for the unfiltered case (zero
+      // blackouts in the DB). The activeOnly branch keeps the legacy
+      // copy: it's a filter-result, not a first-run state.
+      if (f.activeOnly) {
+        return `
+          <div class="page-header">
+            <h2>Blackout windows</h2>
+            ${headerActions}
+          </div>
+          ${filterBar}
+          ${Components.emptyState('No blackouts', 'No blackouts are active right now.')}
+        `;
+      }
       return `
         <div class="page-header">
           <h2>Blackout windows</h2>
           ${headerActions}
         </div>
         ${filterBar}
-        ${Components.emptyState('No blackouts', hint)}
+        <div class="blackouts-empty">
+          <div class="blackouts-empty-icon">${Components.icon('eye-off', 16)}</div>
+          <h3 class="blackouts-empty-title">No hay blackouts definidos</h3>
+          <p class="blackouts-empty-body">
+            Crea ventanas para suprimir scans durante deploys, mantenimiento, o eventos.
+            Los schedules se reanudan automáticamente al cerrar la ventana.
+          </p>
+          <div class="blackouts-empty-actions">
+            <button type="button" class="btn btn-primary" id="blackouts-empty-new">+ New blackout</button>
+            <button type="button" class="btn btn-ghost btn-sm" disabled
+              title="Calendar import coming with calendar integration"
+              aria-disabled="true">Importar desde calendario ↗</button>
+          </div>
+          <p class="blackouts-empty-cli">
+            O desde CLI: <code class="mono">surfbot blackout create</code>
+          </p>
+        </div>
       `;
     }
 
@@ -130,6 +156,10 @@ const BlackoutsPage = {
     }
     const newBtn = document.getElementById('blackouts-new');
     if (newBtn) newBtn.addEventListener('click', () => this.openCreateForm());
+    // PR8 #41 — empty-state CTA. Wired via id, only present in the
+    // first-run branch of template().
+    const emptyBtn = document.getElementById('blackouts-empty-new');
+    if (emptyBtn) emptyBtn.addEventListener('click', () => this.openCreateForm());
   },
 
   // --- Blackout detail ---
@@ -224,11 +254,29 @@ const BlackoutsPage = {
   // multiple blackouts. Duration is rendered as hours + minutes +
   // seconds inputs and serialized to a single `duration_seconds`.
 
-  openCreateForm() {
+  openCreateForm(opts) {
+    const o = opts || {};
     this.openForm({
       mode: 'create',
-      onSaved: () => BlackoutsPage.render(document.getElementById('app'), {}),
+      prefill: o.prefill,
+      onSaved: () => {
+        if (typeof o.onSaved === 'function') o.onSaved();
+        // Re-render the list when the user is on /blackouts; skip the
+        // refresh otherwise (the modal was launched from the topbar or
+        // another page, the operator stays where they were).
+        if ((location.hash || '').startsWith('#/blackouts')) {
+          BlackoutsPage.render(document.getElementById('app'), {});
+        }
+      },
     });
+  },
+
+  // PR8 #41 — public alias for the topbar +New menu and the asset
+  // detail-pane "Add to blackout" CTA. Same shape as
+  // SchedulesPage.openCreateForm but without listFilters since blackouts
+  // doesn't paginate the list filter state into the create flow.
+  openCreateModal(opts) {
+    return this.openCreateForm(opts);
   },
 
   openEditForm(app, b) {
@@ -239,8 +287,15 @@ const BlackoutsPage = {
     });
   },
 
-  openForm({ mode, blackout, onSaved }) {
-    const b = blackout || {};
+  openForm({ mode, blackout, prefill, onSaved }) {
+    // PR8 #41: when a caller (asset detail pane, topbar +New) opens the
+    // create modal with a `prefill` payload, merge it onto the empty
+    // blackout draft so the scope/target_id fields render pre-filled.
+    // Edit mode ignores prefill — the existing record always wins.
+    const base = blackout || {};
+    const b = (mode === 'create' && prefill)
+      ? Object.assign({}, base, prefill)
+      : base;
     const secs = Math.max(0, b.duration_seconds || 0);
     const hours = Math.floor(secs / 3600);
     const mins = Math.floor((secs % 3600) / 60);

--- a/internal/webui/static/js/pages/changes.js
+++ b/internal/webui/static/js/pages/changes.js
@@ -1,0 +1,216 @@
+// PR8 #41 — Changes page. Three-column attack-surface diff:
+//
+//   Nuevos (status=new)         — brand tone,    + prefix
+//   Desaparecidos (=disappeared) — sev-critical, − prefix, line-through
+//   Volvieron (=returned)        — status-ack,   no prefix
+//
+// P0 fetches three /assets queries in parallel filtered by status. The
+// time-windowed `Range: 7d` and `Export diff` actions are visual-only
+// placeholders awaiting the P1 /asset-changes endpoint.
+//
+// On render the page also pushes the disappeared count to the sidebar
+// "Changes" nav badge — the badge tracks attack-surface loss, which the
+// wireframe surfaces as the most actionable signal.
+const ChangesPage = {
+  STORAGE_KEY_ACTIVE_TARGET: 'surfbot_changes_active_target',
+  TOP_N: 10,
+
+  _targets: [],
+  _activeTargetID: '',
+  _data: { newAssets: [], disappeared: [], returned: [] },
+
+  async render(app, params) {
+    app.innerHTML = '<div class="loading">Loading changes...</div>';
+
+    try {
+      const targetsResp = await API.targets().catch(() => ({ targets: [] }));
+      this._targets = (targetsResp && targetsResp.targets) || [];
+
+      if (this._targets.length === 0) {
+        app.innerHTML = `
+          ${this._headerHtml()}
+          ${Components.emptyState(
+            'No targets configured',
+            'Add a target before tracking changes.',
+          )}
+          <div style="text-align:center;margin-top:12px">
+            <a href="#/targets" class="btn btn-primary">Add target</a>
+          </div>
+        `;
+        return;
+      }
+
+      this._activeTargetID = this._resolveActiveTarget(params || {});
+      try { localStorage.setItem(this.STORAGE_KEY_ACTIVE_TARGET, this._activeTargetID); } catch (_) {}
+
+      const [news, gone, returned] = await Promise.all([
+        API.assets({ status: 'new',         target_id: this._activeTargetID, limit: 100 }).catch(() => ({ assets: [] })),
+        API.assets({ status: 'disappeared', target_id: this._activeTargetID, limit: 100 }).catch(() => ({ assets: [] })),
+        API.assets({ status: 'returned',    target_id: this._activeTargetID, limit: 100 }).catch(() => ({ assets: [] })),
+      ]);
+
+      this._data = {
+        newAssets:    (news     && news.assets)     || [],
+        disappeared:  (gone     && gone.assets)     || [],
+        returned:     (returned && returned.assets) || [],
+      };
+
+      app.innerHTML = this._template();
+      this._wire(app);
+      this._syncSidebarBadge(this._data.disappeared.length);
+    } catch (err) {
+      app.innerHTML = `
+        ${this._headerHtml()}
+        ${Components.errorBanner(err)}
+      `;
+    }
+  },
+
+  _resolveActiveTarget(params) {
+    if (params.target_id && this._targets.some(t => t.id === params.target_id)) return params.target_id;
+    let stored = '';
+    try { stored = localStorage.getItem(this.STORAGE_KEY_ACTIVE_TARGET) || ''; } catch (_) {}
+    if (stored && this._targets.some(t => t.id === stored)) return stored;
+    return this._targets[0] ? this._targets[0].id : '';
+  },
+
+  _headerHtml() {
+    const headerActions = `
+      <div style="margin-left:auto;display:flex;gap:8px">
+        <button type="button" class="btn btn-ghost" disabled
+          title="Time-range filter coming with /asset-changes endpoint"
+          aria-disabled="true">${Components.icon('clock', 14)} Range: 7d</button>
+        <button type="button" class="btn btn-ghost" disabled
+          title="Export coming with diff endpoint"
+          aria-disabled="true">${Components.icon('external', 14)} Export diff</button>
+      </div>
+    `;
+    return `
+      <div class="page-header">
+        <h2>Changes</h2>
+        <p>Diff de attack surface · nuevos / desaparecidos / volvieron</p>
+        ${headerActions}
+      </div>
+    `;
+  },
+
+  _targetBarHtml() {
+    if (this._targets.length < 2) return '';
+    const opts = this._targets.map(t =>
+      `<option value="${escapeHtml(t.id)}"${t.id === this._activeTargetID ? ' selected' : ''}>${escapeHtml(t.value)}</option>`
+    ).join('');
+    return `<div class="assets-target-bar">
+      <label class="form-label" for="changes-target-select">Target</label>
+      <select id="changes-target-select" class="assets-target-select" data-changes-target aria-label="Select active target">
+        ${opts}
+      </select>
+    </div>`;
+  },
+
+  _template() {
+    const d = this._data;
+    const total = d.newAssets.length + d.disappeared.length + d.returned.length;
+
+    if (total === 0) {
+      return `
+        ${this._headerHtml()}
+        ${this._targetBarHtml()}
+        ${Components.emptyState(
+          'No changes detected',
+          'Run a scan to see what is new, what disappeared, and what came back.',
+        )}
+      `;
+    }
+
+    return `
+      ${this._headerHtml()}
+      ${this._targetBarHtml()}
+      <div class="changes-grid">
+        ${this._cardHtml({
+          label: 'Nuevos',
+          tone:  'new',
+          prefix:'+',
+          assets: d.newAssets,
+          strike: false,
+        })}
+        ${this._cardHtml({
+          label: 'Desaparecidos',
+          tone:  'gone',
+          prefix:'−',
+          assets: d.disappeared,
+          strike: true,
+        })}
+        ${this._cardHtml({
+          label: 'Volvieron',
+          tone:  'back',
+          prefix:'',
+          assets: d.returned,
+          strike: false,
+        })}
+      </div>
+    `;
+  },
+
+  _cardHtml({ label, tone, prefix, assets, strike }) {
+    const count = assets.length;
+    const top = assets.slice(0, this.TOP_N);
+    const remaining = count - top.length;
+
+    const items = top.map(a => {
+      const id = escapeHtml(a.id);
+      const value = escapeHtml(a.value);
+      const cls = 'changes-row' + (strike ? ' changes-row-strike' : '');
+      return `<li class="${cls}" data-changes-row="${id}" tabindex="0" role="button"
+        aria-label="Open asset ${value}">${value}</li>`;
+    }).join('');
+
+    const tail = remaining > 0
+      ? `<li class="changes-row-more">+ ${remaining} más…</li>`
+      : '';
+
+    const list = count > 0
+      ? `<ul class="changes-list">${items}${tail}</ul>`
+      : `<div class="changes-empty">No changes.</div>`;
+
+    return `<div class="changes-card changes-card-${tone}">
+      <div class="changes-card-header">
+        <div class="changes-card-label">${escapeHtml(label)}</div>
+        <span class="changes-card-count changes-count-${tone}">${prefix}${count}</span>
+      </div>
+      ${list}
+    </div>`;
+  },
+
+  _wire(app) {
+    const targetSel = app.querySelector('[data-changes-target]');
+    if (targetSel) targetSel.addEventListener('change', () => {
+      const id = targetSel.value;
+      try { localStorage.setItem(this.STORAGE_KEY_ACTIVE_TARGET, id); } catch (_) {}
+      this.render(app, { target_id: id });
+    });
+
+    app.querySelectorAll('[data-changes-row]').forEach(row => {
+      const id = row.getAttribute('data-changes-row');
+      const go = () => { location.hash = '#/assets?id=' + encodeURIComponent(id); };
+      row.addEventListener('click', go);
+      row.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          go();
+        }
+      });
+    });
+  },
+
+  _syncSidebarBadge(count) {
+    const el = document.getElementById('changes-badge');
+    if (!el) return;
+    if (count > 0) {
+      el.textContent = String(count);
+      el.style.display = '';
+    } else {
+      el.style.display = 'none';
+      el.textContent = '';
+    }
+  },
+};

--- a/internal/webui/static/js/pages/schedules.js
+++ b/internal/webui/static/js/pages/schedules.js
@@ -269,6 +269,14 @@ const SchedulesPage = {
     });
   },
 
+  // PR8 #41 — public alias for the topbar +New menu. The list page's
+  // own "New schedule" button still calls openCreateForm directly with
+  // its filter snapshot; this version assumes the operator wants a
+  // fresh form and refreshes the unfiltered list on save.
+  openCreateModal() {
+    return this.openCreateForm(document.getElementById('app'), {});
+  },
+
   openEditForm(app, schedule) {
     this.openForm({
       mode: 'edit',

--- a/internal/webui/static/js/pages/settings.js
+++ b/internal/webui/static/js/pages/settings.js
@@ -1,0 +1,107 @@
+// PR8 #41 — Consolidated Settings page. Replaces the singleton
+// /settings/defaults route with a sub-nav + section shell that scales as
+// new config surfaces land. P0 ships:
+//
+//   • Scan defaults — delegates to SettingsDefaultsPage (functional form)
+//   • General / Notifications / Integrations / API & tokens / Storage /
+//     About — placeholder cards ("Coming in v0.6") with section copy
+//
+// Routing:
+//   #/settings                    → renders shell + scan-defaults
+//   #/settings/<section>          → shell + that section
+//   #/settings/defaults           → router redirects to /settings/scan-defaults
+//
+// Section state is held in URL hash, not in module state, so a refresh
+// or a deep link from a docs page lands on the right pane.
+const SettingsPage = {
+  DEFAULT_SECTION: 'scan-defaults',
+
+  SECTIONS: [
+    { key: 'general',         label: 'General',        description: 'Agent identity, locale' },
+    { key: 'scan-defaults',   label: 'Scan defaults',  description: 'Concurrency, rate-limit, depth' },
+    { key: 'notifications',   label: 'Notifications',  description: 'Webhooks, Slack, email' },
+    { key: 'integrations',    label: 'Integrations',   description: 'Jira, GitHub, MCP' },
+    { key: 'api-tokens',      label: 'API & tokens',   description: 'UI token, API access' },
+    { key: 'storage',         label: 'Storage',        description: 'SQLite path, retention' },
+    { key: 'about',           label: 'About',          description: 'Version, license, logs' },
+  ],
+
+  async render(app, params) {
+    const requested = (params && params.section) || this.DEFAULT_SECTION;
+    const section = this.SECTIONS.some(s => s.key === requested) ? requested : this.DEFAULT_SECTION;
+
+    app.innerHTML = this._shellHtml(section);
+    this._wireShell(app);
+
+    const host = app.querySelector('[data-settings-section-host]');
+    if (!host) return;
+    await this._renderSection(host, section);
+  },
+
+  _shellHtml(activeKey) {
+    const subnav = this.SECTIONS.map(s => {
+      const active = s.key === activeKey;
+      const cls = 'settings-subnav-item' + (active ? ' settings-subnav-item-active' : '');
+      return `<li>
+        <a href="#/settings/${escapeHtml(s.key)}" class="${cls}"
+           data-settings-link="${escapeHtml(s.key)}"
+           aria-current="${active ? 'page' : 'false'}">
+          <div class="settings-subnav-label">${escapeHtml(s.label)}</div>
+          <div class="settings-subnav-desc">${escapeHtml(s.description)}</div>
+        </a>
+      </li>`;
+    }).join('');
+
+    return `
+      <div class="page-header">
+        <h2>Settings</h2>
+        <p>Configuración del agente, defaults de scan e integraciones</p>
+      </div>
+      <div class="settings-grid">
+        <nav class="settings-subnav" aria-label="Settings sections">
+          <ul>${subnav}</ul>
+        </nav>
+        <section class="settings-section" data-settings-section-host
+          aria-live="polite">
+          <div class="loading">Loading...</div>
+        </section>
+      </div>
+    `;
+  },
+
+  _wireShell(app) {
+    // The links are real anchors; the browser's hash navigation will
+    // re-trigger the router and refresh the section. No JS click
+    // handler needed — this preserves the back/forward stack.
+  },
+
+  async _renderSection(host, key) {
+    if (key === 'scan-defaults') {
+      // Reuse the existing SettingsDefaultsPage rendering logic. Its
+      // render() targets the #app container directly, so we hand it our
+      // section host instead — it owns the loading spinner, error
+      // banner, and view↔edit transitions inside this slot.
+      if (typeof SettingsDefaultsPage === 'undefined') {
+        host.innerHTML = Components.errorBanner({
+          message: 'SettingsDefaultsPage module not loaded',
+        });
+        return;
+      }
+      await SettingsDefaultsPage.render(host);
+      return;
+    }
+    host.innerHTML = this._placeholderHtml(key);
+  },
+
+  _placeholderHtml(key) {
+    const sec = this.SECTIONS.find(s => s.key === key);
+    if (!sec) return Components.emptyState('Section not found', 'Pick a section from the left.');
+    return `
+      <div class="settings-placeholder">
+        <div class="settings-placeholder-eyebrow">${escapeHtml(sec.label)}</div>
+        <h3 class="settings-placeholder-title">Coming in v0.6</h3>
+        <p class="settings-placeholder-body">${escapeHtml(sec.description)}.</p>
+      </div>
+    `;
+  },
+};

--- a/internal/webui/static/js/pages/targets.js
+++ b/internal/webui/static/js/pages/targets.js
@@ -197,6 +197,25 @@ const TargetsPage = {
     } catch (_) {}
   },
 
+  // PR8 #41 — public entry point used by the topbar +New menu. The
+  // targets page uses an inline form rather than a modal, so the
+  // public API is "navigate + focus the value input" rather than
+  // mounting a dialog. If the operator is already on /targets the
+  // hashchange handler is a no-op, so focus needs the manual nudge
+  // either way.
+  openCreateModal() {
+    const focusInput = () => {
+      const input = document.getElementById('target-value');
+      if (input) input.focus();
+    };
+    if ((location.hash || '').startsWith('#/targets')) {
+      focusInput();
+      return;
+    }
+    location.hash = '#/targets';
+    setTimeout(focusInput, 50);
+  },
+
   bindEvents(app) {
     const form = document.getElementById('add-target-form');
     if (form) {


### PR DESCRIPTION
## Summary

- **Changes page** (`/changes`): 3 columnas (Nuevos / Desaparecidos / Volvieron) sobre `/assets?status=…`. Sidebar badge muestra count de Desaparecidos.
- **Backend 1-liner**: `/assets` acepta `?status=…`; valida igual que `/findings` (passthrough al store, 0 rows si inválido).
- **Blackouts empty state premium**: ícono eye-off + título + body + CTA "+ New blackout" + CLI hint (`surfbot blackout create`) + calendar import disabled. `BlackoutsPage.openCreateModal({prefill, onSaved})` público.
- **Asset → Blackout**: botón "Add to blackout" del detail pane (PR10) habilitado. Pre-fill del modal con `scope=target` + `target_id` del asset.
- **Settings consolidation**: nueva ruta `/settings` con sub-nav lateral (7 secciones). `scan-defaults` reusa `SettingsDefaultsPage`; las otras 6 son placeholders "Coming in v0.6". Legacy `/settings/defaults` redirige transparente a `/settings/scan-defaults`.
- **Topbar `+ New` dropdown**: 4 acciones (target / scan / schedule / blackout) con click-outside, Esc y arrow-key nav. Fallback a hash navigation si la página no expone `openCreateModal`.

## Test plan

- [x] `go test ./... -race` — verde (incluye `TestAssetsListAcceptsStatusParam` nuevo + 8 invariantes Go nuevos en `foundation_assets_test.go`)
- [x] `golangci-lint run` — 0 issues
- [x] `node --check` sobre cada `.js` modificado — sintaxis OK
- [ ] Smoke manual:
  - [ ] `/changes` con datos reales muestra 3 columnas + counts
  - [ ] Sidebar badge `Changes` matchea Desaparecidos
  - [ ] `/blackouts` con DB vacía muestra empty state premium
  - [ ] `/assets` detail "Add to blackout" abre modal pre-fill
  - [ ] `/settings` sub-nav navega entre 7 secciones
  - [ ] `/settings/defaults` redirige sin warning
  - [ ] Topbar `+ New` abre dropdown, cada item dispatch al modal correcto
  - [ ] Mobile 768px: settings sub-nav stack vertical, changes 3 cols stack vertical

## Non-goals (per spec)

- Reports (cloud-only, surfbot-web).
- `/asset-changes` time-windowed endpoint (P1, defers Range:7d + Export diff buttons — visibles pero disabled).
- Settings sections funcionales más allá de Scan defaults.
- Bulk en blackouts, edit-in-place, calendar import.
- Topbar `+ New` keyboard shortcuts globales (defer a PR9 #42 Cmd+K).

Closes #41