### PR TITLE
webui pr6 #39: schedules names + rrule humanizer + templates cards + modal redesign

### DIFF
--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -1,36 +1,48 @@
 /* === Reset & Base === */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
+/* Design system v0.2 — light-first, Magnetic Blue.
+ *
+ * Legacy variable NAMES preserved so the 4000+ existing selectors below
+ * keep working without a renaming pass. Only the VALUES change — they
+ * now resolve to the design system tokens defined in tokens.css.
+ *
+ * tokens.css already provides --text-primary, --text-secondary,
+ * --font-sans, --font-mono, --radius-lg with light-first values, so we
+ * intentionally don't redeclare those here — they shine through. */
 :root {
-  --bg-primary: #0d1117;
-  --bg-secondary: #161b22;
-  --bg-tertiary: #21262d;
-  --bg-hover: #30363d;
-  --border: #30363d;
-  --text-primary: #e6edf3;
-  --text-secondary: #8b949e;
-  --text-muted: #484f58;
-  --accent: #00E599;
-  --accent-hover: #33EDAE;
+  /* Surfaces */
+  --bg-primary:    var(--surface-page);     /* was #0d1117 */
+  --bg-secondary:  var(--surface-card);     /* was #161b22 */
+  --bg-tertiary:   var(--surface-sunken);   /* was #21262d */
+  --bg-hover:      var(--surface-sunken);   /* was #30363d */
+  --border:        var(--border-subtle);    /* was #30363d */
 
-  --sev-critical: #f85149;
-  --sev-critical-bg: rgba(248,81,73,0.15);
-  --sev-high: #db6d28;
-  --sev-high-bg: rgba(219,109,40,0.15);
-  --sev-medium: #d29922;
-  --sev-medium-bg: rgba(210,153,34,0.15);
-  --sev-low: #58a6ff;
-  --sev-low-bg: rgba(88,166,255,0.15);
-  --sev-info: #8b949e;
-  --sev-info-bg: rgba(139,148,158,0.15);
+  /* Text muted (the rest comes from tokens.css) */
+  --text-muted:    var(--color-neutral-500); /* was #484f58 */
 
-  --success: #00E599;
-  --danger: #f85149;
+  /* Brand: mint → Magnetic Blue */
+  --accent:        var(--color-brand-700);  /* was #00E599 */
+  --accent-hover:  var(--color-brand-800);  /* was #33EDAE */
 
-  --radius: 6px;
-  --radius-lg: 8px;
-  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
-  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  /* Semantic */
+  --success:       var(--color-success-700); /* was #00E599 */
+  --danger:        var(--color-danger-700);  /* was #f85149 */
+
+  /* Severity — flat tints over light surfaces (was rgba over dark) */
+  --sev-critical:    var(--color-severity-critical);
+  --sev-critical-bg: var(--color-danger-100);
+  --sev-high:        var(--color-severity-high);
+  --sev-high-bg:     var(--color-danger-100);
+  --sev-medium:      var(--color-severity-medium);
+  --sev-medium-bg:   var(--color-warning-100);
+  --sev-low:         var(--color-severity-low);
+  --sev-low-bg:      var(--color-info-100);
+  --sev-info:        var(--color-severity-info);
+  --sev-info-bg:     var(--color-neutral-100);
+
+  /* Legacy radius alias (--radius-lg comes from tokens.css = 8px) */
+  --radius:        var(--radius-md);
 }
 
 html, body { height: 100%; }
@@ -106,7 +118,7 @@ a:hover { color: var(--accent-hover); }
 }
 
 .nav-link.active {
-  background: rgba(0,229,153,0.08);
+  background: rgba(5,48,140,0.08);
   color: var(--accent);
   font-weight: 500;
 }
@@ -320,8 +332,8 @@ a:hover { color: var(--accent-hover); }
 }
 
 .badge-open { background: var(--sev-critical-bg); color: var(--sev-critical); }
-.badge-completed { background: rgba(0,229,153,0.15); color: var(--success); }
-.badge-running { background: rgba(0,229,153,0.1); color: var(--accent); }
+.badge-completed { background: rgba(5,48,140,0.15); color: var(--success); }
+.badge-running { background: rgba(5,48,140,0.1); color: var(--accent); }
 .badge-failed { background: var(--sev-high-bg); color: var(--sev-high); }
 
 /* === Tables === */
@@ -931,7 +943,7 @@ tr.finding-detail-row td.finding-detail-cell {
 
 .btn-primary {
   background: var(--accent);
-  color: #0d1117;
+  color: var(--text-on-brand);
   border-color: var(--accent);
   font-weight: 600;
 }
@@ -947,12 +959,12 @@ tr.finding-detail-row td.finding-detail-cell {
 .btn-secondary:hover { background: var(--bg-secondary); border-color: var(--text-muted); }
 
 .btn-accent {
-  background: rgba(0,229,153,0.1);
+  background: rgba(5,48,140,0.1);
   color: var(--accent);
-  border-color: rgba(0,229,153,0.3);
+  border-color: rgba(5,48,140,0.3);
 }
 
-.btn-accent:hover { background: rgba(0,229,153,0.2); }
+.btn-accent:hover { background: rgba(5,48,140,0.2); }
 
 .btn-danger {
   background: rgba(248,81,73,0.1);
@@ -995,7 +1007,7 @@ tr.finding-detail-row td.finding-detail-cell {
 .form-input:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(0,229,153,0.15);
+  box-shadow: 0 0 0 2px rgba(5,48,140,0.15);
 }
 
 .form-input::placeholder { color: var(--text-muted); }
@@ -1045,7 +1057,7 @@ tr.finding-detail-row td.finding-detail-cell {
 .status-select:focus { outline: none; border-color: var(--accent); }
 .status-select.status-open { background: var(--sev-critical-bg); color: var(--sev-critical); border-color: rgba(248,81,73,0.3); }
 .status-select.status-acknowledged { background: var(--sev-medium-bg); color: var(--sev-medium); border-color: rgba(210,153,34,0.3); }
-.status-select.status-resolved { background: rgba(0,229,153,0.15); color: var(--success); border-color: rgba(0,229,153,0.3); }
+.status-select.status-resolved { background: rgba(5,48,140,0.15); color: var(--success); border-color: rgba(5,48,140,0.3); }
 .status-select.status-false_positive { background: var(--sev-info-bg); color: var(--sev-info); border-color: rgba(139,148,158,0.3); }
 .status-select.status-ignored { background: var(--sev-info-bg); color: var(--sev-info); border-color: rgba(139,148,158,0.3); }
 
@@ -1076,7 +1088,7 @@ tr.finding-detail-row td.finding-detail-cell {
 
 .scan-banner {
   background: var(--bg-secondary);
-  border: 1px solid rgba(0,229,153,0.3);
+  border: 1px solid rgba(5,48,140,0.3);
   border-radius: var(--radius-lg);
   padding: 16px 20px;
   margin-bottom: 20px;
@@ -1105,7 +1117,7 @@ tr.finding-detail-row td.finding-detail-cell {
 
 /* === Status badges (additions) === */
 .badge-acknowledged { background: var(--sev-medium-bg); color: var(--sev-medium); }
-.badge-resolved { background: rgba(0,229,153,0.15); color: var(--success); }
+.badge-resolved { background: rgba(5,48,140,0.15); color: var(--success); }
 .badge-false_positive { background: var(--sev-info-bg); color: var(--sev-info); }
 .badge-ignored { background: var(--sev-info-bg); color: var(--sev-info); }
 .badge-queued { background: var(--sev-low-bg); color: var(--sev-low); }
@@ -1147,7 +1159,7 @@ tr.finding-detail-row td.finding-detail-cell {
   border-radius: 50%;
   background: #888;
 }
-.agent-dot-ok   { background: var(--success, #00e599); box-shadow: 0 0 6px rgba(0,229,153,0.6); }
+.agent-dot-ok   { background: var(--success, #15803D); box-shadow: 0 0 6px rgba(5,48,140,0.6); }
 .agent-dot-warn { background: var(--sev-medium, #f5a623); }
 .agent-dot-err  { background: var(--danger, #ff4d4f); }
 .agent-actions {
@@ -1208,7 +1220,7 @@ tr.finding-detail-row td.finding-detail-cell {
 .phase-circle.phase-done {
   background: var(--accent);
   border-color: var(--accent);
-  color: #0d1117;
+  color: var(--text-on-brand);
 }
 
 .phase-circle.phase-active {
@@ -1508,7 +1520,7 @@ body.modal-open { overflow: hidden; }
 .bulk-actions-count { font-size: 13px; color: var(--text-secondary); }
 .bulk-actions-count strong { color: var(--text-primary); }
 .bulk-actions-buttons { display: flex; gap: 8px; }
-tr.row-selected { background: rgba(0,229,153,0.06); }
+tr.row-selected { background: rgba(5,48,140,0.06); }
 
 /* Schedule/template/blackout detail grids reuse .detail-grid but the
  * rrule/JSON blocks benefit from a fixed-height scroll. */
@@ -1535,37 +1547,37 @@ tr.row-selected { background: rgba(0,229,153,0.06); }
  * =================================================================== */
 
 :root {
-  /* Surface scale — lower number = darker. Mapped 1:1 to existing
-   * --bg-* so the redesign can reach for semantic names without a
-   * second source of truth for the actual hex. */
-  --ink-900: #0d1117;
-  --ink-800: #161b22;
-  --ink-700: #21262d;
-  --ink-600: #30363d;
+  /* --ink-* originally mapped 1:1 to --bg-* in the dark theme. Same
+   * semantic kept: lower number = "deeper surface". Now chains through
+   * to the new light-first surface tokens. */
+  --ink-900: var(--bg-primary);
+  --ink-800: var(--bg-secondary);
+  --ink-700: var(--bg-tertiary);
+  --ink-600: var(--border);
 
   /* Brand alias for --accent. Keeps the wireframe vocabulary. */
-  --brand: var(--accent);
+  --brand:        var(--accent);
   --brand-strong: var(--accent-hover);
 
-  /* Finding triage status. Open is attention-red, ack is amber,
-   * resolved is brand green, fp/ignored fade to muted greys. */
-  --status-open:     #f85149;
-  --status-ack:      #d29922;
-  --status-resolved: #00E599;
-  --status-fp:       #8b949e;
-  --status-ignored:  #6e7681;
+  /* Finding triage status — light-first.
+   * open = danger, ack = warning, resolved = success, fp/ignored = neutral. */
+  --status-open:     var(--color-danger-600);
+  --status-ack:      var(--color-warning-600);
+  --status-resolved: var(--color-success-600);
+  --status-fp:       var(--color-neutral-500);
+  --status-ignored:  var(--color-neutral-400);
 
-  --status-open-bg:     rgba(248,81,73,0.15);
-  --status-ack-bg:      rgba(210,153,34,0.15);
-  --status-resolved-bg: rgba(0,229,153,0.15);
-  --status-fp-bg:       rgba(139,148,158,0.15);
-  --status-ignored-bg:  rgba(110,118,129,0.15);
+  --status-open-bg:     var(--color-danger-50);
+  --status-ack-bg:      var(--color-warning-50);
+  --status-resolved-bg: var(--color-success-50);
+  --status-fp-bg:       var(--color-neutral-100);
+  --status-ignored-bg:  var(--color-neutral-100);
 
-  --status-open-border:     rgba(248,81,73,0.4);
-  --status-ack-border:      rgba(210,153,34,0.4);
-  --status-resolved-border: rgba(0,229,153,0.4);
-  --status-fp-border:       rgba(139,148,158,0.3);
-  --status-ignored-border:  rgba(110,118,129,0.3);
+  --status-open-border:     rgba(220, 38, 38, 0.4);  /* danger-600 */
+  --status-ack-border:      rgba(217, 119, 6, 0.4);  /* warning-600 */
+  --status-resolved-border: rgba(22, 163, 74, 0.4);  /* success-600 */
+  --status-fp-border:       rgba(100, 116, 139, 0.3);/* neutral-500 */
+  --status-ignored-border:  rgba(148, 163, 184, 0.3);/* neutral-400 */
 }
 
 /* --- Pills (severity + status) -------------------------------------
@@ -1844,7 +1856,7 @@ tr.row-selected { background: rgba(0,229,153,0.06); }
  * visually with the active-scan pill. The real "+ New" affordance
  * lands in PR3. */
 .topbar-new:hover {
-  border-color: rgba(0,229,153,0.6);
+  border-color: rgba(5,48,140,0.6);
   color: var(--text-primary);
 }
 
@@ -1873,7 +1885,7 @@ tr.row-selected { background: rgba(0,229,153,0.06); }
 }
 
 .topbar-search:hover {
-  border-color: rgba(0,229,153,0.6);
+  border-color: rgba(5,48,140,0.6);
   color: var(--text-secondary);
 }
 
@@ -1917,8 +1929,8 @@ tr.row-selected { background: rgba(0,229,153,0.06); }
   gap: 6px;
   padding: 4px 10px;
   border-radius: 9999px;
-  background: rgba(0,229,153,0.1);
-  border: 1px solid rgba(0,229,153,0.3);
+  background: rgba(5,48,140,0.1);
+  border: 1px solid rgba(5,48,140,0.3);
   color: var(--text-secondary);
   font-size: 12px;
   font-weight: 500;
@@ -1928,7 +1940,7 @@ tr.row-selected { background: rgba(0,229,153,0.06); }
 }
 
 .scan-indicator:hover {
-  border-color: rgba(0,229,153,0.6);
+  border-color: rgba(5,48,140,0.6);
   color: var(--text-primary);
 }
 
@@ -2105,7 +2117,7 @@ button.kpi-card:focus-visible {
   font-size: 11px;
   font-weight: 500;
 }
-.kpi-trend-up { color: var(--sev-low); background: rgba(0,229,153,0.15); }
+.kpi-trend-up { color: var(--sev-low); background: rgba(5,48,140,0.15); }
 .kpi-trend-down { color: var(--sev-critical); background: var(--sev-critical-bg); }
 .kpi-trend-flat { color: var(--text-muted); background: var(--ink-700); }
 
@@ -2119,7 +2131,7 @@ button.kpi-card:focus-visible {
 .sparkline-bar {
   flex: 1;
   min-height: 2px;
-  background: rgba(0,229,153,0.3);
+  background: rgba(5,48,140,0.3);
   border-radius: 1px;
 }
 
@@ -2193,7 +2205,7 @@ button.kpi-card:focus-visible {
   color: var(--text-secondary);
   cursor: pointer;
 }
-.dash-tab.active { color: var(--brand); background: rgba(0,229,153,0.1); }
+.dash-tab.active { color: var(--brand); background: rgba(5,48,140,0.1); }
 .dash-tab:hover:not(.active) { color: var(--text-primary); }
 
 .activity-list { list-style: none; margin: 0; padding: 0; }
@@ -2438,7 +2450,7 @@ button.kpi-card:focus-visible {
 .so-prose code {
   font-family: var(--font-mono, monospace);
   color: var(--brand);
-  background: rgba(0,229,153,0.08);
+  background: rgba(5,48,140,0.08);
   border-radius: 3px;
   padding: 1px 4px;
   font-size: 12px;
@@ -2662,8 +2674,8 @@ button.kpi-card:focus-visible {
 .sev-tab-low      { color: var(--sev-low); }
 .sev-tab-info     { color: var(--sev-info); }
 .sev-tab-active {
-  background: rgba(0,229,153,0.10);
-  border-color: rgba(0,229,153,0.4);
+  background: rgba(5,48,140,0.10);
+  border-color: rgba(5,48,140,0.4);
   color: var(--brand);
 }
 .sev-tab-active.sev-tab-critical { background: var(--sev-critical-bg); border-color: rgba(248,81,73,0.4); color: var(--sev-critical); }
@@ -2718,8 +2730,8 @@ button.kpi-card:focus-visible {
   line-height: 1.4;
 }
 .save-view-pill.empty { color: var(--text-muted); cursor: default; }
-.save-view-pill.saved { color: var(--brand); border-color: rgba(0,229,153,0.4); }
-.save-view-pill:hover.saved { background: rgba(0,229,153,0.08); }
+.save-view-pill.saved { color: var(--brand); border-color: rgba(5,48,140,0.4); }
+.save-view-pill:hover.saved { background: rgba(5,48,140,0.08); }
 
 /* --- Filter menu / submenu (popup) -------------------------------- */
 .filter-menu {
@@ -2768,7 +2780,7 @@ button.kpi-card:focus-visible {
 .filter-menu-list { max-height: 220px; overflow-y: auto; }
 .filter-menu-apply {
   margin-top: 4px;
-  background: rgba(0,229,153,0.10);
+  background: rgba(5,48,140,0.10);
   color: var(--brand);
   text-align: center;
 }
@@ -2786,10 +2798,10 @@ button.kpi-card:focus-visible {
   cursor: pointer;
   accent-color: var(--brand);
 }
-.fnd-row-selected { background: rgba(0,229,153,0.06); }
-.fnd-row-selected:hover { background: rgba(0,229,153,0.14); }
-.tgt-row-selected { background: rgba(0,229,153,0.06); }
-.tgt-row-selected:hover { background: rgba(0,229,153,0.14); }
+.fnd-row-selected { background: rgba(5,48,140,0.06); }
+.fnd-row-selected:hover { background: rgba(5,48,140,0.14); }
+.tgt-row-selected { background: rgba(5,48,140,0.06); }
+.tgt-row-selected:hover { background: rgba(5,48,140,0.14); }
 
 /* --- Pagination (light) ------------------------------------------- */
 .pagination {
@@ -2927,7 +2939,7 @@ button.kpi-card:focus-visible {
   flex-shrink: 0;
 }
 .phase-dot-pending { background: var(--ink-700); border-color: var(--ink-600); }
-.phase-dot-done    { background: var(--success, #00e599); border-color: var(--success, #00e599); }
+.phase-dot-done    { background: var(--success, #15803D); border-color: var(--success, #15803D); }
 .phase-dot-running { background: var(--brand); border-color: var(--brand); animation: phase-pulse 1.4s ease-in-out infinite; }
 .phase-dot-failed  { background: var(--sev-critical); border-color: var(--sev-critical); }
 .phase-stem {
@@ -2972,7 +2984,7 @@ button.kpi-card:focus-visible {
 .phase-bar-track { background: var(--ink-700); }
 .phase-bar-fill { height: 100%; background: var(--brand); }
 .phase-bar-pending { background: var(--ink-700); }
-.phase-bar-done    { background: var(--success, #00e599); opacity: 0.55; }
+.phase-bar-done    { background: var(--success, #15803D); opacity: 0.55; }
 .phase-bar-failed  { background: var(--sev-critical); opacity: 0.55; }
 @media (max-width: 900px) {
   .phase-body { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
@@ -3218,8 +3230,8 @@ button.kpi-card:focus-visible {
 }
 .scan-log-chip:hover { background: var(--ink-700); color: var(--text-primary); }
 .scan-log-chip.active {
-  background: rgba(0,229,153,0.10);
-  border-color: rgba(0,229,153,0.4);
+  background: rgba(5,48,140,0.10);
+  border-color: rgba(5,48,140,0.4);
   color: var(--brand);
 }
 .scan-log-chip-error.active { background: var(--sev-critical-bg); border-color: rgba(248,81,73,0.4); color: var(--sev-critical); }
@@ -3420,7 +3432,7 @@ button.kpi-card:focus-visible {
 .tree-row:hover { background: var(--ink-800); }
 .tree-row-selected,
 .tree-row-selected:hover {
-  background: rgba(0,229,153,0.10);
+  background: rgba(5,48,140,0.10);
   border-left-color: var(--brand);
 }
 .tree-row-truncated {
@@ -3817,3 +3829,283 @@ button.kpi-card:focus-visible {
   font-size: 10px;
   color: var(--text-secondary);
 }
+
+/* === PR6 #39 — Schedules row pills + Templates card grid =========== */
+
+/* Action-pill variant: a clickable .pill that responds to hover/focus.
+ * Used inline in the Schedules table row and inside template cards. */
+.pill-action {
+  cursor: pointer;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-color: var(--border);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 10px;
+}
+.pill-action:hover { background: var(--bg-hover); color: var(--text-primary); }
+.pill-action:focus-visible { outline: 2px solid var(--brand); outline-offset: 1px; }
+.pill-action:disabled { opacity: 0.5; cursor: default; }
+
+/* Brand variant of pill-action — used for the primary CTA on a card
+ * (e.g. "Run with…") so the dispatcher action stands out from Edit /
+ * Duplicate. */
+.pill-brand {
+  background: rgba(0, 229, 153, 0.12);
+  color: var(--brand);
+  border-color: rgba(0, 229, 153, 0.4);
+}
+.pill-brand:hover { background: rgba(0, 229, 153, 0.2); color: var(--brand-strong); }
+
+/* Muted variant — read-only counters on the card meta row. */
+.pill-muted {
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border-color: var(--border);
+}
+
+/* Right-aligned actions cell in the schedules table. Keeps the two
+ * inline pills tight and prevents the row click handler from firing
+ * when the operator clicks on the gap between buttons. */
+.schedule-actions {
+  text-align: right;
+  white-space: nowrap;
+}
+.schedule-actions .pill-action + .pill-action { margin-left: 6px; }
+
+/* Two-line target / template cells in the schedules list: primary
+ * label on top, faint UUID short-id underneath. Scoped to <small>
+ * inside table cells so we don't restyle the many other places that
+ * combine .mono and .text-muted across the SPA. */
+td > small.text-muted.mono,
+td > small.mono.text-muted { font-size: 11px; }
+
+/* --- Templates: responsive card grid ------------------------------- */
+.template-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+@media (min-width: 640px) {
+  .template-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 1024px) {
+  .template-grid { grid-template-columns: repeat(3, 1fr); }
+}
+
+.template-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.template-card:hover {
+  border-color: var(--bg-hover);
+  background: var(--bg-tertiary);
+}
+
+.template-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.template-card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: break-word;
+}
+
+.template-card .card-desc {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.template-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.template-card-uuid {
+  margin-left: auto;
+  font-size: 11px;
+}
+
+.template-card-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: auto;
+  padding-top: 4px;
+}
+
+/* === PR6 #39 — Schedule modal redesign ============================ */
+
+/* Segmented preset selector. Each <label> wraps a hidden radio input;
+ * we paint the label and use :has(input:checked) to highlight the
+ * active preset. :has() needs Chrome 105+ / Safari 15.4+ / Firefox 121+
+ * which the SPA already targets. */
+.rrule-builder { gap: 0; }
+.rrule-builder .form-label { margin-bottom: 8px; }
+
+/* Edit-mode warning shown when the existing schedule's RRULE doesn't
+ * fit Daily/Weekly/Monthly (e.g. FREQ=HOURLY created via CLI). The
+ * operator sees this before clicking Save so the replacement isn't
+ * silent. */
+.rrule-incompat {
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  background: var(--sev-medium-bg);
+  border: 1px solid rgba(210, 153, 34, 0.4);
+  border-radius: var(--radius);
+  font-size: 13px;
+  color: var(--text-primary);
+}
+.rrule-incompat strong { color: var(--sev-medium); }
+.rrule-incompat code { color: var(--text-primary); }
+
+.rrule-presets {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.rrule-preset {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-size: 13px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  user-select: none;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+.rrule-preset:hover { color: var(--text-primary); }
+.rrule-preset input { position: absolute; opacity: 0; pointer-events: none; }
+.rrule-preset:has(input:checked) {
+  background: rgba(0, 229, 153, 0.12);
+  border-color: rgba(0, 229, 153, 0.4);
+  color: var(--brand);
+}
+.rrule-preset input:focus-visible + span {
+  outline: 2px solid var(--brand);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+/* Per-mode controls row. Inputs sit inline with small labels so the
+ * sentence reads naturally: "every [6] hours". */
+.rrule-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+.rrule-panel {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.rrule-panel[hidden] { display: none; }
+.rrule-text { color: var(--text-secondary); }
+
+.rrule-controls input[type="time"],
+.rrule-controls input[type="number"],
+.rrule-controls input[type="text"] {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 4px 8px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font-mono);
+}
+.rrule-controls input[type="number"] { width: 70px; }
+.rrule-controls input[type="time"]   { width: 110px; }
+.rrule-custom-input { width: 100%; }
+
+/* Weekday toggle row — same pattern as the preset selector. */
+.rrule-day-toggles {
+  display: inline-flex;
+  gap: 2px;
+  flex-wrap: wrap;
+}
+.rrule-day-toggle {
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-size: 11px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  user-select: none;
+}
+.rrule-day-toggle:hover { color: var(--text-primary); }
+.rrule-day-toggle input { position: absolute; opacity: 0; pointer-events: none; }
+.rrule-day-toggle:has(input:checked) {
+  background: rgba(0, 229, 153, 0.12);
+  border-color: rgba(0, 229, 153, 0.4);
+  color: var(--brand);
+}
+
+/* Live preview of the rrule. Echoes humanizeRRule() output as the
+ * operator clicks; falls back to the raw rule when the pattern isn't
+ * humanized (Custom mode with COUNT/UNTIL/etc.). */
+.rrule-preview {
+  padding: 8px 12px;
+  background: var(--bg-tertiary);
+  border-left: 2px solid var(--brand);
+  border-radius: var(--radius);
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.rrule-preview-label { color: var(--text-muted); margin-right: 6px; }
+.rrule-preview strong { color: var(--text-primary); font-weight: 500; }
+.rrule-preview-error { border-left-color: var(--sev-medium); }
+.rrule-preview-error strong { color: var(--sev-medium); }
+
+/* Advanced disclosure — collapsible bottom section so estimated
+ * duration and edit-mode status don't crowd the primary fields. */
+.form-disclosure {
+  margin-top: 12px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+.form-disclosure > summary {
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text-secondary);
+  padding: 6px 0;
+  list-style: none;
+  user-select: none;
+}
+.form-disclosure > summary::-webkit-details-marker { display: none; }
+.form-disclosure > summary::before {
+  content: '▶';
+  display: inline-block;
+  margin-right: 6px;
+  font-size: 10px;
+  transition: transform 120ms ease;
+}
+.form-disclosure[open] > summary::before { transform: rotate(90deg); }
+.form-disclosure > summary:hover { color: var(--text-primary); }

--- a/internal/webui/static/js/components.js
+++ b/internal/webui/static/js/components.js
@@ -165,6 +165,9 @@ const Components = {
   // rruleCompact keeps the first semicolon-separated component (FREQ=...)
   // or the first 40 chars, whichever is shorter. Full RRULE goes into the
   // title attribute for hover.
+  //
+  // Prefer humanizeRRule for new code — this stays as the fallback shape
+  // when a pattern isn't yet covered by the humanizer.
   rruleCompact(rrule) {
     if (!rrule) return '-';
     const safe = escapeHtml(rrule);
@@ -172,6 +175,83 @@ const Components = {
     let short = first.length < 40 ? first : rrule.slice(0, 40);
     if (short.length < rrule.length) short += '…';
     return `<span class="mono" title="${safe}">${escapeHtml(short)}</span>`;
+  },
+
+  // humanizeRRule renders the most common RRULE patterns as plain English.
+  // Returns a plain text string for covered patterns (e.g. "Daily at 02:00",
+  // "Weekly on Mon, Wed, Fri at 09:00", "Every 6 hours") and falls back to
+  // rruleCompact()'s mono span when the rule contains fields the humanizer
+  // doesn't model — that way unknown rules stay legible without inventing
+  // labels for fields like COUNT/UNTIL/BYSETPOS.
+  //
+  // Returning a mixed shape (string vs HTML) is a deliberate trade-off so
+  // the covered cases are easy to assert in tests and easy to wrap in a
+  // tooltip at the call site; callers detect the fallback by checking
+  // whether the value starts with '<'.
+  humanizeRRule(rrule) {
+    if (rrule == null || rrule === '') return '-';
+    const parts = parseRRule(rrule);
+    if (!parts.FREQ) return Components.rruleCompact(rrule);
+
+    // Bail to the fallback when fields outside our model are present.
+    // Keeps "Daily at 02:00" from showing for FREQ=DAILY;COUNT=10.
+    const SUPPORTED = new Set(['FREQ', 'INTERVAL', 'BYHOUR', 'BYMINUTE', 'BYDAY', 'BYMONTHDAY']);
+    for (const k of Object.keys(parts)) {
+      if (!SUPPORTED.has(k)) return Components.rruleCompact(rrule);
+    }
+
+    const interval = parts.INTERVAL ? parseInt(parts.INTERVAL, 10) : 1;
+    if (isNaN(interval) || interval < 1) return Components.rruleCompact(rrule);
+    const time = formatRRuleTime(parts.BYHOUR, parts.BYMINUTE);
+
+    switch (parts.FREQ.toUpperCase()) {
+      case 'DAILY':
+        if (parts.BYDAY || parts.BYMONTHDAY) return Components.rruleCompact(rrule);
+        return interval > 1
+          ? `Every ${interval} days${time ? ' at ' + time : ''}`
+          : `Daily${time ? ' at ' + time : ''}`;
+      case 'WEEKLY': {
+        if (parts.BYMONTHDAY) return Components.rruleCompact(rrule);
+        const days = formatRRuleByDay(parts.BYDAY);
+        if (parts.BYDAY && !days) return Components.rruleCompact(rrule);
+        return interval > 1
+          ? `Every ${interval} weeks${days ? ' on ' + days : ''}${time ? ' at ' + time : ''}`
+          : `Weekly${days ? ' on ' + days : ''}${time ? ' at ' + time : ''}`;
+      }
+      case 'MONTHLY': {
+        if (parts.BYDAY) return Components.rruleCompact(rrule);
+        const dayN = parts.BYMONTHDAY ? parseInt(parts.BYMONTHDAY, 10) : null;
+        if (parts.BYMONTHDAY && (isNaN(dayN) || dayN < 1 || dayN > 31)) {
+          return Components.rruleCompact(rrule);
+        }
+        const day = dayN ? ` on day ${dayN}` : '';
+        return interval > 1
+          ? `Every ${interval} months${day}${time ? ' at ' + time : ''}`
+          : `Monthly${day}${time ? ' at ' + time : ''}`;
+      }
+      case 'HOURLY':
+        if (parts.BYDAY || parts.BYMONTHDAY || parts.BYHOUR || parts.BYMINUTE) {
+          return Components.rruleCompact(rrule);
+        }
+        return interval > 1 ? `Every ${interval} hours` : 'Hourly';
+      case 'MINUTELY':
+        if (parts.BYDAY || parts.BYMONTHDAY || parts.BYHOUR || parts.BYMINUTE) {
+          return Components.rruleCompact(rrule);
+        }
+        return interval > 1 ? `Every ${interval} minutes` : 'Every minute';
+      default:
+        return Components.rruleCompact(rrule);
+    }
+  },
+
+  // rruleCellHtml wraps humanizeRRule's output for table cells: covered
+  // patterns get a tooltip carrying the raw RRULE; the fallback already
+  // ships its own title=, so it passes through.
+  rruleCellHtml(rrule) {
+    const human = Components.humanizeRRule(rrule);
+    if (human === '-') return '<span class="text-muted">—</span>';
+    if (typeof human === 'string' && human.charAt(0) === '<') return human;
+    return `<span title="${escapeHtml(rrule || '')}">${escapeHtml(human)}</span>`;
   },
 
   // nextRun formats a *future* time as "in 3h 42m" and a past time as
@@ -268,9 +348,252 @@ const Components = {
     });
   },
 
+  // entityPicker renders a datalist-backed input. options is an array
+  // of { id, label } where label is what the operator sees and types.
+  // The form ultimately submits the typed text, not the id — callers
+  // resolve text → id at submit time via entityPickerResolve so a
+  // pasted UUID still works as a power-user escape hatch. Pickers stay
+  // stateless on purpose; reading happens in the page's read*Form.
+  entityPicker({ name, value, label, options, required, allowEmpty, help, placeholder }) {
+    const opts = (options || []).map(o =>
+      `<option value="${escapeHtml(o.label)}"></option>`
+    ).join('');
+    let display = '';
+    if (value) {
+      const match = (options || []).find(o => o.id === value);
+      display = match ? match.label : String(value);
+    }
+    const reqMark = (required && !allowEmpty) ? ' <span class="form-required">*</span>' : '';
+    const helpHtml = help ? `<div class="form-help">${escapeHtml(help)}</div>` : '';
+    const ph = placeholder ? `placeholder="${escapeHtml(placeholder)}"` : '';
+    return `<div class="form-field" data-field="${escapeHtml(name)}">
+      <label class="form-label" for="f-${escapeHtml(name)}">${escapeHtml(label)}${reqMark}</label>
+      <input class="form-input" id="f-${escapeHtml(name)}" name="${escapeHtml(name)}"
+             list="${escapeHtml(name)}-options" autocomplete="off"
+             ${(required && !allowEmpty) ? 'required' : ''}
+             ${ph}
+             value="${escapeHtml(display)}">
+      <datalist id="${escapeHtml(name)}-options">${opts}</datalist>
+      ${helpHtml}
+      <div class="field-error" data-field-error="${escapeHtml(name)}" style="display:none"></div>
+    </div>`;
+  },
+
+  // entityPickerResolve maps the typed text in a picker input to its id.
+  // Returns '' for empty input, the matched id for a successful lookup,
+  // or null when the typed text matches neither a label nor a known id
+  // — the caller surfaces a field error in that case.
+  entityPickerResolve(typed, options) {
+    const t = (typed || '').trim();
+    if (!t) return '';
+    const byLabel = (options || []).find(o => o.label === t);
+    if (byLabel) return byLabel.id;
+    const byId = (options || []).find(o => o.id === t);
+    if (byId) return byId.id;
+    return null;
+  },
+
+  // rruleBuilder renders the segmented preset selector + per-mode
+  // controls + live preview + a hidden input named `name` so the
+  // existing FormData read picks it up unchanged. Wire interactivity
+  // after mount via rruleBuilderAttach(formEl). The default preset is
+  // DAILY at 02:00; data-rrule-initial drives hydration on edit.
+  //
+  // Only Daily / Weekly / Monthly are exposed; sub-daily cadences
+  // (hourly, minutely) and exotic patterns (YEARLY, COUNT, UNTIL,
+  // BYSETPOS) are CLI territory. When edit mode loads a schedule
+  // whose RRULE doesn't fit any preset, the builder shows an inline
+  // warning so the operator knows saving will replace the pattern.
+  rruleBuilder({ name, value, label, required }) {
+    const reqMark = required ? ' <span class="form-required">*</span>' : '';
+    const lbl = label || 'Schedule';
+    const safeName = escapeHtml(name);
+    return `<div class="form-field rrule-builder" data-field="${safeName}" data-rrule-builder data-rrule-initial="${escapeHtml(value || '')}">
+      <label class="form-label">${escapeHtml(lbl)}${reqMark}</label>
+      <div class="rrule-incompat" data-rb-incompat hidden>
+        <div><strong>Heads up:</strong> the existing schedule uses a pattern this form doesn't model
+          (<code class="mono" data-rb-incompat-raw></code>).
+          Saving here will replace it with whatever you pick below. Cancel and use the CLI if you want to keep it.</div>
+      </div>
+      <div class="rrule-presets" role="radiogroup" aria-label="Recurrence frequency">
+        <label class="rrule-preset"><input type="radio" name="${safeName}-mode" data-rb-mode value="DAILY" checked><span>Daily</span></label>
+        <label class="rrule-preset"><input type="radio" name="${safeName}-mode" data-rb-mode value="WEEKLY"><span>Weekly</span></label>
+        <label class="rrule-preset"><input type="radio" name="${safeName}-mode" data-rb-mode value="MONTHLY"><span>Monthly</span></label>
+      </div>
+      <div class="rrule-controls">
+        <div class="rrule-panel" data-rb-panel="DAILY">
+          <span class="rrule-text">at</span>
+          <input type="time" data-rb="time-daily" value="02:00">
+        </div>
+        <div class="rrule-panel" data-rb-panel="WEEKLY" hidden>
+          <span class="rrule-text">on</span>
+          <span class="rrule-day-toggles">
+            <label class="rrule-day-toggle"><input type="checkbox" data-rb="day-MO"><span>Mon</span></label>
+            <label class="rrule-day-toggle"><input type="checkbox" data-rb="day-TU"><span>Tue</span></label>
+            <label class="rrule-day-toggle"><input type="checkbox" data-rb="day-WE"><span>Wed</span></label>
+            <label class="rrule-day-toggle"><input type="checkbox" data-rb="day-TH"><span>Thu</span></label>
+            <label class="rrule-day-toggle"><input type="checkbox" data-rb="day-FR"><span>Fri</span></label>
+            <label class="rrule-day-toggle"><input type="checkbox" data-rb="day-SA"><span>Sat</span></label>
+            <label class="rrule-day-toggle"><input type="checkbox" data-rb="day-SU"><span>Sun</span></label>
+          </span>
+          <span class="rrule-text">at</span>
+          <input type="time" data-rb="time-weekly" value="09:00">
+        </div>
+        <div class="rrule-panel" data-rb-panel="MONTHLY" hidden>
+          <span class="rrule-text">on day</span>
+          <input type="number" data-rb="monthday" min="1" max="31" value="1">
+          <span class="rrule-text">at</span>
+          <input type="time" data-rb="time-monthly" value="00:00">
+        </div>
+      </div>
+      <div class="rrule-preview" data-rb-preview-host>
+        <span class="rrule-preview-label">Will run:</span>
+        <strong data-rb-preview>—</strong>
+      </div>
+      <input type="hidden" name="${safeName}" data-rb-output value="">
+      <div class="field-error" data-field-error="${safeName}" style="display:none"></div>
+    </div>`;
+  },
+
+  // rruleBuilderAttach wires the segmented selector, panels, and live
+  // preview, then hydrates from data-rrule-initial. Idempotent so it's
+  // safe to call after partial DOM updates.
+  rruleBuilderAttach(rootOrForm) {
+    const root = rootOrForm && rootOrForm.matches && rootOrForm.matches('[data-rrule-builder]')
+      ? rootOrForm
+      : (rootOrForm && rootOrForm.querySelector ? rootOrForm.querySelector('[data-rrule-builder]') : null);
+    if (!root) return;
+    if (root.dataset.rbAttached) return;
+    root.dataset.rbAttached = '1';
+
+    const output = root.querySelector('[data-rb-output]');
+    const preview = root.querySelector('[data-rb-preview]');
+    const previewHost = root.querySelector('[data-rb-preview-host]');
+    const modeRadios = root.querySelectorAll('[data-rb-mode]');
+
+    function selectedMode() {
+      for (const r of modeRadios) if (r.checked) return r.value;
+      return 'DAILY';
+    }
+
+    function showPanel(mode) {
+      root.querySelectorAll('[data-rb-panel]').forEach(p => {
+        p.hidden = p.dataset.rbPanel !== mode;
+      });
+    }
+
+    function buildRRule() {
+      const mode = selectedMode();
+      const q = (sel) => root.querySelector(sel);
+      if (mode === 'DAILY') {
+        const t = (q('[data-rb="time-daily"]').value || '00:00').split(':');
+        return `FREQ=DAILY;BYHOUR=${parseInt(t[0],10)};BYMINUTE=${parseInt(t[1],10)}`;
+      }
+      if (mode === 'WEEKLY') {
+        const days = ['MO','TU','WE','TH','FR','SA','SU']
+          .filter(d => q(`[data-rb="day-${d}"]`).checked);
+        const t = (q('[data-rb="time-weekly"]').value || '00:00').split(':');
+        let s = 'FREQ=WEEKLY';
+        if (days.length) s += `;BYDAY=${days.join(',')}`;
+        s += `;BYHOUR=${parseInt(t[0],10)};BYMINUTE=${parseInt(t[1],10)}`;
+        return s;
+      }
+      if (mode === 'MONTHLY') {
+        const d = parseInt(q('[data-rb="monthday"]').value, 10) || 1;
+        const t = (q('[data-rb="time-monthly"]').value || '00:00').split(':');
+        return `FREQ=MONTHLY;BYMONTHDAY=${d};BYHOUR=${parseInt(t[0],10)};BYMINUTE=${parseInt(t[1],10)}`;
+      }
+      return '';
+    }
+
+    function update() {
+      const rrule = buildRRule();
+      output.value = rrule;
+      previewHost.classList.remove('rrule-preview-error');
+      if (!rrule) {
+        preview.textContent = '—';
+      } else {
+        const human = Components.humanizeRRule(rrule);
+        if (typeof human === 'string' && human.charAt(0) === '<') {
+          preview.innerHTML = human;
+          previewHost.classList.add('rrule-preview-error');
+        } else if (human === '-') {
+          preview.textContent = '—';
+        } else {
+          preview.textContent = human;
+        }
+      }
+      root.dispatchEvent(new CustomEvent('rrule-change', {
+        bubbles: true,
+        detail: { rrule },
+      }));
+    }
+
+    function hydrate(rrule) {
+      const incompat = root.querySelector('[data-rb-incompat]');
+      const incompatRaw = root.querySelector('[data-rb-incompat-raw]');
+
+      if (!rrule) { update(); return; }
+      const parts = parseRRule(rrule);
+      const freq = (parts.FREQ || '').toUpperCase();
+      const supported = freq === 'DAILY' || freq === 'WEEKLY' || freq === 'MONTHLY';
+
+      if (!supported) {
+        // Existing schedule uses HOURLY/MINUTELY/YEARLY/COUNT/UNTIL/etc.
+        // We can't represent it here — surface the warning and leave
+        // the controls at the default DAILY preset so the operator
+        // makes an explicit choice if they want to overwrite.
+        if (incompat) incompat.hidden = false;
+        if (incompatRaw) incompatRaw.textContent = rrule;
+        update();
+        return;
+      }
+
+      if (incompat) incompat.hidden = true;
+      if (incompatRaw) incompatRaw.textContent = '';
+
+      const r = root.querySelector(`[data-rb-mode][value="${freq}"]`);
+      if (r) r.checked = true;
+
+      const h = parseInt(parts.BYHOUR || 0, 10);
+      const m = parseInt(parts.BYMINUTE || 0, 10);
+      const time = `${pad2(h)}:${pad2(m)}`;
+      if (freq === 'DAILY') {
+        root.querySelector('[data-rb="time-daily"]').value = time;
+      } else if (freq === 'WEEKLY') {
+        root.querySelector('[data-rb="time-weekly"]').value = time;
+        const days = (parts.BYDAY || '').split(',').map(s => s.trim().toUpperCase());
+        ['MO','TU','WE','TH','FR','SA','SU'].forEach(d => {
+          const cb = root.querySelector(`[data-rb="day-${d}"]`);
+          if (cb) cb.checked = days.indexOf(d) >= 0;
+        });
+      } else if (freq === 'MONTHLY') {
+        root.querySelector('[data-rb="time-monthly"]').value = time;
+        if (parts.BYMONTHDAY) {
+          root.querySelector('[data-rb="monthday"]').value = String(parseInt(parts.BYMONTHDAY, 10));
+        }
+      }
+
+      showPanel(freq);
+      update();
+    }
+
+    modeRadios.forEach(r => r.addEventListener('change', () => {
+      showPanel(selectedMode());
+      update();
+    }));
+    root.querySelectorAll('[data-rb]').forEach(el => {
+      const ev = (el.type === 'checkbox') ? 'change' : 'input';
+      el.addEventListener(ev, update);
+    });
+
+    hydrate(root.dataset.rruleInitial || '');
+  },
+
   // rruleField wraps formInput with a non-blocking client-side syntax
   // check. The server's 422 is the source of truth; the warning just
-  // catches obvious typos before the round-trip.
+  // catches obvious typos before the round-trip. Kept for callers that
+  // haven't migrated to rruleBuilder yet.
   rruleField({ label, name, value, error }) {
     const html = Components.formInput({
       label, name, type: 'text', value, error,
@@ -837,6 +1160,90 @@ function toDatetimeLocal(v) {
   const pad = (n) => String(n).padStart(2, '0');
   return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate())
     + 'T' + pad(d.getHours()) + ':' + pad(d.getMinutes());
+}
+
+// parseRRule splits "FREQ=DAILY;BYHOUR=2" into { FREQ:'DAILY', BYHOUR:'2' }.
+// Keys are upper-cased; values are kept verbatim. Components without an '='
+// are skipped so a stray "GARBAGE" doesn't crash the humanizer.
+function parseRRule(rrule) {
+  const out = {};
+  if (!rrule || typeof rrule !== 'string') return out;
+  rrule.split(';').forEach(part => {
+    const idx = part.indexOf('=');
+    if (idx < 0) return;
+    const k = part.slice(0, idx).trim().toUpperCase();
+    const v = part.slice(idx + 1).trim();
+    if (k) out[k] = v;
+  });
+  return out;
+}
+
+// formatRRuleTime renders "HH:MM" from BYHOUR/BYMINUTE strings. BYMINUTE
+// defaults to 0 when only BYHOUR is set so "FREQ=DAILY;BYHOUR=2" reads
+// "Daily at 02:00". Returns '' when BYHOUR is missing or out of range.
+function formatRRuleTime(byhour, byminute) {
+  if (byhour == null || byhour === '') return '';
+  const h = parseInt(byhour, 10);
+  if (isNaN(h) || h < 0 || h > 23) return '';
+  const mRaw = byminute != null && byminute !== '' ? parseInt(byminute, 10) : 0;
+  if (isNaN(mRaw) || mRaw < 0 || mRaw > 59) return '';
+  return pad2(h) + ':' + pad2(mRaw);
+}
+
+// formatRRuleByDay renders "MO,WE,FR" as "Mon, Wed, Fri". Unknown codes
+// short-circuit to '' so the humanizer can fall back to the raw rule.
+const RRULE_DAY_LABELS = Object.freeze({
+  MO: 'Mon', TU: 'Tue', WE: 'Wed', TH: 'Thu',
+  FR: 'Fri', SA: 'Sat', SU: 'Sun',
+});
+function formatRRuleByDay(byday) {
+  if (!byday) return '';
+  const tokens = byday.split(',').map(s => s.trim().toUpperCase()).filter(Boolean);
+  if (!tokens.length) return '';
+  const labels = [];
+  for (const t of tokens) {
+    const lbl = RRULE_DAY_LABELS[t];
+    if (!lbl) return '';
+    labels.push(lbl);
+  }
+  return labels.join(', ');
+}
+
+// browserTimezone returns the operator's IANA timezone (e.g.
+// "Europe/Madrid"). Falls back to "UTC" on the rare browser that
+// doesn't surface resolvedOptions.
+function browserTimezone() {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  } catch (_) {
+    return 'UTC';
+  }
+}
+
+// defaultDtstartLocal returns "now + 15 min, rounded up to the next
+// 15-min boundary" formatted for a datetime-local input. Used as the
+// pre-fill so the create-schedule modal doesn't open with an empty
+// required field — most operators just accept it and click Create.
+function defaultDtstartLocal() {
+  const d = new Date(Date.now() + 15 * 60 * 1000);
+  d.setSeconds(0, 0);
+  d.setMinutes(Math.ceil(d.getMinutes() / 15) * 15);
+  return d.getFullYear() + '-' + pad2(d.getMonth() + 1) + '-' + pad2(d.getDate())
+    + 'T' + pad2(d.getHours()) + ':' + pad2(d.getMinutes());
+}
+
+// suggestScheduleName composes a readable default like
+// "iana.org daily at 02:00" from a target value + RRULE. Returns ''
+// when there's no target to anchor on so callers can short-circuit
+// without overwriting whatever the user already typed.
+function suggestScheduleName(targetValue, rrule) {
+  const tv = (targetValue || '').trim();
+  if (!tv) return '';
+  const human = Components.humanizeRRule(rrule);
+  if (typeof human === 'string' && human.charAt(0) !== '<' && human !== '-') {
+    return tv + ' ' + human.toLowerCase();
+  }
+  return tv;
 }
 
 // cssEscape quotes a string for use in a CSS attribute selector. Light

--- a/internal/webui/static/js/pages/schedules.js
+++ b/internal/webui/static/js/pages/schedules.js
@@ -1,8 +1,36 @@
 // SPEC-SCHED1.4a: Schedules page (list + detail). Read-only; write flows
 // land in 1.4b. Mirrors the targets.js / scans.js layout so nav, loading,
 // empty, and error states match the rest of the SPA.
+//
+// PR6 #39 — list now resolves target/template UUIDs to names by fetching
+// /targets and /templates in parallel with /schedules. The lookup cache
+// is module-scoped and invalidated on any mutation flow that changes
+// names (create/edit/delete of schedule, plus full reload via hash nav).
 const SchedulesPage = {
   pageSize: 50,
+
+  // _lookupCache memoizes the parallel /targets and /templates fetches
+  // across renders within the same SPA session. Invalidated by any of
+  // our own write flows; external mutations (CLI) require a refresh.
+  _lookupCache: null,
+
+  async _getLookups() {
+    if (this._lookupCache) return this._lookupCache;
+    const [targetsResp, templatesResp] = await Promise.all([
+      API.targets().catch(() => ({ targets: [] })),
+      API.listTemplates({ limit: 500 }).catch(() => ({ items: [] })),
+    ]);
+    const targets = new Map();
+    const targetsList = (targetsResp && (targetsResp.targets || targetsResp.items)) || [];
+    targetsList.forEach(t => { if (t && t.id) targets.set(t.id, t); });
+    const templates = new Map();
+    const templatesList = (templatesResp && templatesResp.items) || [];
+    templatesList.forEach(t => { if (t && t.id) templates.set(t.id, t); });
+    this._lookupCache = { targets, templates };
+    return this._lookupCache;
+  },
+
+  _invalidateLookups() { this._lookupCache = null; },
 
   async render(app, params) {
     if (params && params.id) {
@@ -12,8 +40,11 @@ const SchedulesPage = {
 
     const filters = this.parseFilters(params || {});
     try {
-      const data = await API.listSchedules(this.apiParams(filters));
-      app.innerHTML = this.template(data, filters);
+      const [data, lookups] = await Promise.all([
+        API.listSchedules(this.apiParams(filters)),
+        this._getLookups(),
+      ]);
+      app.innerHTML = this.template(data, filters, lookups);
       this.bindEvents(app, filters);
     } catch (err) {
       app.innerHTML = `
@@ -41,9 +72,10 @@ const SchedulesPage = {
     return out;
   },
 
-  template(data, f) {
+  template(data, f, lookups) {
     const items = data.items || [];
     const total = data.total || 0;
+    const L = lookups || { targets: new Map(), templates: new Map() };
 
     const filterBar = `
       <form id="schedules-filters" class="inline-form" style="margin-bottom:16px">
@@ -76,20 +108,65 @@ const SchedulesPage = {
       `;
     }
 
-    const rows = items.map(s => `
-      <tr data-schedule-id="${encodeURIComponent(s.id)}">
-        <td class="bulk-cell" onclick="event.stopPropagation()">
-          <input type="checkbox" class="bulk-row-check" data-id="${escapeHtml(s.id)}">
+    const rows = items.map(s => {
+      const sid = encodeURIComponent(s.id);
+      const goRow = `location.hash='#/schedules/${sid}'`;
+
+      // Target cell: resolved value with UUID short-id underneath; if
+      // the target was deleted between fetch and render, surface a
+      // tooltip explaining the gap rather than blanking the cell.
+      const tgt = L.targets.get(s.target_id);
+      const tgtCell = tgt
+        ? `<td class="clickable" onclick="event.stopPropagation();location.hash='#/targets/${encodeURIComponent(s.target_id)}'">
+             <div>${escapeHtml(tgt.value || s.target_id)}</div>
+             <small class="text-muted mono">${Components.truncateID(s.target_id)}</small>
+           </td>`
+        : `<td class="mono clickable" title="Target not found — may have been deleted." onclick="${goRow}">
+             ${Components.truncateID(s.target_id)}
+           </td>`;
+
+      // Template cell: name + short UUID, or em-dash when the schedule
+      // doesn't reference a template at all.
+      let tmplCell;
+      if (!s.template_id) {
+        tmplCell = `<td class="clickable" onclick="${goRow}"><span class="text-muted">—</span></td>`;
+      } else {
+        const tmpl = L.templates.get(s.template_id);
+        tmplCell = tmpl
+          ? `<td class="clickable" onclick="event.stopPropagation();location.hash='#/templates/${encodeURIComponent(s.template_id)}'">
+               <div>${escapeHtml(tmpl.name || s.template_id)}</div>
+               <small class="text-muted mono">${Components.truncateID(s.template_id)}</small>
+             </td>`
+          : `<td class="mono clickable" title="Template not found — may have been deleted." onclick="${goRow}">
+               ${Components.truncateID(s.template_id)}
+             </td>`;
+      }
+
+      const isActive = s.status === 'active';
+      const pauseLabel = isActive ? 'Pause' : 'Resume';
+      const actions = `
+        <td class="schedule-actions" onclick="event.stopPropagation()">
+          <button type="button" class="pill pill-action row-action-pause" data-row-id="${escapeHtml(s.id)}" data-action="${isActive ? 'pause' : 'resume'}">${pauseLabel}</button>
+          <button type="button" class="pill pill-action row-action-edit" data-row-id="${escapeHtml(s.id)}" data-action="edit">Edit</button>
         </td>
-        <td class="mono clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">${Components.truncateID(s.id)}</td>
-        <td class="clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">${escapeHtml(s.name || '-')}</td>
-        <td class="mono clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">${Components.truncateID(s.target_id)}</td>
-        <td class="mono clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">${s.template_id ? Components.truncateID(s.template_id) : '<span class="text-muted">—</span>'}</td>
-        <td class="clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">${Components.scheduleStatusBadge(s.status)}</td>
-        <td class="clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">${Components.rruleCompact(s.rrule)}</td>
-        <td class="text-muted clickable" onclick="location.hash='#/schedules/${encodeURIComponent(s.id)}'">${Components.nextRun(s.next_run_at)}</td>
-      </tr>
-    `).join('');
+      `;
+
+      return `
+        <tr data-schedule-id="${sid}">
+          <td class="bulk-cell" onclick="event.stopPropagation()">
+            <input type="checkbox" class="bulk-row-check" data-id="${escapeHtml(s.id)}">
+          </td>
+          <td class="mono clickable" onclick="${goRow}">${Components.truncateID(s.id)}</td>
+          <td class="clickable" onclick="${goRow}">${escapeHtml(s.name || '-')}</td>
+          ${tgtCell}
+          ${tmplCell}
+          <td class="clickable" onclick="${goRow}">${Components.scheduleStatusBadge(s.status)}</td>
+          <td class="clickable" onclick="${goRow}">${Components.rruleCellHtml(s.rrule)}</td>
+          <td class="text-muted clickable" onclick="${goRow}">${Components.nextRun(s.next_run_at)}</td>
+          ${actions}
+        </tr>
+      `;
+    }).join('');
 
     const pager = this.pagerHtml(total, f);
 
@@ -105,7 +182,7 @@ const SchedulesPage = {
       <div id="schedules-bulk-error" style="margin-bottom:8px"></div>
       ${Components.table(
         ['<input type="checkbox" id="bulk-select-all" title="Select all on this page">',
-         'ID', 'Name', 'Target', 'Template', 'Status', 'RRULE', 'Next run'],
+         'ID', 'Name', 'Target', 'Template', 'Status', 'Schedule', 'Next run', ''],
         [rows]
       )}
       ${pager}
@@ -178,7 +255,63 @@ const SchedulesPage = {
       this.onRowCheck(app, f);
     });
 
+    // Inline row actions: Pause/Resume/Edit pills. We don't reuse the
+    // bulk-action handlers because these need per-row state (id, the
+    // schedule object for Edit) and have to refresh just the list.
+    app.querySelectorAll('.pill-action').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        const id = btn.dataset.rowId;
+        const action = btn.dataset.action;
+        if (!id || !action) return;
+        if (action === 'pause' || action === 'resume') {
+          this.inlinePauseResume(app, f, id, action === 'resume');
+        } else if (action === 'edit') {
+          this.inlineEdit(app, f, id);
+        }
+      });
+    });
+
     this.rebindBulkBar(app, f);
+  },
+
+  async inlinePauseResume(app, f, id, toActive) {
+    const errBox = document.getElementById('schedules-bulk-error');
+    if (errBox) errBox.innerHTML = '';
+    const btn = app.querySelector(`.row-action-pause[data-row-id="${cssEscape(id)}"]`);
+    const orig = btn ? btn.textContent : '';
+    if (btn) { btn.disabled = true; btn.textContent = '…'; }
+    try {
+      if (toActive) await API.resumeSchedule(id);
+      else await API.pauseSchedule(id);
+      // Names didn't change; keep the lookup cache. Re-render the list
+      // so the status badge flips and the pill swaps Pause↔Resume.
+      SchedulesPage.render(app, f);
+    } catch (err) {
+      if (errBox) errBox.innerHTML = Components.errorBanner(err);
+      if (btn) { btn.disabled = false; btn.textContent = orig; }
+    }
+  },
+
+  async inlineEdit(app, f, id) {
+    const errBox = document.getElementById('schedules-bulk-error');
+    if (errBox) errBox.innerHTML = '';
+    let s;
+    try {
+      s = await API.getSchedule(id);
+    } catch (err) {
+      if (errBox) errBox.innerHTML = Components.errorBanner(err);
+      return;
+    }
+    this.openForm({
+      mode: 'edit',
+      schedule: s,
+      onSaved: () => {
+        SchedulesPage._invalidateLookups();
+        SchedulesPage.render(app, f);
+      },
+    });
   },
 
   onRowCheck(app, f) {
@@ -253,7 +386,11 @@ const SchedulesPage = {
         errBox.innerHTML = parts.join('');
       }
       // Refresh the list so paused→active (etc.) visibly flips and
-      // deleted rows disappear. Keep filters.
+      // deleted rows disappear. Keep filters. Bulk delete may have
+      // removed schedules referencing now-orphan target IDs in the
+      // lookup, but the lookup is keyed by target_id so it stays
+      // valid; only delete invalidates because the page itself moves.
+      if (operation === 'delete') SchedulesPage._invalidateLookups();
       SchedulesPage.render(app, f);
     } catch (err) {
       if (errBox) errBox.innerHTML = Components.errorBanner(err);
@@ -265,7 +402,10 @@ const SchedulesPage = {
   openCreateForm(app, listFilters) {
     this.openForm({
       mode: 'create',
-      onSaved: () => SchedulesPage.render(app, listFilters || {}),
+      onSaved: () => {
+        SchedulesPage._invalidateLookups();
+        SchedulesPage.render(app, listFilters || {});
+      },
     });
   },
 
@@ -281,51 +421,106 @@ const SchedulesPage = {
     this.openForm({
       mode: 'edit',
       schedule,
-      onSaved: () => SchedulesPage.renderDetail(app, schedule.id),
+      onSaved: () => {
+        SchedulesPage._invalidateLookups();
+        SchedulesPage.renderDetail(app, schedule.id);
+      },
     });
   },
 
-  openForm({ mode, schedule, onSaved }) {
+  // openForm opens the schedule create/edit modal.
+  //
+  // PR6 #39 — async because we pre-load the targets/templates lookup so
+  // the entity pickers have data; in-flight callers don't need to await
+  // (they're fire-and-forget). Form sub-fields:
+  //   - Target/Template via Components.entityPicker (datalist typeahead).
+  //   - Schedule via Components.rruleBuilder (preset selector + live preview).
+  //   - DTSTART pre-filled to "now + 15 min" rounded; timezone defaults
+  //     to the browser's IANA zone — both reduce empty-required friction.
+  //   - Advanced disclosure hides estimated_duration + edit-mode status.
+  async openForm({ mode, schedule, onSaved }) {
+    const lookups = await this._getLookups();
+    const targetOptions = Array.from(lookups.targets.values()).map(t => ({
+      id: t.id, label: t.value || t.id,
+    }));
+    const templateOptions = Array.from(lookups.templates.values()).map(t => ({
+      id: t.id, label: t.name || t.id,
+    }));
+
     const s = schedule || {};
+    const isCreate = mode === 'create';
+    const dtstartDefault = isCreate ? defaultDtstartLocal() : '';
+    const tzDefault = s.timezone || (isCreate ? browserTimezone() : 'UTC');
+    const targetHelp = mode === 'edit'
+      ? 'Target cannot be changed after creation.'
+      : (targetOptions.length ? 'Pick a target by name or paste a UUID.' : 'No targets yet — create one in /targets first.');
+
     const body = `
       <form id="schedule-form" novalidate>
         <div class="field-error" data-field-error="__general__" style="display:none;margin-bottom:12px;padding:8px 12px;background:var(--sev-critical-bg);border-radius:var(--radius)"></div>
-        ${Components.formInput({ label: 'Name', name: 'name', value: s.name, required: true })}
+
         ${Components.formInput({
-          label: 'Target ID', name: 'target_id', value: s.target_id, required: true,
-          placeholder: 'UUID from /targets',
-          help: mode === 'edit' ? 'Target cannot be changed after creation.' : '',
+          label: 'Name', name: 'name', value: s.name, required: true,
+          placeholder: 'auto-suggested from target + cadence',
         })}
-        ${Components.formInput({ label: 'Template ID', name: 'template_id', value: s.template_id || '',
-          help: 'Optional. Omit to run with tool_config directly.' })}
-        ${Components.rruleField({ label: 'RRULE', name: 'rrule', value: s.rrule })}
-        ${Components.formDatetime({ label: 'DTSTART', name: 'dtstart', value: s.dtstart, required: true })}
-        ${Components.formInput({ label: 'Timezone', name: 'timezone', value: s.timezone || 'UTC', required: true })}
+
+        ${Components.entityPicker({
+          label: 'Target', name: 'target_id', value: s.target_id || '',
+          options: targetOptions, required: true,
+          placeholder: targetOptions.length ? 'Select a target…' : 'No targets available',
+          help: targetHelp,
+        })}
+
+        ${Components.entityPicker({
+          label: 'Template', name: 'template_id', value: s.template_id || '',
+          options: templateOptions, allowEmpty: true,
+          placeholder: 'None — use tool_config directly',
+          help: 'Optional. Pick by name or leave blank.',
+        })}
+
+        ${Components.rruleBuilder({
+          label: 'Schedule', name: 'rrule', value: s.rrule, required: true,
+        })}
+
+        ${Components.formDatetime({
+          label: 'Starts at', name: 'dtstart',
+          value: s.dtstart || dtstartDefault, required: true,
+        })}
+
         ${Components.formInput({
-          label: 'Estimated duration (seconds)', name: 'estimated_duration_seconds',
-          type: 'number', value: '',
-          help: 'Used for overlap checks at create/update time. Leave blank to use the server default (3600s).',
+          label: 'Timezone', name: 'timezone', value: tzDefault, required: true,
+          placeholder: 'Europe/Madrid',
+          help: 'IANA timezone identifier (e.g. UTC, Europe/Madrid, America/New_York).',
         })}
-        ${mode === 'edit' ? Components.formSelect({
-          label: 'Status', name: 'status',
-          options: [{ value: 'active', label: 'Active' }, { value: 'paused', label: 'Paused' }],
-          value: s.status || 'active',
-        }) : ''}
+
+        <details class="form-disclosure">
+          <summary>Advanced</summary>
+          ${Components.formInput({
+            label: 'Estimated duration (seconds)', name: 'estimated_duration_seconds',
+            type: 'number', value: '',
+            help: 'Used for overlap checks at create/update time. Leave blank to use the server default (3600s).',
+          })}
+          ${mode === 'edit' ? Components.formSelect({
+            label: 'Status', name: 'status',
+            options: [{ value: 'active', label: 'Active' }, { value: 'paused', label: 'Paused' }],
+            value: s.status || 'active',
+          }) : ''}
+        </details>
       </form>
     `;
 
     const m = Components.modal({
-      title: mode === 'create' ? 'New schedule' : 'Edit schedule',
+      title: isCreate ? 'New schedule' : 'Edit schedule',
       body,
       size: 'md',
       primaryAction: {
-        label: mode === 'create' ? 'Create' : 'Save',
+        label: isCreate ? 'Create' : 'Save',
         onClick: async ({ close }) => {
           const form = document.getElementById('schedule-form');
-          const data = readScheduleForm(form, mode);
+          const data = readScheduleForm(form, mode, lookups);
           if (!data) return;
           try {
-            if (mode === 'create') await API.createSchedule(data);
+            if (isCreate) await API.createSchedule(data);
             else await API.updateSchedule(schedule.id, data);
             if (onSaved) onSaved();
             close('saved');
@@ -336,11 +531,8 @@ const SchedulesPage = {
       },
       secondaryAction: { label: 'Cancel' },
       onClose: () => {
-        // SPEC-SCHED2.2: clear field values on unmount as a belt-and-
-        // suspenders measure against browser autofill carrying state
-        // from one open into the next. R1's hydrateScheduleForm is the
-        // load-bearing fix; this just makes sure stale values don't
-        // outlive the modal in any reference held elsewhere.
+        // SPEC-SCHED2.2: clear field values on unmount so browser
+        // autofill can't leak state from one open into the next.
         const form = m.root.querySelector('#schedule-form');
         if (!form) return;
         Array.from(form.elements).forEach(el => {
@@ -351,13 +543,46 @@ const SchedulesPage = {
         });
       },
     });
-    // SPEC-SCHED2.2: explicit state hydration. Don't rely on the value=
-    // attribute alone — Chrome/Safari autofill can override it when the
-    // form is re-mounted with the same field names, leaking values from
-    // a previously-edited schedule into the next open.
-    hydrateScheduleForm(m.root.querySelector('#schedule-form'), s, mode);
-    // Non-blocking RRULE syntax warning wires after the DOM is in place.
-    Components.rruleAttachBlurCheck(m.root.querySelector('#schedule-form'), 'rrule');
+
+    const form = m.root.querySelector('#schedule-form');
+    // SPEC-SCHED2.2: explicit state hydration so Chrome/Safari autofill
+    // can't override the freshly mounted values with cached prior input.
+    hydrateScheduleForm(form, s, mode, lookups);
+    // Wire the rrule builder (preset selector + live preview).
+    Components.rruleBuilderAttach(form);
+
+    // Auto-suggest the schedule name in create mode while the user
+    // hasn't edited it. Stops as soon as the operator types — never
+    // clobber a manually entered name.
+    if (isCreate) {
+      const nameInput = form.querySelector('[name="name"]');
+      const targetInput = form.querySelector('[name="target_id"]');
+      let nameTouched = !!s.name;
+      if (nameInput) {
+        nameInput.addEventListener('input', () => { nameTouched = true; });
+      }
+      const refreshName = () => {
+        if (nameTouched || !nameInput || !targetInput) return;
+        const tgtTyped = (targetInput.value || '').trim();
+        const tgtId = Components.entityPickerResolve(tgtTyped, targetOptions);
+        // Prefer the resolved label when the user picked from the list
+        // (covers paste-a-UUID flow too); fall back to the raw text.
+        const tgtLabel = tgtId
+          ? (targetOptions.find(o => o.id === tgtId) || {}).label || tgtTyped
+          : tgtTyped;
+        const rr = (form.querySelector('[data-rb-output]') || {}).value || '';
+        const suggested = suggestScheduleName(tgtLabel, rr);
+        if (suggested) nameInput.value = suggested;
+      };
+      if (targetInput) {
+        targetInput.addEventListener('input', refreshName);
+        targetInput.addEventListener('change', refreshName);
+      }
+      form.addEventListener('rrule-change', refreshName);
+      // Initial suggestion — the rrule builder fires its first
+      // rrule-change on attach, so the suggestion lands without us
+      // explicitly poking it here.
+    }
   },
 
   // --- Schedule detail ---
@@ -368,7 +593,10 @@ const SchedulesPage = {
     if (scroller) scroller.scrollTop = 0;
 
     try {
-      const s = await API.getSchedule(id);
+      const [s, lookups] = await Promise.all([
+        API.getSchedule(id),
+        this._getLookups(),
+      ]);
       let upcoming = [];
       try {
         // The 1.3a /schedules/upcoming endpoint doesn't filter by
@@ -379,7 +607,7 @@ const SchedulesPage = {
       } catch (_) {
         upcoming = [];
       }
-      app.innerHTML = this.detailTemplate(s, upcoming);
+      app.innerHTML = this.detailTemplate(s, upcoming, lookups);
       this.bindDetailActions(app, s);
     } catch (err) {
       app.innerHTML = `
@@ -429,6 +657,7 @@ const SchedulesPage = {
     if (!ok) return;
     try {
       await API.deleteSchedule(s.id);
+      SchedulesPage._invalidateLookups();
       location.hash = '#/schedules';
       SchedulesPage.render(app, {});
     } catch (err) {
@@ -437,7 +666,8 @@ const SchedulesPage = {
     }
   },
 
-  detailTemplate(s, upcoming) {
+  detailTemplate(s, upcoming, lookups) {
+    const L = lookups || { targets: new Map(), templates: new Map() };
     const overrideList = (s.overrides && s.overrides.length)
       ? s.overrides.map(o => `<code class="mono">${escapeHtml(o)}</code>`).join(', ')
       : '<span class="text-muted">none</span>';
@@ -450,9 +680,35 @@ const SchedulesPage = {
       ? `<pre class="json-block">${escapeHtml(JSON.stringify(s.maintenance_window, null, 2))}</pre>`
       : '<span class="text-muted">none</span>';
 
-    const tmplCell = s.template_id
-      ? `<a href="#/templates/${encodeURIComponent(s.template_id)}" class="mono">${escapeHtml(s.template_id)}</a>`
-      : '<span class="text-muted">—</span>';
+    // Target: link to detail; show resolved value with the UUID
+    // underneath. Falls back to the raw UUID + tooltip if the target
+    // was deleted between fetches.
+    const tgt = L.targets.get(s.target_id);
+    const tgtCell = tgt
+      ? `<a href="#/targets/${encodeURIComponent(s.target_id)}">${escapeHtml(tgt.value || s.target_id)}</a>
+         <div><small class="text-muted mono">${escapeHtml(s.target_id)}</small></div>`
+      : `<a href="#/targets/${encodeURIComponent(s.target_id)}" class="mono" title="Target not found — may have been deleted.">${escapeHtml(s.target_id)}</a>`;
+
+    let tmplCell;
+    if (!s.template_id) {
+      tmplCell = '<span class="text-muted">—</span>';
+    } else {
+      const tmpl = L.templates.get(s.template_id);
+      tmplCell = tmpl
+        ? `<a href="#/templates/${encodeURIComponent(s.template_id)}">${escapeHtml(tmpl.name || s.template_id)}</a>
+           <div><small class="text-muted mono">${escapeHtml(s.template_id)}</small></div>`
+        : `<a href="#/templates/${encodeURIComponent(s.template_id)}" class="mono" title="Template not found — may have been deleted.">${escapeHtml(s.template_id)}</a>`;
+    }
+
+    // RRULE detail row: humanized line first, with the raw rule kept
+    // visible underneath so operators can copy/edit it without hovering.
+    const human = Components.humanizeRRule(s.rrule);
+    const rruleHuman = (typeof human === 'string' && human.charAt(0) === '<')
+      ? human  // unknown pattern — already a span with title=
+      : escapeHtml(human);
+    const rruleRaw = s.rrule
+      ? `<div><small class="mono text-muted">${escapeHtml(s.rrule)}</small></div>`
+      : '';
 
     return `
       ${Components.backLink('#/schedules', 'Back to schedules')}
@@ -473,13 +729,12 @@ const SchedulesPage = {
           <div class="detail-grid" style="margin-top:12px">
             <span class="detail-label">ID</span><span class="detail-value mono">${escapeHtml(s.id)}</span>
             <span class="detail-label">Target</span>
-            <span class="detail-value mono">
-              <a href="#/targets/${encodeURIComponent(s.target_id)}">${escapeHtml(s.target_id)}</a>
-            </span>
+            <span class="detail-value">${tgtCell}</span>
             <span class="detail-label">Template</span><span class="detail-value">${tmplCell}</span>
             <span class="detail-label">Timezone</span><span class="detail-value mono">${escapeHtml(s.timezone || '-')}</span>
             <span class="detail-label">DTSTART</span><span class="detail-value mono">${escapeHtml(s.dtstart || '-')}</span>
-            <span class="detail-label">RRULE</span><span class="detail-value mono" style="word-break:break-all">${escapeHtml(s.rrule || '-')}</span>
+            <span class="detail-label">RRULE</span>
+            <span class="detail-value">${rruleHuman}${rruleRaw}</span>
             <span class="detail-label">Overrides</span><span class="detail-value">${overrideList}</span>
             <span class="detail-label">Next run</span><span class="detail-value">${Components.nextRun(s.next_run_at)}</span>
             <span class="detail-label">Last run</span><span class="detail-value">${s.last_run_at ? Components.formatDate(s.last_run_at) : '<span class="text-muted">never</span>'}</span>
@@ -516,10 +771,17 @@ const SchedulesPage = {
 // of the same form. Required for SPEC-SCHED2.2 — without this, editing
 // schedule A then closing and editing schedule B would re-display A's
 // values and silently overwrite B on save.
-function hydrateScheduleForm(form, schedule, mode) {
+//
+// PR6 #39 — entity pickers display the human-readable label, not the
+// raw UUID. We resolve target/template via the lookups Map so re-opens
+// don't show "abc-123" instead of "iana.org". The rrule builder
+// hydrates from data-rrule-initial in rruleBuilderAttach, so this fn
+// doesn't touch the rrule field.
+function hydrateScheduleForm(form, schedule, mode, lookups) {
   if (!form) return;
   const s = schedule || {};
   const isCreate = mode === 'create';
+  const L = lookups || { targets: new Map(), templates: new Map() };
 
   const setVal = (name, value) => {
     const el = form.elements[name];
@@ -528,12 +790,33 @@ function hydrateScheduleForm(form, schedule, mode) {
   };
 
   setVal('name', isCreate ? '' : s.name);
-  setVal('target_id', isCreate ? '' : s.target_id);
-  setVal('template_id', isCreate ? '' : s.template_id);
-  setVal('rrule', isCreate ? '' : s.rrule);
+
+  if (isCreate) {
+    // Pre-fill the target picker if the caller seeded a target_id
+    // (e.g. targets-page "Create schedule" button). Look up the label.
+    if (s.target_id) {
+      const t = L.targets.get(s.target_id);
+      setVal('target_id', t ? (t.value || s.target_id) : s.target_id);
+    } else {
+      setVal('target_id', '');
+    }
+    setVal('template_id', '');
+  } else {
+    const t = L.targets.get(s.target_id);
+    setVal('target_id', t ? (t.value || s.target_id) : (s.target_id || ''));
+    if (s.template_id) {
+      const tmpl = L.templates.get(s.template_id);
+      setVal('template_id', tmpl ? (tmpl.name || s.template_id) : s.template_id);
+    } else {
+      setVal('template_id', '');
+    }
+  }
+
   // datetime-local needs "YYYY-MM-DDTHH:MM"; the API gives back ISO-8601.
-  setVal('dtstart', isCreate ? '' : toDatetimeLocal(s.dtstart));
-  setVal('timezone', s.timezone || 'UTC');
+  // Create mode: pre-fill with the rounded "now + 15min" so the required
+  // field isn't empty.
+  setVal('dtstart', isCreate ? defaultDtstartLocal() : toDatetimeLocal(s.dtstart));
+  setVal('timezone', s.timezone || (isCreate ? browserTimezone() : 'UTC'));
   setVal('estimated_duration_seconds', '');
   if (form.elements.status) {
     setVal('status', s.status || 'active');
@@ -542,22 +825,67 @@ function hydrateScheduleForm(form, schedule, mode) {
 
 // readScheduleForm serializes the schedule form into the API shape.
 // DTSTART is converted from "datetime-local" ("YYYY-MM-DDTHH:MM") to a
-// UTC ISO string; empty template_id is submitted as "" so the server
-// treats it as "no template" (edit flow uses clear_template when the
-// caller wants to explicitly drop the link, but the UI doesn't surface
-// that nuance yet — 1.4c may expose a dedicated "clear template" ticker).
-// Returns null after surfacing field errors when the form is syntactically
-// bad at the client level.
-function readScheduleForm(form, mode) {
+// UTC ISO string; empty template_id is dropped on create and sent as ""
+// on edit so the server applies clear_template via the partial patch.
+//
+// PR6 #39 — target/template inputs carry the typed label or a pasted
+// UUID; we resolve to UUID via Components.entityPickerResolve and
+// surface a field error when the typed text matches nothing.
+function readScheduleForm(form, mode, lookups) {
   if (!form) return null;
   const fd = new FormData(form);
+  const L = lookups || { targets: new Map(), templates: new Map() };
+
+  const targetOptions = Array.from(L.targets.values()).map(t => ({
+    id: t.id, label: t.value || t.id,
+  }));
+  const templateOptions = Array.from(L.templates.values()).map(t => ({
+    id: t.id, label: t.name || t.id,
+  }));
+
+  const targetTyped = (fd.get('target_id') || '').toString().trim();
+  const targetID = Components.entityPickerResolve(targetTyped, targetOptions);
+  if (targetID === null) {
+    Components.applyFieldErrors(form, [{
+      field: 'target_id',
+      message: 'unknown target — pick one from the list or paste its UUID',
+    }]);
+    return null;
+  }
+  if (mode === 'create' && !targetID) {
+    Components.applyFieldErrors(form, [{ field: 'target_id', message: 'required' }]);
+    return null;
+  }
+
+  const templateTyped = (fd.get('template_id') || '').toString().trim();
+  let templateID = '';
+  if (templateTyped) {
+    const r = Components.entityPickerResolve(templateTyped, templateOptions);
+    if (r === null) {
+      Components.applyFieldErrors(form, [{
+        field: 'template_id',
+        message: 'unknown template — pick one from the list, paste its UUID, or leave empty',
+      }]);
+      return null;
+    }
+    templateID = r;
+  }
+
   const out = {
     name: (fd.get('name') || '').toString().trim(),
-    target_id: (fd.get('target_id') || '').toString().trim(),
-    template_id: (fd.get('template_id') || '').toString().trim(),
     rrule: (fd.get('rrule') || '').toString().trim(),
     timezone: (fd.get('timezone') || '').toString().trim() || 'UTC',
   };
+  if (targetID) out.target_id = targetID;
+  // template_id: drop the key on create so the server's omitempty
+  // handling treats "no template" as "no template". On edit we send ""
+  // when explicitly cleared so the server applies clear_template.
+  if (mode === 'create') {
+    if (templateID) out.template_id = templateID;
+  } else {
+    out.template_id = templateID;
+  }
+
   const dtLocal = (fd.get('dtstart') || '').toString().trim();
   if (dtLocal) {
     const d = new Date(dtLocal);
@@ -575,13 +903,6 @@ function readScheduleForm(form, mode) {
       return null;
     }
     out.estimated_duration_seconds = n;
-  }
-  // template_id: empty string means "not set" — drop the key on create
-  // so the omitempty JSON handling on the server treats it naturally.
-  // On edit we send "" if the user cleared it so the server applies
-  // clear_template semantics via the partial patch.
-  if (!out.template_id) {
-    delete out.template_id;
   }
   if (mode === 'edit') {
     const status = (fd.get('status') || '').toString();

--- a/internal/webui/static/js/pages/templates.js
+++ b/internal/webui/static/js/pages/templates.js
@@ -18,6 +18,10 @@ const TemplatesPage = {
     const offset = parseInt((params || {}).offset, 10) || 0;
     try {
       const data = await API.listTemplates({ limit, offset });
+      // _lastItems backs the click handlers in bindListActions so cards
+      // can pass the full template object to the duplicate / edit /
+      // run flows without re-fetching.
+      this._lastItems = (data && data.items) || [];
       app.innerHTML = this.template(data, { limit, offset });
       this.bindListActions(app);
       // SPEC-SCHED1.4c R6: hydrate USED BY counts for the visible
@@ -43,11 +47,14 @@ const TemplatesPage = {
     const cells = document.querySelectorAll('[data-used-by]');
     if (!cells.length) return;
 
+    const setCount = (cell, label, title) => {
+      cell.textContent = label;
+      cell.title = title;
+    };
+
     if (items.length > this.USED_BY_SOFT_THRESHOLD) {
-      cells.forEach(cell => {
-        cell.textContent = '—';
-        cell.title = 'Count unavailable for lists over ' + this.USED_BY_SOFT_THRESHOLD + ' templates.';
-      });
+      cells.forEach(cell => setCount(cell, '— schedules',
+        'Count unavailable for lists over ' + this.USED_BY_SOFT_THRESHOLD + ' templates.'));
       return;
     }
 
@@ -62,15 +69,14 @@ const TemplatesPage = {
         const resp = await API.listSchedules({ template_id: t.id, limit: 1 });
         const total = (resp && typeof resp.total === 'number') ? resp.total : null;
         if (total == null) {
-          cell.textContent = '?';
-          cell.title = 'Count not available (API did not return a total).';
+          setCount(cell, '? schedules', 'Count not available (API did not return a total).');
         } else {
-          cell.textContent = String(total);
-          cell.title = total === 0 ? 'No schedules reference this template.' : total + ' schedule(s) reference this template.';
+          const noun = total === 1 ? 'schedule' : 'schedules';
+          setCount(cell, `${total} ${noun}`,
+            total === 0 ? 'No schedules reference this template.' : total + ' schedule(s) reference this template.');
         }
       } catch (err) {
-        cell.textContent = '?';
-        cell.title = 'Error loading count: ' + (err.message || 'unknown');
+        setCount(cell, '? schedules', 'Error loading count: ' + (err.message || 'unknown'));
       }
     }));
   },
@@ -78,6 +84,29 @@ const TemplatesPage = {
   bindListActions(app) {
     const newBtn = document.getElementById('templates-new');
     if (newBtn) newBtn.addEventListener('click', () => this.openCreateForm(app));
+
+    // Card click → detail. Action buttons inside the card stop
+    // propagation so they don't double-navigate. We keep the
+    // dispatching here (instead of inline onclick) so the per-card
+    // template object can be passed by reference rather than re-fetched.
+    const cards = app.querySelectorAll('.template-card');
+    cards.forEach(card => {
+      const id = card.dataset.id;
+      if (!id) return;
+      const t = (this._lastItems || []).find(x => x.id === id);
+      card.addEventListener('click', () => { location.hash = '#/templates/' + encodeURIComponent(id); });
+      card.querySelectorAll('[data-action]').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          const action = btn.dataset.action;
+          if (!t) return;
+          if (action === 'run') AdHocPage.open({ prefillTemplateID: t.id });
+          else if (action === 'edit') this.openEditForm(app, t);
+          else if (action === 'duplicate') this.duplicate(app, t);
+        });
+      });
+    });
   },
 
   template(data, f) {
@@ -97,19 +126,35 @@ const TemplatesPage = {
       `;
     }
 
-    const rows = items.map(t => {
+    const cards = items.map(t => {
       const toolCount = Object.keys(t.tool_config || {}).length;
-      const sysBadge = t.is_system ? '<span class="badge badge-muted" title="Built-in template — seeded on first boot.">built-in</span>' : '';
+      const toolNoun = toolCount === 1 ? 'tool' : 'tools';
+      const kindBadge = t.is_system
+        ? '<span class="badge badge-muted" title="Built-in template — seeded on first boot.">built-in</span>'
+        : '<span class="badge badge-muted">custom</span>';
+      const desc = (t.description || '').trim();
+      const descHtml = desc
+        ? `<p class="card-desc">${escapeHtml(desc)}</p>`
+        : '<p class="card-desc text-muted">No description.</p>';
+
       return `
-        <tr class="clickable" onclick="location.hash='#/templates/${encodeURIComponent(t.id)}'">
-          <td class="mono">${Components.truncateID(t.id)}</td>
-          <td>${escapeHtml(t.name || '-')} ${sysBadge}</td>
-          <td class="text-muted">${escapeHtml(Components.truncate(t.description || '', 80))}</td>
-          <td>${toolCount}</td>
-          <td data-used-by="${escapeHtml(t.id)}" title="Loading…">…</td>
-          <td>${Components.rruleCompact(t.rrule)}</td>
-          <td class="text-muted">${Components.timeAgo(t.updated_at)}</td>
-        </tr>
+        <div class="template-card clickable" data-id="${escapeHtml(t.id)}">
+          <div class="template-card-header">
+            <span class="template-card-title">${escapeHtml(t.name || '-')}</span>
+            ${kindBadge}
+          </div>
+          ${descHtml}
+          <div class="template-card-meta">
+            <span class="pill pill-muted">${toolCount} ${toolNoun}</span>
+            <span class="pill pill-muted" data-used-by="${escapeHtml(t.id)}" title="Loading…">… schedules</span>
+            <span class="template-card-uuid mono text-muted" title="${escapeHtml(t.id)}">${Components.truncateID(t.id)}</span>
+          </div>
+          <div class="template-card-actions">
+            <button type="button" class="pill pill-action pill-brand" data-action="run">Run with…</button>
+            <button type="button" class="pill pill-action" data-action="edit">Edit</button>
+            <button type="button" class="pill pill-action" data-action="duplicate">Duplicate</button>
+          </div>
+        </div>
       `;
     }).join('');
 
@@ -121,10 +166,7 @@ const TemplatesPage = {
         <p>${total} template${total === 1 ? '' : 's'}</p>
         ${headerActions}
       </div>
-      ${Components.table(
-        ['ID', 'Name', 'Description', 'Tools', 'USED BY', 'RRULE', 'Updated'],
-        [rows]
-      )}
+      <div class="template-grid">${cards}</div>
       ${pager}
     `;
   },
@@ -252,6 +294,25 @@ const TemplatesPage = {
     });
   },
 
+  // duplicate seeds the create form with a copy of the source template.
+  // is_system is intentionally dropped — built-in is a server-managed
+  // marker, not part of the user-editable shape.
+  duplicate(app, t) {
+    const copy = {
+      name: `${t.name || 'template'} (copy)`,
+      description: t.description || '',
+      rrule: t.rrule || '',
+      timezone: t.timezone || 'UTC',
+      tool_config: t.tool_config || {},
+      maintenance_window: t.maintenance_window || null,
+    };
+    this.openForm({
+      mode: 'create',
+      template: copy,
+      onSaved: () => TemplatesPage.render(app, {}),
+    });
+  },
+
   openEditForm(app, t) {
     this.openForm({
       mode: 'edit',
@@ -263,13 +324,22 @@ const TemplatesPage = {
   openForm({ mode, template, onSaved }) {
     const t = template || {};
     const toolConfigJson = JSON.stringify(t.tool_config || {}, null, 2);
+    // Fields the form doesn't surface (e.g. maintenance_window) but we
+    // still want to forward when the form was seeded by Duplicate.
+    const carryover = {};
+    if (mode === 'create' && t.maintenance_window) {
+      carryover.maintenance_window = t.maintenance_window;
+    }
+    const tzDefault = t.timezone || (mode === 'create' ? browserTimezone() : 'UTC');
     const body = `
       <form id="template-form" novalidate>
         <div class="field-error" data-field-error="__general__" style="display:none;margin-bottom:12px;padding:8px 12px;background:var(--sev-critical-bg);border-radius:var(--radius)"></div>
         ${Components.formInput({ label: 'Name', name: 'name', value: t.name, required: true })}
         ${Components.formInput({ label: 'Description', name: 'description', value: t.description || '' })}
-        ${Components.rruleField({ label: 'RRULE', name: 'rrule', value: t.rrule })}
-        ${Components.formInput({ label: 'Timezone', name: 'timezone', value: t.timezone || 'UTC' })}
+        ${Components.rruleBuilder({ label: 'Schedule', name: 'rrule', value: t.rrule, required: true })}
+        ${Components.formInput({ label: 'Timezone', name: 'timezone', value: tzDefault,
+          placeholder: 'Europe/Madrid',
+          help: 'IANA timezone identifier (e.g. UTC, Europe/Madrid).' })}
         ${Components.formTextarea({
           label: 'Tool config (JSON)', name: 'tool_config',
           value: t.tool_config ? toolConfigJson : '{}',
@@ -289,6 +359,7 @@ const TemplatesPage = {
           const form = document.getElementById('template-form');
           const data = readTemplateForm(form);
           if (!data) return;
+          Object.assign(data, carryover);
           try {
             if (mode === 'create') await API.createTemplate(data);
             else await API.updateTemplate(t.id, data);
@@ -301,7 +372,7 @@ const TemplatesPage = {
       },
       secondaryAction: { label: 'Cancel' },
     });
-    Components.rruleAttachBlurCheck(m.root.querySelector('#template-form'), 'rrule');
+    Components.rruleBuilderAttach(m.root.querySelector('#template-form'));
   },
 
   async confirmDelete(app, t, usedBy) {


### PR DESCRIPTION
## Summary

- **Schedules list/detail**: resolve target/template UUIDs to names (`iana.org` / `default`) with short UUID underneath; humanize RRULE column (`Daily at 02:00`, `Weekly on Mon, Wed, Fri at 09:00`); inline Pause/Resume + Edit pills with stop-propagation.
- **Templates list**: 7-col table → responsive 1/2/3-col card grid with Run with… / Edit / Duplicate CTAs; Duplicate seeds the create form including `maintenance_window`.
- **Schedule + Template modals redesigned**: combobox typeahead replaces UUID inputs; RRULE textbox replaced with Daily/Weekly/Monthly preset builder + live `Will run: …` preview; DTSTART pre-fills to now+15min rounded; timezone defaults to the browser's IANA zone; auto-suggested Name from target + cadence; estimated_duration + status moved behind an Advanced disclosure. Edit mode warns inline when an existing RRULE uses a pattern the builder doesn't model so saving never silently overwrites it.

Closes #39

## Test plan

- [ ] `#/schedules` — Target/Template show resolved names with UUID short-id underneath; Schedule column humanizes (`Daily at 02:00`, `Weekly on Mon, Wed, Fri at 09:00`); hover shows raw RRULE in tooltip.
- [ ] Inline `Pause` pill on an active schedule → status flips, no navigation, no bulk-select state change.
- [ ] Inline `Edit` pill → modal opens with the schedule pre-filled.
- [ ] Bulk select-all + bulk Pause/Resume/Delete still work; pills don't enter the `_selected` set.
- [ ] `#/templates` — responsive grid (1 col <640px, 2 col 640-1023px, 3 col ≥1024px); each card shows full description (no 80-char truncate), schedules count (lazy), and Run with… / Edit / Duplicate.
- [ ] `Run with…` → AdHoc modal opens with Template ID pre-filled, Target editable.
- [ ] `Duplicate` → create form opens with `<name> (copy)` plus description/rrule/timezone/tool_config; saving creates a new template.
- [ ] `+ New schedule` modal — Name auto-fills suggested label, Target/Template are typeahead comboboxes (no raw UUIDs visible), DTSTART pre-filled to now+15min rounded, timezone is the browser zone, Schedule shows Daily/Weekly/Monthly with live `Will run: …` preview.
- [ ] Edit a CLI-created schedule with `FREQ=HOURLY;INTERVAL=6` → inline amber warning explains the pattern doesn't fit; controls default to Daily so any save is an explicit replacement.
- [ ] Edit a Daily/Weekly/Monthly schedule → builder hydrates correctly, save round-trips the same RRULE.