### PR TITLE
webui pr11 #44: tools page actions + update CTAs + status pills

### DIFF
--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -4109,3 +4109,38 @@ td > small.mono.text-muted { font-size: 11px; }
 }
 .form-disclosure[open] > summary::before { transform: rotate(90deg); }
 .form-disclosure > summary:hover { color: var(--text-primary); }
+
+/* === PR11 #44 — Tools page status pills + header actions =========== */
+
+/* Three-state status pill for the Tools page. Green for healthy,
+ * amber for "update available", red for "unavailable". Reuses the
+ * shared .pill base; only color/bg/border differ per state. */
+.pill-tool-status-available {
+  color: var(--success);
+  background: var(--color-success-100);
+  border-color: rgba(21, 128, 61, 0.35);
+}
+.pill-tool-status-update {
+  color: var(--sev-medium);
+  background: var(--sev-medium-bg);
+  border-color: rgba(210, 153, 34, 0.4);
+}
+.pill-tool-status-unavailable {
+  color: var(--sev-critical);
+  background: var(--sev-critical-bg);
+  border-color: rgba(248, 81, 73, 0.4);
+}
+
+/* Header CTAs (Refresh status + Update all) sit to the right of the
+ * Tools page title, mirroring the schedules page pattern. */
+.tools-page-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+/* Right-align the per-row action button so the column reads as a
+ * trailing CTA — same pattern as .schedule-actions. */
+.tools-actions-cell { text-align: right; white-space: nowrap; }
+.tools-th-actions { display: inline-block; width: 100%; text-align: right; }

--- a/internal/webui/static/js/api.js
+++ b/internal/webui/static/js/api.js
@@ -72,6 +72,28 @@ const API = {
   target(id)            { return this.get('/targets/' + id); },
   tools()               { return this.get('/tools'); },
   availableTools()      { return this.get('/tools/available'); },
+  // Alias of availableTools — named for the Tools page "Refresh status" CTA
+  // so the call site reads as the operator's intent.
+  toolsRefresh()        { return this.get('/tools/available'); },
+  // Tool update / test endpoints don't exist server-side yet (#44 P0 ships
+  // the UI ahead of backend). These resolve with a typed marker so the page
+  // can show the right toast and the operator gets feedback. When the
+  // endpoints land, replace the Promise.resolve with `this.post(...)` —
+  // the call sites stay identical.
+  toolUpdate(name) {
+    return Promise.resolve({
+      status: 'mock',
+      message: 'Backend update endpoint coming in v0.6 · this is a UI placeholder',
+      tool: name,
+    });
+  },
+  toolTest(name) {
+    return Promise.resolve({
+      status: 'mock',
+      message: 'Backend test endpoint coming in v0.6 · this is a UI placeholder',
+      tool: name,
+    });
+  },
   scanStatus()          { return this.get('/scans/status'); },
   // SPEC-SCHED1.3a read-only endpoints. 1.4b adds write methods on top.
   listSchedules(params) { return this.get('/schedules' + toQuery(params)); },

--- a/internal/webui/static/js/pages/tools.js
+++ b/internal/webui/static/js/pages/tools.js
@@ -1,44 +1,197 @@
-// Tools page — shows registered detection tools and their availability.
+// Tools page — UI v2 (#44).
+//
+// Shows the agent's detection tools with version, templates count, status,
+// last update and a contextual action button. The backend response today
+// only carries {name, phase, available}; the new metadata fields
+// (version, updated_at, metadata.templates_count, update_available) are
+// optional and degrade gracefully — see _rowHtml for the null-safe paths.
 const ToolsPage = {
   async render(app) {
     app.innerHTML = '<div class="loading">Loading tools...</div>';
     try {
       const data = await API.availableTools();
       app.innerHTML = this.template(data);
+      this.bindEvents(app);
     } catch (err) {
       app.innerHTML = Components.emptyState('Error', 'Failed to load tools: ' + err.message);
     }
   },
 
   template(data) {
-    const tools = data.tools || [];
+    const tools = (data && data.tools) || [];
+    const total = (data && data.total != null) ? data.total : tools.length;
+    const available = (data && data.available != null)
+      ? data.available
+      : tools.filter(t => t && t.available).length;
+    const updateCount = tools.filter(t => t && t.available && t.update_available).length;
+    const unavailableCount = Math.max(0, total - available);
+
+    const subtitle = this._subtitleHtml(available, total, updateCount, unavailableCount);
+    const headerActions = `
+      <div class="tools-page-actions">
+        <button type="button" class="btn btn-ghost" id="tools-refresh">Refresh status</button>
+        <button type="button" class="btn btn-primary" id="tools-update-all">Update all</button>
+      </div>
+    `;
 
     if (tools.length === 0) {
       return `
-        <div class="page-header"><h2>Tools</h2></div>
+        <div class="page-header">
+          <div style="flex:1">
+            <h2>Tools</h2>
+            <p>${subtitle}</p>
+          </div>
+          ${headerActions}
+        </div>
         ${Components.emptyState('No tools registered', 'No detection tools are registered in the pipeline.')}
       `;
     }
 
-    const rows = tools.map(t => {
-      const badge = t.available
-        ? '<span class="badge badge-success">available</span>'
-        : '<span class="badge badge-muted">unavailable</span>';
-      return `
-        <tr>
-          <td class="mono">${escapeHtml(t.name)}</td>
-          <td>${escapeHtml(t.phase)}</td>
-          <td>${badge}</td>
-        </tr>
-      `;
-    }).join('');
+    const headers = [
+      'Tool',
+      'Phase',
+      'Version',
+      'Templates',
+      'Status',
+      'Last update',
+      '<span class="tools-th-actions">Actions</span>',
+    ];
+    const rows = tools.map(t => this._rowHtml(t)).join('');
 
     return `
       <div class="page-header">
-        <h2>Tools</h2>
-        <p>${data.available}/${data.total} available</p>
+        <div style="flex:1">
+          <h2>Tools</h2>
+          <p>${subtitle}</p>
+        </div>
+        ${headerActions}
       </div>
-      ${Components.table(['Name', 'Phase', 'Status'], [rows])}
+      ${Components.table(headers, [rows])}
     `;
+  },
+
+  _subtitleHtml(available, total, updateCount, unavailableCount) {
+    const parts = [`${available}/${total} available`];
+    if (unavailableCount > 0) {
+      parts.push(`run <code class="mono">surfbot tool install</code>`);
+    }
+    if (updateCount > 0) {
+      parts.push(`${updateCount} update${updateCount === 1 ? '' : 's'} available`);
+    }
+    return parts.join(' · ');
+  },
+
+  _rowHtml(t) {
+    const name = (t && t.name) || '';
+    const phase = (t && t.phase) || '';
+    const muted = (txt) => `<span class="text-muted">${txt}</span>`;
+    const version = t && t.version
+      ? `<span class="mono">${escapeHtml(t.version)}</span>`
+      : muted('—');
+    const updated = t && t.updated_at
+      ? muted(escapeHtml(Components.timeAgo(t.updated_at)))
+      : muted('—');
+
+    let templates = '';
+    const tc = t && t.metadata && t.metadata.templates_count;
+    if (tc != null) {
+      // Force en-US so the thousand separator stays consistent — es-ES
+      // suppresses the separator for sub-10k numbers, which clashes with
+      // the spec's "9,412" example.
+      templates = `<span class="mono">${Number(tc).toLocaleString('en-US')}</span>`;
+    } else if (name === 'nuclei') {
+      templates = `<span class="text-muted" title="Backend metadata pending">—</span>`;
+    }
+
+    let statusClass, statusLabel, action;
+    if (!t || !t.available) {
+      statusClass = 'pill-tool-status-unavailable';
+      statusLabel = 'unavailable';
+      action = `<button type="button" class="pill pill-action" data-tool-action="install" data-tool="${escapeHtml(name)}" disabled title="Backend support coming in v0.6">Install</button>`;
+    } else if (t.update_available) {
+      statusClass = 'pill-tool-status-update';
+      statusLabel = 'update available';
+      action = `<button type="button" class="pill pill-action" data-tool-action="update" data-tool="${escapeHtml(name)}">Update</button>`;
+    } else {
+      statusClass = 'pill-tool-status-available';
+      statusLabel = 'available';
+      action = `<button type="button" class="pill pill-action" data-tool-action="test" data-tool="${escapeHtml(name)}">Test</button>`;
+    }
+
+    return `
+      <tr>
+        <td><code class="mono">${escapeHtml(name)}</code></td>
+        <td><span class="pill pill-muted">${escapeHtml(phase)}</span></td>
+        <td>${version}</td>
+        <td>${templates}</td>
+        <td><span class="pill ${statusClass}">${statusLabel}</span></td>
+        <td>${updated}</td>
+        <td class="tools-actions-cell">${action}</td>
+      </tr>
+    `;
+  },
+
+  bindEvents(app) {
+    const refresh = document.getElementById('tools-refresh');
+    if (refresh) refresh.addEventListener('click', () => this._refresh(app, refresh));
+
+    const updateAll = document.getElementById('tools-update-all');
+    if (updateAll) updateAll.addEventListener('click', () => this._updateAll(updateAll));
+
+    document.querySelectorAll('[data-tool-action]').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        if (btn.disabled) return;
+        const action = btn.getAttribute('data-tool-action');
+        const tool = btn.getAttribute('data-tool');
+        this._toolAction(action, tool);
+      });
+    });
+  },
+
+  async _refresh(app, btn) {
+    const orig = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = 'Refreshing…';
+    try {
+      const data = await API.toolsRefresh();
+      app.innerHTML = this.template(data);
+      this.bindEvents(app);
+    } catch (err) {
+      btn.disabled = false;
+      btn.textContent = orig;
+      Components.toast.error('Failed to refresh tools: ' + err.message);
+    }
+  },
+
+  async _updateAll(btn) {
+    const orig = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = 'Updating…';
+    try {
+      const r = await API.toolUpdate('all');
+      const msg = (r && r.message) || 'Update dispatched';
+      const kind = (r && r.status === 'mock') ? 'info' : 'success';
+      Components.toast(msg, { kind });
+    } catch (err) {
+      Components.toast.error(err.message || 'Update failed');
+    } finally {
+      btn.disabled = false;
+      btn.textContent = orig;
+    }
+  },
+
+  async _toolAction(action, tool) {
+    try {
+      let r;
+      if (action === 'update') r = await API.toolUpdate(tool);
+      else if (action === 'test') r = await API.toolTest(tool);
+      else return;
+      const msg = (r && r.message) || 'Done';
+      const kind = (r && r.status === 'mock') ? 'info' : 'success';
+      Components.toast(msg, { kind });
+    } catch (err) {
+      Components.toast.error(err.message || 'Action failed');
+    }
   },
 };


### PR DESCRIPTION
Closes #44.

## Summary
- Rewrites the Tools page (`/tools`) with the 7-column layout from the UI v2 wireframe: Tool / Phase / Version / Templates / Status / Last update / Actions.
- Three-state status pill (`available` green / `update available` amber / `unavailable` red) with the priority logic from P0.2; backend that doesn't expose `update_available` keeps falling back to `available` cleanly.
- Contextual action button per row (`Test` / `Update` / `Install`) plus header CTAs `Refresh status` + `Update all`.
- Dynamic subtitle: counts available/total and appends `run surfbot tool install` and/or `<n> updates available` when relevant.
- Defensive rendering for the missing backend fields (version, updated_at, metadata.templates_count, update_available) — see "Backend graceful degradation" in the spec. The UI lights up automatically when those land.
- Added `API.toolsRefresh / toolUpdate / toolTest` in api.js. Update/test return a typed mock so the toast wiring is real and the call sites stay identical when the backend endpoints exist.
- New CSS for `.pill-tool-status-{available,update,unavailable}` plus header/actions layout helpers.

## Out of scope (per spec non-goals)
- Backend `version` / `updated_at` / `templates_count` / `update_available` fields and the new `/tools/{name}/{update,test}` + `/tools/refresh` endpoints — to be tracked as a separate backend follow-up issue ("Tools API expansion").
- Live update progress streaming, install action enablement, in-flight polling — P1.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/webui/...`
- [x] Manual smoke against `http://127.0.0.1:8470/#/tools` with the running daemon — 5 tools render, all `available` (real backend response), subtitle `5/5 available`, no console errors.
- [x] `Test` and `Update all` clicks fire the mock toasts ("Backend …​ endpoint coming in v0.6 · this is a UI placeholder").
- [x] Synthetic dataset injection in DevTools verified the unavailable + update_available branches: red pill + disabled `Install`, amber pill + enabled `Update`, subtitle `4/5 available · run surfbot tool install · 1 update available`.
- [x] Templates count uses `toLocaleString('en-US')` so `9412` renders as `9,412` regardless of browser locale (caught during `es-ES` smoke).