### PR TITLE
webui pr9 #42: cmdk palette + ad-hoc modal upgrade

### DIFF
--- a/internal/api/v1/adhoc.go
+++ b/internal/api/v1/adhoc.go
@@ -16,12 +16,19 @@ import (
 // CreateAdHocRequest is the POST /api/v1/scans/ad-hoc body. TargetID is
 // required; RequestedBy populates initiated_by on the persisted row so
 // audit trails survive process restarts.
+//
+// Name is accepted from PR9 #42 onward as an optional human label for
+// the run (parity with schedule names). It is currently round-tripped
+// through dispatch but not persisted — a follow-up backend issue adds
+// the column to ad_hoc_scan_runs. Accepting the field today keeps the
+// UI from 400-ing on DisallowUnknownFields.
 type CreateAdHocRequest struct {
 	TargetID           string                     `json:"target_id"`
 	TemplateID         *string                    `json:"template_id,omitempty"`
 	ToolConfigOverride map[string]json.RawMessage `json:"tool_config_override,omitempty"`
 	RequestedBy        string                     `json:"requested_by,omitempty"`
 	Reason             string                     `json:"reason,omitempty"`
+	Name               string                     `json:"name,omitempty"`
 }
 
 // CreateAdHocResponse is the 202 body. ScanID is empty on the immediate

--- a/internal/webui/static/css/style.css
+++ b/internal/webui/static/css/style.css
@@ -4144,3 +4144,168 @@ td > small.mono.text-muted { font-size: 11px; }
  * trailing CTA — same pattern as .schedule-actions. */
 .tools-actions-cell { text-align: right; white-space: nowrap; }
 .tools-th-actions { display: inline-block; width: 100%; text-align: right; }
+
+/* === PR9 #42 — Cmd+K command palette overlay ======================= */
+
+body.cmdk-open { overflow: hidden; }
+.command-palette-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 1100; /* above modal-backdrop (1000) so palette can open over a modal closing */
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+}
+.cmdk-panel {
+  width: 100%;
+  max-width: 620px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  max-height: 70vh;
+  overflow: hidden;
+}
+.cmdk-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.cmdk-input-wrap .icon { color: var(--text-secondary); flex-shrink: 0; }
+.cmdk-input {
+  flex: 1;
+  background: transparent;
+  border: 0;
+  outline: none;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 15px;
+  padding: 2px 0;
+}
+.cmdk-input::placeholder { color: var(--text-muted); }
+.cmdk-kbd-esc { color: var(--text-secondary); }
+
+.cmdk-results {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+.cmdk-source { padding: 4px 0; }
+.cmdk-source-header {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  padding: 6px 14px 4px;
+}
+.cmdk-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  cursor: pointer;
+  user-select: none;
+}
+.cmdk-item-icon {
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+.cmdk-item-label {
+  color: var(--text-primary);
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+}
+.cmdk-item-sub {
+  color: var(--text-muted);
+  font-size: 12px;
+  margin-left: auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 50%;
+}
+.cmdk-item-right {
+  color: var(--text-secondary);
+  font-size: 11px;
+  margin-left: 8px;
+}
+.cmdk-item-active {
+  background: var(--bg-hover);
+}
+.cmdk-item-active .cmdk-item-icon,
+.cmdk-item-active .cmdk-item-sub {
+  color: var(--text-primary);
+}
+.cmdk-item-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.cmdk-loading,
+.cmdk-error,
+.cmdk-no-results {
+  padding: 8px 14px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.cmdk-error { color: var(--sev-critical); }
+
+.cmdk-footer {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 14px;
+  border-top: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.cmdk-footer .kbd {
+  margin-right: 4px;
+}
+.cmdk-footer-hint {
+  margin-left: auto;
+  color: var(--text-muted);
+}
+
+@keyframes cmdk-shake {
+  0%, 100% { transform: translateX(0); }
+  20%, 60% { transform: translateX(-3px); }
+  40%, 80% { transform: translateX(3px); }
+}
+.cmdk-shake { animation: cmdk-shake 240ms ease-in-out; }
+
+/* === PR9 #42 — Ad-hoc modal advanced collapsible ==================== */
+
+.adhoc-advanced {
+  margin-top: 12px;
+  padding: 8px 0 0;
+  border-top: 1px solid var(--border);
+}
+.adhoc-advanced > summary {
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text-secondary);
+  padding: 4px 0;
+  list-style: none;
+  user-select: none;
+}
+.adhoc-advanced > summary::-webkit-details-marker { display: none; }
+.adhoc-advanced > summary::before {
+  content: '▶';
+  display: inline-block;
+  margin-right: 6px;
+  font-size: 10px;
+  transition: transform 120ms ease;
+}
+.adhoc-advanced[open] > summary::before { transform: rotate(90deg); }
+.adhoc-advanced > summary:hover { color: var(--text-primary); }
+.adhoc-advanced-body { padding-top: 8px; }

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -106,7 +106,7 @@
         <nav class="breadcrumbs" id="breadcrumbs" aria-label="Breadcrumb">
           <span class="breadcrumb-item">Surfbot</span>
         </nav>
-        <button type="button" class="topbar-search" id="topbar-cmdk-btn" aria-label="Search (coming soon)">
+        <button type="button" class="topbar-search" id="topbar-cmdk-btn" aria-label="Open command palette">
           <svg class="icon icon-14" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><line x1="20" y1="20" x2="16.65" y2="16.65"/></svg>
           <span class="topbar-search-placeholder">Search findings, assets, scans…</span>
           <kbd class="kbd">⌘K</kbd>
@@ -153,6 +153,7 @@
   <script src="/js/pages/settings.js"></script>
   <script src="/js/pages/changes.js"></script>
   <script src="/js/pages/adhoc.js"></script>
+  <script src="/js/cmdk.js"></script>
   <script src="/js/app.js"></script>
 </body>
 </html>

--- a/internal/webui/static/js/app.js
+++ b/internal/webui/static/js/app.js
@@ -276,14 +276,17 @@ document.addEventListener('DOMContentLoaded', () => {
     adhocBtn.addEventListener('click', () => AdHocPage.open());
   }
 
-  // PR2 #35 stubs. Cmd+K and "+ New" are placeholders until PR9
-  // (search) and PR3 (dashboard reframe) wire real behavior. Notif and
+  // PR9 #42: Cmd+K command palette + Cmd+R ad-hoc dispatcher. The
+  // topbar search button is the click affordance for Cmd+K. Notif and
   // help icons stay disabled with a "Coming in v0.6" tooltip set in
   // markup; no handler needed.
   const cmdkBtn = document.getElementById('topbar-cmdk-btn');
-  if (cmdkBtn) cmdkBtn.addEventListener('click', () => {
-    // Placeholder — PR9 implements global search.
-  });
+  if (cmdkBtn) {
+    cmdkBtn.addEventListener('click', () => {
+      if (typeof CommandPalette !== 'undefined') CommandPalette.open();
+    });
+  }
+  bindGlobalShortcuts();
   const newBtn = document.getElementById('topbar-new-btn');
   if (newBtn) {
     newBtn.setAttribute('aria-haspopup', 'menu');
@@ -448,3 +451,52 @@ const TopbarNewMenu = {
     }
   },
 };
+
+// PR9 #42 — global keyboard shortcuts. Cmd+K opens the command palette
+// from any route; Cmd+R opens the ad-hoc dispatcher. Both are no-ops
+// when their respective overlay is already open. Cmd+R intercepts the
+// browser refresh (OQ4 default); F5 stays available as a fallback and
+// the cmdk footer documents this.
+//
+// The handler skips when the user is typing into an input/textarea
+// /select/contenteditable to avoid hijacking text input — except inside
+// the palette overlay, where Cmd+K must still no-op the palette and Esc
+// is owned by the palette controller itself.
+function bindGlobalShortcuts() {
+  document.addEventListener('keydown', (e) => {
+    const meta = e.metaKey || e.ctrlKey;
+    if (!meta) return;
+    const key = (e.key || '').toLowerCase();
+    if (key !== 'k' && key !== 'r') return;
+
+    const t = e.target;
+    const inEditable = t && t.matches && t.matches('input, textarea, select, [contenteditable=""], [contenteditable="true"]');
+    const inPalette = t && t.closest && t.closest('.command-palette-overlay');
+    if (inEditable && !inPalette) {
+      // Cmd+K is a universal "open search" pattern — intercept even
+      // inside text fields so the user doesn't have to click out
+      // first. Cmd+R inside a text field stays as the browser default
+      // (refresh) so an operator typing in a textarea isn't
+      // interrupted by a modal opening on top of their work.
+      if (key === 'r') return;
+    }
+
+    if (key === 'k') {
+      e.preventDefault();
+      if (typeof CommandPalette === 'undefined') return;
+      if (CommandPalette.isOpen()) return;
+      CommandPalette.open();
+      return;
+    }
+    if (key === 'r') {
+      e.preventDefault();
+      if (typeof AdHocPage === 'undefined') return;
+      // No-op if a modal or the command palette is already open — both
+      // would otherwise stack a second overlay on top.
+      if (document.body.classList.contains('modal-open')) return;
+      if (document.body.classList.contains('cmdk-open')) return;
+      AdHocPage.open();
+      return;
+    }
+  });
+}

--- a/internal/webui/static/js/cmdk.js
+++ b/internal/webui/static/js/cmdk.js
@@ -1,0 +1,379 @@
+// PR9 #42 — Cmd+K command palette controller + shared LookupCache.
+//
+// LookupCache memoizes /targets and /templates fetches across pages.
+// SchedulesPage already had a per-page cache; this cross-page version
+// is what the AdHoc combobox upgrade and the palette query for value
+// resolution. Invalidation is best-effort: callers that mutate
+// targets/templates (`createTarget`, `deleteTarget`, etc.) call
+// LookupCache.invalidate() themselves; otherwise the cache lives for
+// the session.
+const LookupCache = {
+  _targets: null,    // Map<id, target>
+  _templates: null,  // Map<id, template>
+  _targetsP: null,
+  _templatesP: null,
+
+  async targets() {
+    if (this._targets) return this._targets;
+    if (!this._targetsP) {
+      this._targetsP = API.targets()
+        .then(resp => {
+          const m = new Map();
+          // /api/v1/targets returns {targets:[…]}; some test harnesses
+          // return a bare array — accept both shapes.
+          const list = Array.isArray(resp)
+            ? resp
+            : (resp && (resp.targets || resp.items)) || [];
+          list.forEach(t => { if (t && t.id) m.set(t.id, t); });
+          this._targets = m;
+          return m;
+        })
+        .catch(err => { this._targetsP = null; throw err; });
+    }
+    return this._targetsP;
+  },
+
+  async templates() {
+    if (this._templates) return this._templates;
+    if (!this._templatesP) {
+      this._templatesP = API.listTemplates({ limit: 500 })
+        .then(resp => {
+          const m = new Map();
+          // /api/v1/templates returns the shared PaginatedResponse
+          // ({items:[…]}). Same defensive fallback as targets().
+          const list = Array.isArray(resp)
+            ? resp
+            : (resp && (resp.items || resp.templates)) || [];
+          list.forEach(t => { if (t && t.id) m.set(t.id, t); });
+          this._templates = m;
+          return m;
+        })
+        .catch(err => { this._templatesP = null; throw err; });
+    }
+    return this._templatesP;
+  },
+
+  invalidate(kind) {
+    if (!kind || kind === 'targets')   { this._targets = null;   this._targetsP = null; }
+    if (!kind || kind === 'templates') { this._templates = null; this._templatesP = null; }
+  },
+
+  // resolveTargetID maps a user-typed string (target value or UUID) to a
+  // canonical target_id. Returns '' when typed is empty, the resolved id
+  // on a successful lookup, or null when nothing matches. The caller
+  // surfaces a field error on null.
+  resolveTargetID(typed, targets) {
+    const t = (typed || '').trim();
+    if (!t) return '';
+    if (!targets) return null;
+    if (targets.has(t)) return t; // pasted UUID
+    for (const tg of targets.values()) {
+      if (tg.value === t) return tg.id;
+    }
+    return null;
+  },
+
+  resolveTemplateID(typed, templates) {
+    const t = (typed || '').trim();
+    if (!t) return '';
+    if (!templates) return null;
+    if (templates.has(t)) return t;
+    for (const tp of templates.values()) {
+      if ((tp.name || tp.value) === t) return tp.id;
+    }
+    return null;
+  },
+};
+
+// CommandPalette is the controller behind Cmd+K. It owns:
+//   - the open()/close() lifecycle (single instance)
+//   - the parallel fetch of /findings, /assets, /scans on open
+//   - the in-memory recents (last 3 navigations, session-only — P1
+//     upgrade to localStorage is a follow-up)
+//   - the fuzzy filtering + scoring
+//   - the keyboard nav (↑/↓/↵/Esc) on top of Components.commandPalette
+const CommandPalette = {
+  _instance: null,
+  _recents: [],    // [{ type, label, sublabel, hash, icon }]
+  _state: null,    // { findings, assets, scans, query, flat, activeIdx }
+
+  isOpen() { return !!this._instance; },
+
+  open() {
+    if (this._instance) return;
+
+    const state = {
+      findings: { loading: true, items: [], error: null },
+      assets:   { loading: true, items: [], error: null },
+      scans:    { loading: true, items: [], error: null },
+      query: '',
+      flat: [],     // flat list of currently-rendered selectable items
+      activeIdx: 0, // index into flat
+    };
+    this._state = state;
+
+    const palette = Components.commandPalette({
+      onInput: (q) => {
+        state.query = q;
+        this._render();
+      },
+      onAction: (idx) => this._activate(idx),
+      onClose: () => { this._instance = null; this._state = null; },
+      footerHint: 'F5 to refresh',
+    });
+
+    // Global keys for ↑/↓/↵/Esc. Bound on document while the palette is
+    // open so the input keeps its native typing behavior unless we
+    // intercept (arrows + enter + escape).
+    this._onKey = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        palette.close('dismiss');
+        return;
+      }
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        const flat = state.flat;
+        if (!flat.length) return;
+        let i = state.activeIdx;
+        if (e.key === 'ArrowDown') i = (i + 1) % flat.length;
+        else                       i = (i - 1 + flat.length) % flat.length;
+        state.activeIdx = i;
+        palette.setActive(flat[i].idx);
+        return;
+      }
+      if (e.key === 'Enter') {
+        const flat = state.flat;
+        if (!flat.length) return;
+        e.preventDefault();
+        const cur = flat[state.activeIdx];
+        if (cur) this._activate(cur.idx);
+        return;
+      }
+    };
+    document.addEventListener('keydown', this._onKey, true);
+
+    // Replace onClose to also clean up the keydown listener.
+    const innerClose = palette.close;
+    palette.close = (reason) => {
+      document.removeEventListener('keydown', this._onKey, true);
+      innerClose(reason);
+    };
+
+    this._instance = palette;
+    this._render();
+
+    // Fire the three fetches in parallel. Each updates its slice in
+    // state and re-renders. Failures show "Failed to load." in that
+    // block but don't block the others. The webui handlers return
+    // {findings:[]}, {assets:[]}, {scans:[]} — there is no shared
+    // envelope, so each fetch reads its own key (with a defensive
+    // fallback to a bare array in case the shape changes).
+    function asArray(resp, key) {
+      if (Array.isArray(resp)) return resp;
+      if (resp && Array.isArray(resp[key])) return resp[key];
+      return [];
+    }
+    API.findings({ limit: 50 })
+      .then(resp => { state.findings = { loading: false, items: asArray(resp, 'findings') }; })
+      .catch(() => { state.findings = { loading: false, items: [], error: 'Failed to load.' }; })
+      .finally(() => this._render());
+    API.assets({ limit: 50 })
+      .then(resp => { state.assets = { loading: false, items: asArray(resp, 'assets') }; })
+      .catch(() => { state.assets = { loading: false, items: [], error: 'Failed to load.' }; })
+      .finally(() => this._render());
+    API.scans({ limit: 20 })
+      .then(resp => { state.scans = { loading: false, items: asArray(resp, 'scans') }; })
+      .catch(() => { state.scans = { loading: false, items: [], error: 'Failed to load.' }; })
+      .finally(() => this._render());
+
+    // Warm the lookup cache so resolved target/asset values are
+    // available when we render finding sublabels.
+    LookupCache.targets().catch(() => {});
+  },
+
+  close(reason) {
+    if (!this._instance) return;
+    this._instance.close(reason || 'close');
+  },
+
+  // _render rebuilds the source list from current state + query.
+  _render() {
+    if (!this._instance || !this._state) return;
+    const s = this._state;
+    const q = (s.query || '').trim().toLowerCase();
+
+    // Build raw items per category.
+    const findingsRaw = (s.findings.items || []).map(f => {
+      const subParts = [];
+      if (f.severity) subParts.push(String(f.severity));
+      if (f.cve) subParts.push(f.cve);
+      const tail = f.template_id ? f.template_id : '';
+      return {
+        type: 'finding',
+        label: f.title || f.cve || f.template_id || f.id,
+        sublabel: subParts.join(' · ') + (tail ? ' · ' + tail : ''),
+        hash: '#/findings/' + encodeURIComponent(f.id),
+        icon: 'shield',
+        sortKey: f.last_seen || f.updated_at || f.created_at || '',
+      };
+    });
+
+    const assetsRaw = (s.assets.items || []).map(a => ({
+      type: 'asset',
+      label: a.value || a.id,
+      sublabel: (a.type || '') + (a.status ? ' · ' + a.status : ''),
+      hash: '#/assets?id=' + encodeURIComponent(a.id),
+      icon: 'cube',
+      sortKey: a.last_seen || a.updated_at || a.created_at || '',
+    }));
+
+    const scansRaw = (s.scans.items || []).map(sc => ({
+      type: 'scan',
+      label: (sc.target_value || sc.target || sc.target_id || sc.id) + ' · ' + (sc.status || ''),
+      sublabel: (sc.type || '') + (sc.started_at ? ' · ' + new Date(sc.started_at).toLocaleString() : ''),
+      hash: '#/scans/' + encodeURIComponent(sc.id),
+      icon: 'play',
+      sortKey: sc.started_at || sc.created_at || '',
+    }));
+
+    const actionsRaw = [
+      { type: 'action', actionId: 'run-scan', label: 'Run scan on…',
+        sublabel: 'Open the ad-hoc dispatcher (Cmd+R)', icon: 'play', hash: '' },
+      { type: 'action', actionId: 'view-running', label: 'View running scans',
+        sublabel: 'Filter to status=running', icon: 'list', hash: '#/scans?status=running' },
+      { type: 'action', actionId: 'pause-all', label: 'Pause all active schedules',
+        sublabel: 'Coming in PR10 follow-up', icon: 'pause', hash: '',
+        disabled: true, tooltip: 'Coming in PR10 follow-up' },
+    ];
+
+    // Filter + score per category. Empty query → keep everything,
+    // sorted by sortKey desc; non-empty → fuzzy substring + position +
+    // length-penalty scoring (in-house, ~30 LOC).
+    function scoreItem(item, qLower) {
+      if (!qLower) return 0;
+      const lbl = (item.label || '').toLowerCase();
+      const sub = (item.sublabel || '').toLowerCase();
+      let pos = lbl.indexOf(qLower);
+      let base = 0;
+      if (pos === 0) base = 100;
+      else if (pos > 0) base = 50;
+      else {
+        pos = sub.indexOf(qLower);
+        if (pos === 0) base = 60;
+        else if (pos > 0) base = 30;
+        else return -1;
+      }
+      const penalty = Math.min(50, Math.floor((item.label || '').length / 4));
+      return base - penalty;
+    }
+    function pickTopN(arr, n) {
+      if (!q) {
+        const sorted = arr.slice().sort((a, b) => String(b.sortKey).localeCompare(String(a.sortKey)));
+        return sorted.slice(0, n);
+      }
+      const scored = [];
+      for (const it of arr) {
+        const s = scoreItem(it, q);
+        if (s >= 0) scored.push({ it, s });
+      }
+      scored.sort((a, b) => b.s - a.s);
+      return scored.slice(0, n).map(x => x.it);
+    }
+
+    const findingsTop = pickTopN(findingsRaw, 5);
+    const assetsTop   = pickTopN(assetsRaw, 5);
+    const scansTop    = pickTopN(scansRaw, 5);
+    // Quick actions: filter by query but keep all 3 visible when q
+    // empty; an empty query also surfaces recents.
+    const actionsTop = q
+      ? actionsRaw.filter(a => scoreItem(a, q) >= 0)
+      : actionsRaw;
+
+    const recentsTop = !q
+      ? this._recents.slice(0, 3)
+      : this._recents.filter(r => scoreItem(r, q) >= 0).slice(0, 3);
+
+    // Resolve sources order. Recents only show on empty query (or matching).
+    const sources = [];
+    if (recentsTop.length) {
+      sources.push({ type: 'recent', label: 'Recents', items: recentsTop });
+    }
+    sources.push({
+      type: 'finding', label: 'Findings',
+      loading: s.findings.loading, error: s.findings.error,
+      items: findingsTop,
+      emptyMessage: s.findings.loading || s.findings.error ? '' : 'No matches',
+    });
+    sources.push({
+      type: 'asset', label: 'Assets',
+      loading: s.assets.loading, error: s.assets.error,
+      items: assetsTop,
+      emptyMessage: s.assets.loading || s.assets.error ? '' : 'No matches',
+    });
+    sources.push({
+      type: 'scan', label: 'Scans',
+      loading: s.scans.loading, error: s.scans.error,
+      items: scansTop,
+      emptyMessage: s.scans.loading || s.scans.error ? '' : 'No matches',
+    });
+    sources.push({ type: 'action', label: 'Quick actions', items: actionsTop });
+
+    // Build flat selectable list (skip loading/error blocks) so ↑/↓ can
+    // walk a single linear list. idx encodes "<sourceIdx>.<itemIdx>" to
+    // match the data attribute the helper renders.
+    const flat = [];
+    sources.forEach((src, sIdx) => {
+      if (src.loading || src.error || !src.items) return;
+      src.items.forEach((it, iIdx) => {
+        flat.push({ idx: `${sIdx}.${iIdx}`, item: it });
+      });
+    });
+    s.flat = flat;
+    if (s.activeIdx >= flat.length) s.activeIdx = 0;
+
+    this._instance.setSources(sources);
+    if (flat.length) this._instance.setActive(flat[s.activeIdx].idx);
+  },
+
+  _activate(idxStr) {
+    const flat = this._state && this._state.flat;
+    if (!flat || !flat.length) return;
+    const entry = flat.find(f => f.idx === idxStr);
+    if (!entry) return;
+    const item = entry.item;
+    if (item.disabled) return;
+
+    // Quick actions with a synthetic actionId have custom dispatch.
+    if (item.type === 'action') {
+      this._dispatchAction(item.actionId);
+    } else if (item.hash) {
+      this._addRecent(item);
+      location.hash = item.hash;
+    }
+    this.close('action');
+  },
+
+  _dispatchAction(id) {
+    if (id === 'run-scan' && typeof AdHocPage !== 'undefined') {
+      AdHocPage.open();
+      return;
+    }
+    if (id === 'view-running') {
+      location.hash = '#/scans?status=running';
+      return;
+    }
+    // pause-all is disabled in P0; no-op.
+  },
+
+  _addRecent(item) {
+    if (!item || !item.hash) return;
+    // Dedupe by hash, keep most-recent at front, cap at 3.
+    const filtered = this._recents.filter(r => r.hash !== item.hash);
+    filtered.unshift({
+      type: item.type, label: item.label, sublabel: item.sublabel,
+      hash: item.hash, icon: item.icon,
+    });
+    this._recents = filtered.slice(0, 3);
+  },
+};

--- a/internal/webui/static/js/components.js
+++ b/internal/webui/static/js/components.js
@@ -1097,6 +1097,157 @@ const Components = {
     if (timeout > 0) setTimeout(close, timeout);
     return { close };
   },
+
+  // PR9 #42: commandPalette mounts the Cmd+K overlay. The caller (the
+  // CommandPalette controller in cmdk.js) owns data fetching and item
+  // selection state. This helper is responsible for the DOM:
+  //   - input at the top, focused on mount
+  //   - one block per source (header + up to 5 items each); empty
+  //     blocks are omitted unless `loading`/`error` is set
+  //   - footer with kbd hints
+  //
+  // The helper returns { root, close, setSources(sources), setActive(idx) }.
+  // setSources re-renders the result blocks while preserving the input
+  // value and focus; setActive moves the highlight without re-rendering.
+  // The caller handles ↑/↓/↵/Esc and computes the flat list of selectable
+  // items (so source order + per-source caps stay a render concern).
+  commandPalette({ sources, recents, onAction, onInput, onClose, footerHint }) {
+    const root = document.createElement('div');
+    root.className = 'command-palette-overlay';
+    root.setAttribute('role', 'dialog');
+    root.setAttribute('aria-modal', 'true');
+    root.setAttribute('aria-label', 'Command palette');
+    root.innerHTML = `
+      <div class="cmdk-panel" role="combobox" aria-haspopup="listbox" aria-expanded="true">
+        <div class="cmdk-input-wrap">
+          ${Components.icon('search', 16)}
+          <input class="cmdk-input" type="text" autocomplete="off" spellcheck="false"
+                 aria-label="Search findings, assets, scans"
+                 placeholder="Search findings, assets, scans…">
+          <kbd class="kbd cmdk-kbd-esc">Esc</kbd>
+        </div>
+        <div class="cmdk-results" data-cmdk-results role="listbox"></div>
+        <div class="cmdk-footer">
+          <span><kbd class="kbd">↑↓</kbd> navigate</span>
+          <span><kbd class="kbd">↵</kbd> open</span>
+          <span><kbd class="kbd">Esc</kbd> close</span>
+          ${footerHint ? `<span class="cmdk-footer-hint">${escapeHtml(footerHint)}</span>` : ''}
+        </div>
+      </div>
+    `;
+    document.body.appendChild(root);
+    document.body.classList.add('cmdk-open');
+
+    const input = root.querySelector('.cmdk-input');
+    const resultsEl = root.querySelector('[data-cmdk-results]');
+
+    let closed = false;
+    function close(reason) {
+      if (closed) return;
+      closed = true;
+      document.body.classList.remove('cmdk-open');
+      root.remove();
+      if (typeof onClose === 'function') onClose(reason || 'close');
+    }
+    root.addEventListener('mousedown', (e) => {
+      if (e.target === root) close('dismiss');
+    });
+
+    if (typeof onInput === 'function') {
+      input.addEventListener('input', () => onInput(input.value));
+    }
+
+    function renderSources(srcs) {
+      const blocks = [];
+      (srcs || []).forEach((s, sIdx) => {
+        if (s.hidden) return;
+        const headerSafe = escapeHtml(s.label || '');
+        let body = '';
+        if (s.loading) {
+          body = `<div class="cmdk-loading">Loading…</div>`;
+        } else if (s.error) {
+          body = `<div class="cmdk-error">${escapeHtml(s.error)}</div>`;
+        } else if (!s.items || !s.items.length) {
+          if (s.emptyMessage) body = `<div class="cmdk-no-results">${escapeHtml(s.emptyMessage)}</div>`;
+          else return; // no header without items
+        } else {
+          body = s.items.map((it, iIdx) => {
+            const dataIdx = `${sIdx}.${iIdx}`;
+            const iconHtml = it.icon ? Components.icon(it.icon, 14) : '';
+            const sub = it.sublabel ? `<span class="cmdk-item-sub">${escapeHtml(it.sublabel)}</span>` : '';
+            const right = it.right ? `<span class="cmdk-item-right">${escapeHtml(it.right)}</span>` : '';
+            const disabled = it.disabled ? ' cmdk-item-disabled' : '';
+            const tip = it.tooltip ? ` title="${escapeHtml(it.tooltip)}"` : '';
+            return `<div class="cmdk-item${disabled}" role="option" data-cmdk-idx="${dataIdx}"${tip}>
+              <span class="cmdk-item-icon" aria-hidden="true">${iconHtml}</span>
+              <span class="cmdk-item-label">${escapeHtml(it.label || '')}</span>
+              ${sub}
+              ${right}
+            </div>`;
+          }).join('');
+        }
+        blocks.push(`<div class="cmdk-source" data-cmdk-source="${escapeHtml(s.type || '')}">
+          <div class="cmdk-source-header">${headerSafe}</div>
+          ${body}
+        </div>`);
+      });
+      resultsEl.innerHTML = blocks.join('') || `<div class="cmdk-no-results">No matches</div>`;
+    }
+
+    function setActive(idx) {
+      resultsEl.querySelectorAll('.cmdk-item-active').forEach(el => el.classList.remove('cmdk-item-active'));
+      if (idx == null) return;
+      const el = resultsEl.querySelector(`[data-cmdk-idx="${CSS && CSS.escape ? CSS.escape(idx) : idx}"]`);
+      if (el) {
+        el.classList.add('cmdk-item-active');
+        // scrollIntoView with block:nearest so the active item is visible
+        // without the entire results block jumping when the user just
+        // moved one row.
+        const r = el.getBoundingClientRect();
+        const pr = resultsEl.getBoundingClientRect();
+        if (r.top < pr.top || r.bottom > pr.bottom) {
+          el.scrollIntoView({ block: 'nearest' });
+        }
+      }
+    }
+
+    if (typeof onAction === 'function') {
+      resultsEl.addEventListener('click', (e) => {
+        const it = e.target.closest('[data-cmdk-idx]');
+        if (!it) return;
+        if (it.classList.contains('cmdk-item-disabled')) {
+          it.classList.remove('cmdk-shake');
+          // restart the animation
+          void it.offsetWidth;
+          it.classList.add('cmdk-shake');
+          return;
+        }
+        onAction(it.getAttribute('data-cmdk-idx'));
+      });
+      resultsEl.addEventListener('mousemove', (e) => {
+        const it = e.target.closest('[data-cmdk-idx]');
+        if (!it) return;
+        if (it.classList.contains('cmdk-item-active')) return;
+        resultsEl.querySelectorAll('.cmdk-item-active').forEach(el => el.classList.remove('cmdk-item-active'));
+        it.classList.add('cmdk-item-active');
+      });
+    }
+
+    renderSources(sources);
+    setTimeout(() => input.focus(), 0);
+
+    return {
+      root,
+      close,
+      input,
+      setSources: renderSources,
+      setActive,
+      // setQuery updates the input value programmatically (used after
+      // clearing recents on action). Keeps focus.
+      setQuery(v) { input.value = v == null ? '' : String(v); },
+      getQuery() { return input.value; },
+    };
+  },
 };
 
 // Convenience shortcuts so callers can write Components.toast.error('…')
@@ -1132,6 +1283,11 @@ const ICONS = Object.freeze({
   // play for the +New > Run scan item.
   'eye-off':      '<path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19m-6.72-1.07a3 3 0 11-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/>',
   play:           '<polygon points="5 3 19 12 5 21 5 3"/>',
+  // PR9 #42: cmdk palette glyphs.
+  shield:         '<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>',
+  pause:          '<rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/>',
+  list:           '<line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><circle cx="4" cy="6" r="1"/><circle cx="4" cy="12" r="1"/><circle cx="4" cy="18" r="1"/>',
+  cube:           '<path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/>',
 });
 
 function pad2(n) { return String(n).padStart(2, '0'); }

--- a/internal/webui/static/js/pages/adhoc.js
+++ b/internal/webui/static/js/pages/adhoc.js
@@ -1,11 +1,18 @@
 // SPEC-SCHED1.4b R9: Ad-hoc dispatcher modal.
 //
-// Triggered by the "Run scan now" button in the sidebar. The modal hits
-// POST /api/v1/scans/ad-hoc with {target_id, reason?, tool_config_override?}
-// and renders either the 202 success view (with the returned scan_id) or
-// a typed error message derived from the Problem `type` (TARGET_BUSY,
-// IN_BLACKOUT, DISPATCHER_UNREACHABLE). Target picker is free-text —
-// targets-page integration lands in 1.4c (spec non-goal N3).
+// Triggered by the "Run scan now" button in the sidebar (and Cmd+R from
+// any route, see PR9 #42). The modal hits POST /api/v1/scans/ad-hoc
+// with {target_id, name?, reason?, tool_config_override?, template_id?}
+// and renders either the 202 success view (with the returned scan_id)
+// or a typed error message derived from the Problem `type`
+// (TARGET_BUSY, IN_BLACKOUT, DISPATCHER_UNREACHABLE).
+//
+// PR9 #42: target_id and template_id render as datalist-backed
+// comboboxes so the operator can type a target value (e.g. "iana.org")
+// and the field resolves to its UUID at submit. UUIDs pasted directly
+// still work as a power-user escape hatch. The advanced fields
+// (`reason`, `tool_config_override`) collapse under a `<details>` that
+// is closed by default but auto-opens when prefilled.
 
 const AdHocPage = {
   // SPEC-SCHED1.4c R4: open() accepts an optional prefill object so
@@ -15,17 +22,29 @@ const AdHocPage = {
   // from a target page) the field renders readonly with an "Edit
   // target" link that relaxes the lock — guards against accidental
   // retargeting per OQ3.
-  open(prefill) {
+  async open(prefill) {
     const p = prefill || {};
-    const body = this.formBody({
+    const preset = {
       target_id: p.prefillTargetID || p.target_id || '',
       template_id: p.prefillTemplateID || p.template_id || '',
+      name: p.prefillName || p.name || '',
       reason: p.prefillReason || p.reason || '',
       tool_config_override: p.prefillToolConfigOverride || p.tool_config_override || '',
       lockTargetID: p.lockTargetID !== undefined
         ? !!p.lockTargetID
         : !!p.prefillTargetID,
-    });
+    };
+
+    // Lookups are best-effort: the modal still renders if /targets or
+    // /templates fail. The combobox just becomes free-text in that
+    // case, matching the pre-PR9 behavior. Mount happens regardless,
+    // so the operator never sees a blank screen waiting on lookups.
+    let targets = new Map();
+    let templates = new Map();
+    try { targets   = await LookupCache.targets(); }   catch (_) {}
+    try { templates = await LookupCache.templates(); } catch (_) {}
+
+    const body = this.formBody(preset, targets, templates);
     const m = Components.modal({
       title: 'Run scan now',
       body,
@@ -34,11 +53,11 @@ const AdHocPage = {
         label: 'Dispatch',
         onClick: async ({ close, root }) => {
           const form = root.querySelector('#adhoc-form');
-          const data = readAdHocForm(form);
+          const data = readAdHocForm(form, targets, templates);
           if (!data) return;
           try {
             const resp = await API.createAdHocScan(data);
-            swapToSuccessView(root, resp);
+            swapToSuccessView(root, resp, targets, templates);
           } catch (err) {
             showAdHocFormError(root, form, err);
           }
@@ -65,57 +84,130 @@ const AdHocPage = {
 
   // formBody is exported so the success view's "Run another" button can
   // restore the original form markup after a successful dispatch.
-  formBody(preset) {
+  formBody(preset, targets, templates) {
     const p = preset || {};
     const lock = !!p.lockTargetID;
-    const targetIdField = `
+    const T = targets || new Map();
+    const TM = templates || new Map();
+
+    // Display the target value when locked / prefilled by id, else the
+    // raw typed value. Pre-fill resolves the id to the human label so
+    // the field reads "iana.org" not "5acbf288-...".
+    const targetById = T.get(p.target_id);
+    const targetDisplay = p.target_id
+      ? (targetById ? targetById.value : p.target_id)
+      : '';
+    const targetOpts = Array.from(T.values()).map(t =>
+      `<option value="${escapeHtml(t.value)}">${escapeHtml(t.id)}</option>`
+    ).join('');
+
+    const tmplById = TM.get(p.template_id);
+    const tmplDisplay = p.template_id
+      ? (tmplById ? (tmplById.name || tmplById.value || tmplById.id) : p.template_id)
+      : '';
+    const tmplOpts = Array.from(TM.values()).map(t =>
+      `<option value="${escapeHtml(t.name || t.value || t.id)}">${escapeHtml(t.id)}</option>`
+    ).join('');
+
+    const advancedOpen = (p.reason || p.tool_config_override) ? ' open' : '';
+
+    const targetField = `
       <div class="form-field" data-field="target_id">
-        <label class="form-label" for="f-target_id">Target ID <span class="form-required">*</span></label>
+        <label class="form-label" for="f-target_id">Target <span class="form-required">*</span></label>
         <input class="form-input" id="f-target_id" name="target_id" type="text"
-               required
+               list="adhoc-target-options" autocomplete="off" required
                ${lock ? 'readonly' : ''}
-               placeholder="UUID from /targets"
-               value="${escapeHtml(p.target_id || '')}">
+               placeholder="iana.org or UUID"
+               value="${escapeHtml(targetDisplay)}">
+        <datalist id="adhoc-target-options">${targetOpts}</datalist>
         <div class="form-help">
           ${lock
             ? 'Pre-filled from the current target page. <a href="#" id="adhoc-target-unlock">Edit target</a>.'
-            : 'Free-text target ID. Picker ships in a future release.'}
+            : 'Type a value or paste a UUID.'}
         </div>
         <div class="field-error" data-field-error="target_id" style="display:none"></div>
       </div>
     `;
+
+    const templateField = `
+      <div class="form-field" data-field="template_id">
+        <label class="form-label" for="f-template_id">Template</label>
+        <input class="form-input" id="f-template_id" name="template_id" type="text"
+               list="adhoc-template-options" autocomplete="off"
+               placeholder="audit-daily-critical or UUID"
+               value="${escapeHtml(tmplDisplay)}">
+        <datalist id="adhoc-template-options">${tmplOpts}</datalist>
+        <div class="form-help">Optional. Type a template name or paste a UUID.</div>
+        <div class="field-error" data-field-error="template_id" style="display:none"></div>
+      </div>
+    `;
+
+    const nameField = Components.formInput({
+      label: 'Name', name: 'name', value: p.name || '',
+      placeholder: 'e.g. Manual re-run · post-deploy verification',
+      help: 'Optional. Shown on the scan in lists.',
+    });
+
     return `
       <form id="adhoc-form" novalidate>
         <div class="field-error" data-field-error="__general__" style="display:none;margin-bottom:12px;padding:8px 12px;background:var(--sev-critical-bg);border-radius:var(--radius)"></div>
-        ${targetIdField}
-        ${Components.formInput({ label: 'Template ID', name: 'template_id', value: p.template_id || '',
-          help: 'Optional. If set, the template\'s tool_config is used (overlaid with the override below).' })}
-        ${Components.formInput({ label: 'Reason', name: 'reason', value: p.reason || '',
-          placeholder: 'e.g. manual re-run after infra change' })}
-        ${Components.formTextarea({
-          label: 'Tool config override (JSON)', name: 'tool_config_override',
-          value: p.tool_config_override || '', rows: 6, monospace: true,
-          help: 'Optional. Leave blank to let the server auto-populate from the target/template.',
-        })}
+        ${targetField}
+        ${templateField}
+        ${nameField}
+        <details class="adhoc-advanced"${advancedOpen}>
+          <summary>Advanced options</summary>
+          <div class="adhoc-advanced-body">
+            ${Components.formInput({ label: 'Reason', name: 'reason', value: p.reason || '',
+              placeholder: 'e.g. manual re-run after infra change' })}
+            ${Components.formTextarea({
+              label: 'Tool config override (JSON)', name: 'tool_config_override',
+              value: p.tool_config_override || '', rows: 6, monospace: true,
+              help: 'Optional. Leave blank to let the server auto-populate from the target/template.',
+            })}
+          </div>
+        </details>
       </form>
     `;
   },
 };
 
-function readAdHocForm(form) {
+function readAdHocForm(form, targets, templates) {
   if (!form) return null;
   const fd = new FormData(form);
-  const out = {
-    target_id: (fd.get('target_id') || '').toString().trim(),
-    reason: (fd.get('reason') || '').toString().trim(),
-  };
-  if (!out.target_id) {
+  const typedTarget = (fd.get('target_id') || '').toString().trim();
+  if (!typedTarget) {
     Components.applyFieldErrors(form, [{ field: 'target_id', message: 'required' }]);
     return null;
   }
-  if (!out.reason) delete out.reason;
-  const tmpl = (fd.get('template_id') || '').toString().trim();
-  if (tmpl) out.template_id = tmpl;
+  const targetID = LookupCache.resolveTargetID(typedTarget, targets || new Map());
+  if (targetID === null) {
+    Components.applyFieldErrors(form, [{
+      field: 'target_id',
+      message: 'Target not found in /targets — paste the UUID instead',
+    }]);
+    return null;
+  }
+
+  const out = { target_id: targetID || typedTarget };
+
+  const typedTmpl = (fd.get('template_id') || '').toString().trim();
+  if (typedTmpl) {
+    const tmplID = LookupCache.resolveTemplateID(typedTmpl, templates || new Map());
+    if (tmplID === null) {
+      Components.applyFieldErrors(form, [{
+        field: 'template_id',
+        message: 'Template not found — paste the UUID instead',
+      }]);
+      return null;
+    }
+    out.template_id = tmplID || typedTmpl;
+  }
+
+  const name = (fd.get('name') || '').toString().trim();
+  if (name) out.name = name;
+
+  const reason = (fd.get('reason') || '').toString().trim();
+  if (reason) out.reason = reason;
 
   const rawOverride = (fd.get('tool_config_override') || '').toString().trim();
   if (rawOverride) {
@@ -172,7 +264,7 @@ function showAdHocBanner(root, form, message) {
   }
 }
 
-function swapToSuccessView(root, resp) {
+function swapToSuccessView(root, resp, targets, templates) {
   const body = root.querySelector('.modal-body');
   if (!body) return;
   const scanHtml = resp.scan_id
@@ -198,7 +290,7 @@ function swapToSuccessView(root, resp) {
   }
   const another = body.querySelector('#adhoc-run-another');
   if (another) another.addEventListener('click', () => {
-    body.innerHTML = AdHocPage.formBody({});
+    body.innerHTML = AdHocPage.formBody({}, targets, templates);
     // Re-add the Dispatch button.
     if (footer && !footer.querySelector('[data-modal-primary]')) {
       const btn = document.createElement('button');
@@ -211,11 +303,11 @@ function swapToSuccessView(root, resp) {
         btn.disabled = true; btn.textContent = '…';
         try {
           const form = document.getElementById('adhoc-form');
-          const data = readAdHocForm(form);
+          const data = readAdHocForm(form, targets, templates);
           if (!data) { btn.disabled = false; btn.textContent = 'Dispatch'; return; }
           try {
             const resp2 = await API.createAdHocScan(data);
-            swapToSuccessView(root, resp2);
+            swapToSuccessView(root, resp2, targets, templates);
           } catch (err) {
             showAdHocFormError(root, form, err);
             btn.disabled = false; btn.textContent = 'Dispatch';


### PR DESCRIPTION
Closes #42

## Summary
- Cmd+K opens a global command palette: parallel fetch of findings/assets/scans + quick actions, in-house substring scoring, ↑/↓/↵/Esc keyboard nav, session-only recents.
- Cmd+R opens the ad-hoc dispatcher from any route (no-op when palette or another modal is open).
- Ad-hoc modal upgrade: `target_id` and `template_id` render as datalist-backed comboboxes resolving typed values to UUIDs via a new shared `LookupCache`; optional `name` field added; `reason` + `tool_config_override` collapse under an `<details>` advanced section that auto-opens when prefilled.
- Backend: `CreateAdHocRequest` accepts optional `name` (round-trip only — persistence is a backend follow-up; see `internal/api/v1/adhoc.go`).
- Replaces the PR2 #35 placeholder click on the topbar search button.

## Files
- New: `internal/webui/static/js/cmdk.js` (`LookupCache` + `CommandPalette` controller).
- `internal/webui/static/js/components.js` — adds `Components.commandPalette({sources, onAction, recents, onInput, footerHint})` + 4 icons.
- `internal/webui/static/js/app.js` — wires Cmd+K / Cmd+R / topbar button.
- `internal/webui/static/js/pages/adhoc.js` — combobox + name + advanced collapsible.
- `internal/webui/static/css/style.css` — palette overlay + advanced collapsible CSS.
- `internal/webui/static/index.html` — script tag + cmdk button aria-label.
- `internal/api/v1/adhoc.go` — accept `name` on the request body.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -short -race` green
- [x] `go test -tags=e2e ./test/e2e/...` green
- [x] Agent-spec invariants (`TestSpec`) pass
- [x] JS Function-constructor smoke parses cleanly on all touched files
- [x] Manual smoke: Cmd+K from any route opens overlay; query "iana" filters results; arrow keys navigate; ↵ navigates to the hash; Esc closes
- [x] Manual smoke: Cmd+R opens ad-hoc; target combobox suggests on type; UUID paste still works; Advanced options collapsed by default; submit posts to `/api/v1/scans/ad-hoc` with `name` accepted
- [x] Regression: `AdHocPage.open({ prefillTargetID, lockTargetID })` still locks the target field with the unlock link working

## Out of scope (per issue)
- Backend `/api/v1/search` endpoint — defer until volume warrants it.
- Persisting ad-hoc `name` in storage — separate backend follow-up.
- Playwright e2e specs — repo has no Playwright infra today.
- localStorage recents, `Pause all schedules` action wiring, custom dropdown — P1/P2 in the spec.
